### PR TITLE
SDI-98 Pass through ignoreMissingRoom to nomis api to filter out VSIP  visits during testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ POST body to optionally contain:
 - `visitTypes` - a list of visit types to migrate. It will default to `SCON` if not provided.
 - `fromDateTime` - only include visits created after this date. NB this is creation date not the actual visit date.
 - `endDateTime` - only include visits created before this date. NB this is creation date not the actual visit date.
+- `ignoreMissingRoom` - only include visits which happened in a room, e.g where the room is present. Only required when testing
 
 The `from` and `end` times are primarily used to ensure that only visits created after the last migration are migrated. This is a performance optimisation 
 since visits will never be migrated twice. Once it is marked as migrated it can only be migrated again by resetting the visit mapping table.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/NomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/NomisApiService.kt
@@ -19,6 +19,7 @@ class NomisApiService(@Qualifier("nomisApiWebClient") private val webClient: Web
     visitTypes: List<String>,
     fromDateTime: LocalDateTime?,
     toDateTime: LocalDateTime?,
+    ignoreMissingRoom: Boolean,
     pageNumber: Long,
     pageSize: Long,
   ): PageImpl<VisitId> =
@@ -29,6 +30,7 @@ class NomisApiService(@Qualifier("nomisApiWebClient") private val webClient: Web
           .queryParam("visitTypes", visitTypes)
           .queryParam("fromDateTime", fromDateTime)
           .queryParam("toDateTime", toDateTime)
+          .queryParam("ignoreMissingRoom", ignoreMissingRoom)
           .queryParam("page", pageNumber)
           .queryParam("size", pageSize)
           .build()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitsMigrationFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitsMigrationFilter.kt
@@ -29,4 +29,11 @@ data class VisitsMigrationFilter(
     example = "2020-03-24T12:00:00",
   )
   val toDateTime: LocalDateTime? = null,
+
+  @Schema(
+    description = "Only include visits which happened in a room, e.g where the room is present. Only required when testing in the scenario where VSIP visits exist in NOMIS with no associated mapping",
+    example = "false",
+    defaultValue = "false"
+  )
+  val ignoreMissingRoom: Boolean = false,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitsMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitsMigrationService.kt
@@ -38,6 +38,7 @@ class VisitsMigrationService(
       visitTypes = migrationFilter.visitTypes,
       fromDateTime = migrationFilter.fromDateTime,
       toDateTime = migrationFilter.toDateTime,
+      ignoreMissingRoom = migrationFilter.ignoreMissingRoom,
       pageNumber = 0,
       pageSize = 1,
     ).totalElements
@@ -57,7 +58,8 @@ class VisitsMigrationService(
           "prisonIds" to it.body.prisonIds.joinToString(),
           "visitTypes" to it.body.visitTypes.joinToString(),
           "fromDateTime" to it.body.fromDateTime.asStringOrBlank(),
-          "toDateTime" to it.body.toDateTime.asStringOrBlank()
+          "toDateTime" to it.body.toDateTime.asStringOrBlank(),
+          "ignoreMissingRoom" to it.body.ignoreMissingRoom.toString()
         ),
         null
       )
