### PR TITLE
SDI-104 Add basic call to add and update migration history

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/persistence/repository/MigrationHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/persistence/repository/MigrationHistory.kt
@@ -4,7 +4,9 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.Transient
 import org.springframework.data.domain.Persistable
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.persistence.repository.MigrationStatus.STARTED
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationStatus
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationStatus.STARTED
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationType
 import java.time.LocalDateTime
 
 data class MigrationHistory(
@@ -38,13 +40,4 @@ data class MigrationHistory(
   override fun isNew(): Boolean = new
 
   override fun getId(): String = migrationId
-}
-
-enum class MigrationType {
-  VISITS,
-}
-
-enum class MigrationStatus {
-  STARTED,
-  COMPLETED,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/resources/MigrationHistoryResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/resources/MigrationHistoryResource.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.resources
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationHistoryService
+
+@RestController
+@RequestMapping("/", produces = [MediaType.APPLICATION_JSON_VALUE])
+class MigrationHistoryResource(private val migrationHistoryService: MigrationHistoryService) {
+  @PreAuthorize("hasRole('ROLE_MIGRATE_VISITS')")
+  @GetMapping("/history")
+  @Operation(
+    summary = "Lists all migration history records un-paged",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "All history records",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))]
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))]
+      )
+    ]
+  )
+  suspend fun getAll() =
+    migrationHistoryService.findAll()
+
+  @PreAuthorize("hasRole('ROLE_MIGRATION_ADMIN')")
+  @DeleteMapping("/history")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @Operation(
+    summary = "Deletes all migration history records",
+    description = "This is only required for test environments",
+    responses = [
+      ApiResponse(
+        responseCode = "204",
+        description = "All history records deleted",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))]
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))]
+      )
+    ]
+  )
+  suspend fun deleteAll() =
+    migrationHistoryService.deleteAll()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/MigrationHistoryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/MigrationHistoryService.kt
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import kotlinx.coroutines.runBlocking
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.persistence.repository.MigrationHistory
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.persistence.repository.MigrationHistoryRepository
+import java.time.LocalDateTime
+
+@Service
+class MigrationHistoryService(
+  private val migrationHistoryRepository: MigrationHistoryRepository,
+  private val objectMapper: ObjectMapper
+) {
+  private companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun recordMigrationStarted(
+    migrationId: String,
+    migrationType: MigrationType,
+    estimatedRecordCount: Long = 0,
+    filter: Any? = null
+  ) = runBlocking {
+    kotlin.runCatching {
+      migrationHistoryRepository.save(
+        MigrationHistory(
+          migrationId = migrationId,
+          migrationType = migrationType,
+          estimatedRecordCount = estimatedRecordCount,
+          filter = filter?.let { objectMapper.writeValueAsString(it) }
+        )
+      )
+    }.onFailure { log.error("Unable to record migration started record", it) }
+  }
+
+  fun recordMigrationCompleted(migrationId: String, recordsFailed: Long, recordsMigrated: Long) = runBlocking {
+    kotlin.runCatching {
+      migrationHistoryRepository.findById(migrationId)?.run {
+        migrationHistoryRepository.save(
+          this.copy(
+            whenEnded = LocalDateTime.now(),
+            recordsFailed = recordsFailed,
+            recordsMigrated = recordsMigrated,
+            status = MigrationStatus.COMPLETED
+          )
+        )
+      }
+    }.onFailure { log.error("Unable to record migration stopped record", it) }
+  }
+
+  suspend fun findAll() = migrationHistoryRepository.findAll()
+  suspend fun deleteAll() = migrationHistoryRepository.deleteAll()
+}
+
+enum class MigrationType {
+  VISITS,
+}
+
+enum class MigrationStatus {
+  STARTED,
+  COMPLETED,
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/persistence/repository/MigrationHistoryRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/persistence/repository/MigrationHistoryRepositoryTest.kt
@@ -9,7 +9,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.data.r2dbc.DataR2dbcTest
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.TestBase
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.persistence.repository.MigrationType.VISITS
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationStatus
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationType.VISITS
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 


### PR DESCRIPTION
This PR will create the migration history record and update it when migration job has finished 

- Also added basic endpoints to read all migration records
- Delete all records
Still to be done

- Record number of records migrated
- Record number of records failed
- Better GET endpoint with filtering