### PR TITLE
SDI-40 Draft of integrating more migration information into /info endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitMappingService.kt
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 @Service
 class VisitMappingService(@Qualifier("visitMappingApiWebClient") private val webClient: WebClient) {
@@ -45,8 +47,14 @@ class VisitMappingService(@Qualifier("visitMappingApiWebClient") private val web
       }
       .block()
   }
+
+  fun findLatestMigration(): LatestMigration? = LatestMigration()
+  fun getMigrationDetails(migrationId: String): MigrationDetails = MigrationDetails()
 }
 
 data class VisitNomisMapping(val nomisId: Long, val vsipId: String, val label: String?, val mappingType: String)
 
 data class RoomMapping(val vsipId: String, val isOpen: Boolean)
+
+data class LatestMigration(val migrationId: String = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+data class MigrationDetails(val count: Long = 0, val startedDateTime: LocalDateTime = LocalDateTime.now())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitMigrationProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitMigrationProperties.kt
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.visits
+
+import com.amazonaws.services.sqs.model.GetQueueAttributesRequest
+import com.amazonaws.services.sqs.model.GetQueueAttributesResult
+import com.amazonaws.services.sqs.model.QueueAttributeName.All
+import com.amazonaws.services.sqs.model.QueueAttributeName.ApproximateNumberOfMessages
+import com.amazonaws.services.sqs.model.QueueAttributeName.ApproximateNumberOfMessagesNotVisible
+import org.springframework.boot.actuate.info.Info.Builder
+import org.springframework.boot.actuate.info.InfoContributor
+import org.springframework.stereotype.Component
+import uk.gov.justice.hmpps.sqs.HmppsQueue
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+
+@Component
+class VisitMigrationProperties(
+  private var hmppsQueueService: HmppsQueueService,
+  private var visitMappingService: VisitMappingService
+) : InfoContributor {
+
+  internal val registersQueue by lazy { hmppsQueueService.findByQueueId("migration") as HmppsQueue }
+
+  override fun contribute(builder: Builder) {
+    val queueProperties = registersQueue.getQueueAttributes().map {
+      mapOf<String, Any?>(
+        "records waiting processing" to it.attributes[ApproximateNumberOfMessages.toString()],
+        "records currently being processed" to it.attributes[ApproximateNumberOfMessagesNotVisible.toString()]
+      )
+    }.getOrElse { mapOf() }
+
+    val failureQueueProperties = registersQueue.getDlqAttributes().map {
+      mapOf<String, Any?>(
+        "records that have failed" to it.attributes[ApproximateNumberOfMessages.toString()],
+      )
+    }.getOrElse { mapOf() }
+
+    val migrationProperties = visitMappingService.findLatestMigration()?.let {
+      val (count, startedDateTime) = visitMappingService.getMigrationDetails(it.migrationId)
+      mapOf<String, Any?>(
+        "id" to it.migrationId,
+        "records migrated" to count,
+        "started" to startedDateTime
+      )
+    } ?: mapOf()
+
+    builder.withDetail(
+      "last visits migration",
+      queueProperties + failureQueueProperties + migrationProperties
+    )
+  }
+
+  private fun HmppsQueue.getQueueAttributes(): Result<GetQueueAttributesResult> {
+    return runCatching {
+      this.sqsClient.getQueueAttributes(
+        GetQueueAttributesRequest(this.queueUrl).withAttributeNames(
+          All
+        )
+      )
+    }
+  }
+
+  private fun HmppsQueue.getDlqAttributes(): Result<GetQueueAttributesResult> =
+    runCatching {
+      this.sqsDlqClient!!.getQueueAttributes(GetQueueAttributesRequest(this.dlqUrl).withAttributeNames(All))
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitMigrationPropertiesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitMigrationPropertiesTest.kt
@@ -1,0 +1,181 @@
+@file:Suppress("UNCHECKED_CAST")
+
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.visits
+
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.GetQueueAttributesRequest
+import com.amazonaws.services.sqs.model.GetQueueAttributesResult
+import com.amazonaws.services.sqs.model.GetQueueUrlResult
+import com.amazonaws.services.sqs.model.QueueAttributeName
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.boot.actuate.info.Info.Builder
+import uk.gov.justice.hmpps.sqs.HmppsQueue
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import java.time.LocalDateTime
+
+internal class VisitMigrationPropertiesTest {
+  private var hmppsQueueService: HmppsQueueService = mock()
+  private var visitMappingService: VisitMappingService = mock()
+  private val sqsClient: AmazonSQS = mock()
+  private var migrationQueue = HmppsQueue("migration", sqsClient, "queue", sqsClient, "dlq")
+
+  private var visitMigrationProperties = VisitMigrationProperties(hmppsQueueService, visitMappingService)
+  private lateinit var details: Map<String, Any>
+
+  private fun build() =
+    Builder()
+      .apply { visitMigrationProperties.contribute(this) }
+      .let {
+        it.build().details["last visits migration"] as Map<String, Any>
+      }
+
+  @Nested
+  @DisplayName("before first migration")
+  inner class BeforeFirstMigration {
+    @BeforeEach
+    internal fun setUp() {
+      mockEmptyQueues()
+      whenever(visitMappingService.findLatestMigration()).thenReturn(null)
+      details = build()
+    }
+
+    @Test
+    internal fun `will have a migration section`() {
+      assertThat(details).isNotNull
+    }
+
+    @Test
+    internal fun `show zero for all counts`() {
+      assertThat(details["records waiting processing"]).isEqualTo("0")
+      assertThat(details["records currently being processed"]).isEqualTo("0")
+      assertThat(details["records that have failed"]).isEqualTo("0")
+    }
+
+    @Test
+    internal fun `will not show migration Id or totals`() {
+      assertThat(details["id"]).isNull()
+      assertThat(details["records migrated"]).isNull()
+      assertThat(details["started"]).isNull()
+    }
+  }
+
+  @Nested
+  @DisplayName("during a migration")
+  inner class DuringAMigration {
+
+    @BeforeEach
+    internal fun setUp() {
+      mockQueuesWith(messagesOnQueueCount = 20_000, messagesInFlightCount = 16, messagesOnDLQCount = 3)
+      whenever(visitMappingService.findLatestMigration()).thenReturn(LatestMigration(migrationId = "2020-01-01T12:00:00"))
+      whenever(visitMappingService.getMigrationDetails("2020-01-01T12:00:00")).thenReturn(
+        MigrationDetails(
+          count = 12_001,
+          startedDateTime = LocalDateTime.parse("2020-01-01T12:10:29"),
+        )
+      )
+      details = build()
+    }
+
+    @Test
+    internal fun `will have a migration section`() {
+      assertThat(details).isNotNull
+    }
+
+    @Test
+    internal fun `show counts from message queues`() {
+      assertThat(details["records waiting processing"]).isEqualTo("20000")
+      assertThat(details["records currently being processed"]).isEqualTo("16")
+      assertThat(details["records that have failed"]).isEqualTo("3")
+    }
+
+    @Test
+    internal fun `will show migration Id, counts and date`() {
+      assertThat(details["id"]).isEqualTo("2020-01-01T12:00:00")
+      assertThat(details["records migrated"]).isEqualTo(12_001L)
+      assertThat(details["started"]).isEqualTo(LocalDateTime.parse("2020-01-01T12:10:29"))
+    }
+  }
+
+  @Nested
+  @DisplayName("after a migration")
+  inner class AfterAMigration {
+
+    @BeforeEach
+    internal fun setUp() {
+      mockEmptyQueues()
+      whenever(visitMappingService.findLatestMigration()).thenReturn(LatestMigration(migrationId = "2020-01-01T12:00:00"))
+      whenever(visitMappingService.getMigrationDetails("2020-01-01T12:00:00")).thenReturn(
+        MigrationDetails(
+          count = 12_001,
+          startedDateTime = LocalDateTime.parse("2020-01-01T12:10:29"),
+        )
+      )
+      details = build()
+    }
+
+    @Test
+    internal fun `will have a migration section`() {
+      assertThat(details).isNotNull
+    }
+
+    @Test
+    internal fun `show zero for all counts`() {
+      assertThat(details["records waiting processing"]).isEqualTo("0")
+      assertThat(details["records currently being processed"]).isEqualTo("0")
+      assertThat(details["records that have failed"]).isEqualTo("0")
+    }
+
+    @Test
+    internal fun `will show migration Id, counts and date`() {
+      assertThat(details["id"]).isEqualTo("2020-01-01T12:00:00")
+      assertThat(details["records migrated"]).isEqualTo(12_001L)
+      assertThat(details["started"]).isEqualTo(LocalDateTime.parse("2020-01-01T12:10:29"))
+    }
+  }
+
+  private fun mockQueuesWith(messagesOnQueueCount: Long, messagesInFlightCount: Long, messagesOnDLQCount: Long) {
+    whenever(hmppsQueueService.findByQueueId("migration")).thenReturn(migrationQueue)
+    whenever(sqsClient.getQueueUrl("queue")).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenReturn(
+      someGetQueueAttributesResult(
+        messagesInFlightCount = messagesInFlightCount,
+        messagesOnQueueCount = messagesOnQueueCount
+      )
+    )
+    whenever(sqsClient.getQueueUrl("dlq")).thenReturn(someGetQueueUrlResultForDLQ())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequestForDLQ())).thenReturn(
+      someGetQueueAttributesResultForDLQ(messagesOnDLQCount)
+    )
+  }
+
+  private fun mockEmptyQueues() {
+    mockQueuesWith(0, 0, 0)
+  }
+
+  private fun someGetQueueUrlResult(): GetQueueUrlResult = GetQueueUrlResult().withQueueUrl("queueUrl")
+  private fun someGetQueueUrlResultForDLQ(): GetQueueUrlResult = GetQueueUrlResult().withQueueUrl("dlqUrl")
+  private fun someGetQueueAttributesResult(messagesOnQueueCount: Long, messagesInFlightCount: Long) =
+    GetQueueAttributesResult().withAttributes(
+      mapOf(
+        "ApproximateNumberOfMessages" to "$messagesOnQueueCount",
+        "ApproximateNumberOfMessagesNotVisible" to "$messagesInFlightCount",
+        QueueAttributeName.RedrivePolicy.toString() to "any redrive policy"
+      )
+    )
+
+  private fun someGetQueueAttributesResultForDLQ(messagesOnDLQCount: Long) = GetQueueAttributesResult().withAttributes(
+    mapOf("ApproximateNumberOfMessages" to messagesOnDLQCount.toString())
+  )
+
+  private fun someGetQueueAttributesRequest() =
+    GetQueueAttributesRequest("queueUrl").withAttributeNames(listOf(QueueAttributeName.All.toString()))
+
+  private fun someGetQueueAttributesRequestForDLQ() =
+    GetQueueAttributesRequest("dlqUrl").withAttributeNames(listOf(QueueAttributeName.All.toString()))
+}


### PR DESCRIPTION
- use /info as a "at a glance" progress of a migration

TODO
- plug into real mapping endpoints