### PR TITLE
SDI-104 Add migration history repository and table

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,9 +21,13 @@ dependencies {
   implementation("org.springdoc:springdoc-openapi-data-rest:1.6.6")
   implementation("org.springdoc:springdoc-openapi-security:1.6.6")
 
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.6.0")
+
   runtimeOnly("io.r2dbc:r2dbc-postgresql")
   runtimeOnly("org.springframework.boot:spring-boot-starter-jdbc")
   runtimeOnly("org.postgresql:postgresql:42.3.3")
+  implementation("org.flywaydb:flyway-core:8.5.1")
 
   testImplementation("io.swagger.parser.v3:swagger-parser:2.0.30")
   testImplementation("io.jsonwebtoken:jjwt:0.9.1")

--- a/helm_deploy/hmpps-prisoner-from-nomis-migration/values.yaml
+++ b/helm_deploy/hmpps-prisoner-from-nomis-migration/values.yaml
@@ -53,6 +53,8 @@ generic-service:
       HMPPS_SQS_QUEUES_MIGRATION_DLQ_ACCESS_KEY_ID: "access_key_id"
       HMPPS_SQS_QUEUES_MIGRATION_DLQ_SECRET_ACCESS_KEY: "secret_access_key"
     rds-database:
+      SPRING_FLYWAY_USER: "database_username"
+      SPRING_FLYWAY_PASSWORD: "database_password"
       SPRING_R2DBC_USERNAME: "database_username"
       SPRING_R2DBC_PASSWORD: "database_password"
       DATABASE_NAME: "database_name"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/persistence/repository/MigrationHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/persistence/repository/MigrationHistory.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.persistence.repository
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.Transient
+import org.springframework.data.domain.Persistable
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.persistence.repository.MigrationStatus.STARTED
+import java.time.LocalDateTime
+
+data class MigrationHistory(
+  @Id val migrationId: String,
+  val whenStarted: LocalDateTime = LocalDateTime.now(),
+  var whenEnded: LocalDateTime? = null,
+  val estimatedRecordCount: Long,
+  val filter: String? = null,
+  var recordsMigrated: Long = 0,
+  var recordsFailed: Long = 0,
+  val migrationType: MigrationType,
+  var status: MigrationStatus = STARTED,
+  @Transient
+  @Value("false")
+  val new: Boolean = true,
+) : Persistable<String> {
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is MigrationHistory) return false
+
+    if (migrationId != other.migrationId) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    return migrationId.hashCode()
+  }
+
+  override fun isNew(): Boolean = new
+
+  override fun getId(): String = migrationId
+}
+
+enum class MigrationType {
+  VISITS,
+}
+
+enum class MigrationStatus {
+  STARTED,
+  COMPLETED,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/persistence/repository/MigrationHistoryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/persistence/repository/MigrationHistoryRepository.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.persistence.repository
+
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MigrationHistoryRepository : CoroutineCrudRepository<MigrationHistory, String>

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,3 +17,7 @@ spring:
     properties:
       sslMode: DISABLE
       sslRootCert:
+  flyway:
+    url: jdbc:postgresql://localhost:5432/migration?sslmode=prefer
+    user: migration
+    password: migration

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,6 +55,10 @@ spring:
       ssl: true
       sslRootCert: /home/appuser/.postgresql/root.crt
 
+  flyway:
+    enabled: true
+    url: jdbc:postgresql://${DATABASE_ENDPOINT}/${DATABASE_NAME}?sslmode=verify-full
+
 server:
   port: 8080
   servlet:

--- a/src/main/resources/db/migration/V1_2__migration_history.sql
+++ b/src/main/resources/db/migration/V1_2__migration_history.sql
@@ -1,0 +1,14 @@
+create table migration_history
+(
+    migration_id           varchar(40)                            not null
+        constraint migration_history_migration_id_pkey primary key,
+    when_started           timestamp with time zone default now() not null,
+    when_ended             timestamp with time zone,
+    estimated_record_count bigint                                 not null,
+    records_migrated       bigint                   default 0,
+    records_failed         bigint                   default 0,
+    migration_type         varchar(20)                            not null,
+    status                 varchar(20)                            not null,
+    filter                 text
+);
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/SqsIntegrationTestBase.kt
@@ -10,7 +10,6 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.config.PostgresContainer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helper.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.LocalStackContainer.setLocalStackProperties
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.HmppsAuthApiExtension
@@ -28,7 +27,7 @@ import uk.gov.justice.hmpps.sqs.HmppsQueueService
 )
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
-class SqsIntegrationTestBase {
+class SqsIntegrationTestBase : TestBase() {
   @Autowired
   lateinit var webTestClient: WebTestClient
 
@@ -59,22 +58,11 @@ class SqsIntegrationTestBase {
 
   companion object {
     private val localStackContainer = LocalStackContainer.instance
-    private val pgContainer = PostgresContainer.instance
 
     @JvmStatic
     @DynamicPropertySource
     fun testcontainers(registry: DynamicPropertyRegistry) {
       localStackContainer?.also { setLocalStackProperties(it, registry) }
-    }
-
-    @JvmStatic
-    @DynamicPropertySource
-    fun properties(registry: DynamicPropertyRegistry) {
-      pgContainer?.run {
-        registry.add("spring.r2dbc.url") { pgContainer.jdbcUrl.replace("jdbc:", "r2dbc:") }
-        registry.add("spring.r2dbc.username", pgContainer::getUsername)
-        registry.add("spring.r2dbc.password", pgContainer::getPassword)
-      }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/TestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/TestBase.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration
+
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.config.PostgresContainer
+
+@ActiveProfiles("test")
+abstract class TestBase {
+
+  companion object {
+    private val pgContainer = PostgresContainer.instance
+
+    @JvmStatic
+    @DynamicPropertySource
+    fun properties(registry: DynamicPropertyRegistry) {
+      pgContainer?.run {
+        registry.add("spring.flyway.url", pgContainer::getJdbcUrl)
+        registry.add("spring.flyway.user", pgContainer::getUsername)
+        registry.add("spring.flyway.password", pgContainer::getPassword)
+        registry.add("spring.r2dbc.url") { pgContainer.jdbcUrl.replace("jdbc:", "r2dbc:") }
+        registry.add("spring.r2dbc.username", pgContainer::getUsername)
+        registry.add("spring.r2dbc.password", pgContainer::getPassword)
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/persistence/repository/MigrationHistoryRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/persistence/repository/MigrationHistoryRepositoryTest.kt
@@ -1,0 +1,82 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.persistence.repository
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.data.r2dbc.DataR2dbcTest
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.TestBase
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.persistence.repository.MigrationType.VISITS
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+private const val filter = """{
+        "prisonIds": [
+            "HEI"
+        ],
+        "visitTypes": [
+            "SCON"
+        ],
+        "fromDateTime": "2022-03-04T16:01:00",
+        "ignoreMissingRoom": false
+    }"""
+
+@DataR2dbcTest
+@ActiveProfiles("test")
+class MigrationHistoryRepositoryTest : TestBase() {
+  @Autowired
+  lateinit var repository: MigrationHistoryRepository
+
+  @BeforeEach
+  internal fun setUp() = runBlocking {
+    repository.deleteAll()
+  }
+
+  @Test
+  fun `Can create, get and save a MigrationHistory record`(): Unit = runBlocking {
+
+    repository.save(
+      MigrationHistory(
+        migrationId = "2022-01-23T10:31:45",
+        filter = filter,
+        migrationType = VISITS,
+        estimatedRecordCount = 123_678
+      )
+    )
+
+    val persistedMigrationHistory = repository.findById("2022-01-23T10:31:45") ?: throw AssertionError()
+    with(persistedMigrationHistory) {
+      assertThat(migrationId).isEqualTo("2022-01-23T10:31:45")
+      assertThat(filter).isEqualTo(filter)
+      assertThat(migrationType).isEqualTo(VISITS)
+      assertThat(status).isEqualTo(MigrationStatus.STARTED)
+      assertThat(recordsFailed).isEqualTo(0)
+      assertThat(recordsMigrated).isEqualTo(0)
+      assertThat(estimatedRecordCount).isEqualTo(123_678)
+      assertThat(whenEnded).isNull()
+      assertThat(whenStarted).isCloseTo(LocalDateTime.now(), within(5, ChronoUnit.SECONDS))
+    }
+
+    persistedMigrationHistory.whenEnded = LocalDateTime.now()
+    persistedMigrationHistory.recordsFailed = 2
+    persistedMigrationHistory.recordsMigrated = 123_676
+    persistedMigrationHistory.status = MigrationStatus.COMPLETED
+
+    val updatedMigrationHistory = repository.save(persistedMigrationHistory)
+
+    with(updatedMigrationHistory) {
+      assertThat(migrationId).isEqualTo("2022-01-23T10:31:45")
+      assertThat(filter).isEqualTo(filter)
+      assertThat(migrationType).isEqualTo(VISITS)
+      assertThat(status).isEqualTo(MigrationStatus.COMPLETED)
+      assertThat(recordsFailed).isEqualTo(2)
+      assertThat(recordsMigrated).isEqualTo(123_676)
+      assertThat(estimatedRecordCount).isEqualTo(123_678)
+      assertThat(whenEnded).isCloseTo(LocalDateTime.now(), within(5, ChronoUnit.SECONDS))
+      assertThat(whenStarted).isCloseTo(LocalDateTime.now(), within(5, ChronoUnit.SECONDS))
+    }
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -23,3 +23,8 @@ spring:
     properties:
       sslMode: DISABLE
       sslRootCert:
+  flyway:
+    enabled: true
+    url: jdbc:postgresql://localhost:5432/migration?sslmode=prefer
+    user: migration
+    password: migration


### PR DESCRIPTION
So that we can permanently record NOMIS migration job runs we have a table representing each run

This PR only adds the table and repository with test, it is still not used in "anger"