@@ -82,6 +84,7 @@ class VisitsMigrationService(
     visitTypes = context.body.filter.visitTypes,
     fromDateTime = context.body.filter.fromDateTime,
     toDateTime = context.body.filter.toDateTime,
+    ignoreMissingRoom = context.body.filter.ignoreMissingRoom,
     pageNumber = context.body.pageNumber,
     pageSize = context.body.pageSize
   ).content.map {
@@ -207,7 +210,7 @@ private fun NomisCodeDescription.toVisitType() = when (this.code) {
 }
 
 private fun NomisCodeDescription.toVisitStatus() = when (this.code) {
-  // TODO -> WHat statuses are there?
+  // TODO -> What statuses are there?
   "CANC" -> "CANCELLED_BY_PRISON"
   else -> "BOOKED"
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/NomisApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/NomisApiServiceTest.kt
@@ -52,6 +52,7 @@ internal class NomisApiServiceTest {
         visitTypes = listOf("SCON", "OFFI"),
         fromDateTime = LocalDateTime.parse("2020-01-01T01:30:00"),
         toDateTime = LocalDateTime.parse("2020-01-02T23:30:00"),
+        ignoreMissingRoom = false,
         pageNumber = 23,
         pageSize = 10
       )
@@ -70,12 +71,13 @@ internal class NomisApiServiceTest {
         visitTypes = listOf("SCON", "OFFI"),
         fromDateTime = LocalDateTime.parse("2020-01-01T01:30:00"),
         toDateTime = LocalDateTime.parse("2020-01-02T23:30:00"),
+        ignoreMissingRoom = true,
         pageNumber = 23,
         pageSize = 10
       )
       nomisApi.verify(
         getRequestedFor(
-          urlEqualTo("/visits/ids?prisonIds=MDI&prisonIds=BXI&visitTypes=SCON&visitTypes=OFFI&fromDateTime=2020-01-01T01:30&toDateTime=2020-01-02T23:30&page=23&size=10")
+          urlEqualTo("/visits/ids?prisonIds=MDI&prisonIds=BXI&visitTypes=SCON&visitTypes=OFFI&fromDateTime=2020-01-01T01:30&toDateTime=2020-01-02T23:30&ignoreMissingRoom=true&page=23&size=10")
         )
       )
     }
@@ -87,12 +89,13 @@ internal class NomisApiServiceTest {
         visitTypes = listOf(),
         fromDateTime = null,
         toDateTime = null,
+        ignoreMissingRoom = false,
         pageNumber = 23,
         pageSize = 10
       )
       nomisApi.verify(
         getRequestedFor(
-          urlEqualTo("/visits/ids?prisonIds&visitTypes&fromDateTime&toDateTime&page=23&size=10")
+          urlEqualTo("/visits/ids?prisonIds&visitTypes&fromDateTime&toDateTime&ignoreMissingRoom=false&page=23&size=10")
         )
       )
     }
@@ -177,6 +180,7 @@ internal class NomisApiServiceTest {
         prisonIds = listOf("MDI", "BXI"),
         visitTypes = listOf("SCON", "OFFI"),
         fromDateTime = LocalDateTime.parse("2020-01-01T01:30:00"),
+        ignoreMissingRoom = false,
         toDateTime = LocalDateTime.parse("2020-01-02T23:30:00"),
         pageNumber = 23,
         pageSize = 10

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitsMigrationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitsMigrationServiceTest.kt
@@ -57,7 +57,7 @@ internal class VisitsMigrationServiceTest {
   inner class MigrateVisits {
     @BeforeEach
     internal fun setUp() {
-      whenever(nomisApiService.getVisits(any(), any(), any(), any(), any(), any())).thenReturn(
+      whenever(nomisApiService.getVisits(any(), any(), any(), any(), any(), any(), any())).thenReturn(
         pages(1)
       )
     }
@@ -74,18 +74,19 @@ internal class VisitsMigrationServiceTest {
       )
 
       verify(nomisApiService).getVisits(
-        listOf("LEI", "BXI"),
-        listOf("SCON"),
-        LocalDateTime.parse("2020-01-01T00:00:00"),
-        LocalDateTime.parse("2020-01-02T23:00:00"),
-        0,
-        1
+        prisonIds = listOf("LEI", "BXI"),
+        visitTypes = listOf("SCON"),
+        fromDateTime = LocalDateTime.parse("2020-01-01T00:00:00"),
+        toDateTime = LocalDateTime.parse("2020-01-02T23:00:00"),
+        ignoreMissingRoom = false,
+        pageNumber = 0,
+        pageSize = 1
       )
     }
 
     @Test
     internal fun `will pass visit count and filter to queue`() {
-      whenever(nomisApiService.getVisits(any(), any(), any(), any(), any(), any())).thenReturn(
+      whenever(nomisApiService.getVisits(any(), any(), any(), any(), any(), any(), any())).thenReturn(
         pages(23)
       )
       service.migrateVisits(
@@ -111,7 +112,7 @@ internal class VisitsMigrationServiceTest {
 
     @Test
     internal fun `will write analytic with estimated count and filter`() {
-      whenever(nomisApiService.getVisits(any(), any(), any(), any(), any(), any())).thenReturn(
+      whenever(nomisApiService.getVisits(any(), any(), any(), any(), any(), any(), any())).thenReturn(
         pages(23)
       )
       service.migrateVisits(
@@ -145,6 +146,7 @@ internal class VisitsMigrationServiceTest {
           visitTypes = any(),
           fromDateTime = isNull(),
           toDateTime = isNull(),
+          ignoreMissingRoom = any(),
           pageNumber = any(),
           pageSize = any()
         )
@@ -161,6 +163,7 @@ internal class VisitsMigrationServiceTest {
           assertThat(it["migrationId"]).isNotNull
           assertThat(it["estimatedCount"]).isEqualTo("23")
           assertThat(it["prisonIds"]).isEqualTo("")
+          assertThat(it["ignoreMissingRoom"]).isEqualTo("false")
           assertThat(it["visitTypes"]).isEqualTo("")
           assertThat(it["fromDateTime"]).isEqualTo("")
           assertThat(it["toDateTime"]).isEqualTo("")
@@ -176,7 +179,7 @@ internal class VisitsMigrationServiceTest {
 
     @BeforeEach
     internal fun setUp() {
-      whenever(nomisApiService.getVisits(any(), any(), any(), any(), any(), any())).thenReturn(
+      whenever(nomisApiService.getVisits(any(), any(), any(), any(), any(), any(), any())).thenReturn(
         pages(100_200)
       )
     }
@@ -270,7 +273,7 @@ internal class VisitsMigrationServiceTest {
   inner class MigrateVisitsForPage {
     @BeforeEach
     internal fun setUp() {
-      whenever(nomisApiService.getVisits(any(), any(), any(), any(), any(), any())).thenReturn(
+      whenever(nomisApiService.getVisits(any(), any(), any(), any(), any(), any(), any())).thenReturn(
         pages(15)
       )
     }
@@ -284,6 +287,7 @@ internal class VisitsMigrationServiceTest {
             filter = VisitsMigrationFilter(
               prisonIds = listOf("LEI", "BXI"),
               visitTypes = listOf("SCON"),
+              ignoreMissingRoom = true,
               fromDateTime = LocalDateTime.parse("2020-01-01T00:00:00"),
               toDateTime = LocalDateTime.parse("2020-01-02T23:00:00"),
             ),
@@ -293,12 +297,13 @@ internal class VisitsMigrationServiceTest {
       )
 
       verify(nomisApiService).getVisits(
-        listOf("LEI", "BXI"),
-        listOf("SCON"),
-        LocalDateTime.parse("2020-01-01T00:00:00"),
-        LocalDateTime.parse("2020-01-02T23:00:00"),
-        13,
-        15
+        prisonIds = listOf("LEI", "BXI"),
+        visitTypes = listOf("SCON"),
+        fromDateTime = LocalDateTime.parse("2020-01-01T00:00:00"),
+        toDateTime = LocalDateTime.parse("2020-01-02T23:00:00"),
+        ignoreMissingRoom = true,
+        pageNumber = 13,
+        pageSize = 15
       )
     }
 
@@ -333,7 +338,7 @@ internal class VisitsMigrationServiceTest {
 
       val context: KArgumentCaptor<MigrationContext<VisitId>> = argumentCaptor()
 
-      whenever(nomisApiService.getVisits(any(), any(), any(), any(), any(), any())).thenReturn(
+      whenever(nomisApiService.getVisits(any(), any(), any(), any(), any(), any(), any())).thenReturn(
         pages(
           15, startId = 1000
         )


### PR DESCRIPTION
There is an edge case that almost certainly would only affect testing migration / synchronisation 

- Sync a VSIP visit with NOMIS
- Delete all mappings to force a new full migration 
- All VSIP visits will fail migration because they have no room data
This adds a flag to the migration process to ignore all visits that have no rooms (essentially VSIP visits)