### PR TITLE
SDI-104 Add counts to history record

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitMappingService.kt
@@ -66,6 +66,19 @@ class VisitMappingService(@Qualifier("visitMappingApiWebClient") private val web
     .retrieve()
     .bodyToMono(MigrationDetails::class.java)
     .block()!!
+
+  fun getMigrationCount(migrationId: String): Long = webClient.get()
+    .uri {
+      it.path("/mapping/migration-id/{migrationId}")
+        .queryParam("size", 1)
+        .build(migrationId)
+    }
+    .retrieve()
+    .bodyToMono(MigrationDetails::class.java)
+    .onErrorResume(WebClientResponseException.NotFound::class.java) {
+      Mono.empty()
+    }
+    .block()?.count ?: 0
 }
 
 data class VisitNomisMapping(val nomisId: Long, val vsipId: String, val label: String?, val mappingType: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitsMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitsMigrationService.kt
@@ -150,7 +150,7 @@ class VisitsMigrationService(
         } ?: run { handleNoRoomMappingFound(context.migrationId, nomisVisit) }
       }
 
-  fun migrateVisitsStatusCheck(context: MigrationContext<VisitMigrationStatusCheck>) =
+  fun migrateVisitsStatusCheck(context: MigrationContext<VisitMigrationStatusCheck>) {
     /*
        when checking if there are messages to process, it is always an estimation due to SQS, therefore once
        we think there are no messages we check several times in row reducing probability of false positives significantly
@@ -177,8 +177,8 @@ class VisitsMigrationService(
         )
         migrationHistoryService.recordMigrationCompleted(
           migrationId = context.migrationId,
-          recordsFailed = 0, // TODO - calculate from DLQ
-          recordsMigrated = 0, // TODO - calculate from Mapping table?
+          recordsFailed = queueService.countMessagesThatHaveFailed(),
+          recordsMigrated = visitMappingService.getMigrationCount(context.migrationId),
         )
       } else {
         queueService.sendMessage(
@@ -191,6 +191,7 @@ class VisitsMigrationService(
         )
       }
     }
+  }
 
   private fun createNomisVisitMapping(
     nomisVisitId: Long,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/visits/VisitsMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/visits/VisitsMigrationIntTest.kt
@@ -165,23 +165,25 @@ class VisitsMigrationIntTest : SqsIntegrationTestBase() {
         )
       }
 
-      webTestClient.get().uri("/history")
-        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS")))
-        .header("Content-Type", "application/json")
-        .exchange()
-        .expectStatus().isOk
-        .expectBody()
-        .jsonPath("$.size()").isEqualTo(1)
-        .jsonPath("$[0].migrationId").isNotEmpty
-        .jsonPath("$[0].whenStarted").isNotEmpty
-        .jsonPath("$[0].whenEnded").isNotEmpty
-        .jsonPath("$[0].estimatedRecordCount").isEqualTo(26)
-        .jsonPath("$[0].migrationType").isEqualTo("VISITS")
-        .jsonPath("$[0].status").isEqualTo("COMPLETED")
-        .jsonPath("$[0].filter").value(StringContains("SCON"))
-        .jsonPath("$[0].filter").value(StringContains("HEI"))
-        .jsonPath("$[0].recordsMigrated").isEqualTo(25)
-        .jsonPath("$[0].recordsFailed").isEqualTo(1)
+      await untilAsserted {
+        webTestClient.get().uri("/history")
+          .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.size()").isEqualTo(1)
+          .jsonPath("$[0].migrationId").isNotEmpty
+          .jsonPath("$[0].whenStarted").isNotEmpty
+          .jsonPath("$[0].whenEnded").isNotEmpty
+          .jsonPath("$[0].estimatedRecordCount").isEqualTo(26)
+          .jsonPath("$[0].migrationType").isEqualTo("VISITS")
+          .jsonPath("$[0].status").isEqualTo("COMPLETED")
+          .jsonPath("$[0].filter").value(StringContains("SCON"))
+          .jsonPath("$[0].filter").value(StringContains("HEI"))
+          .jsonPath("$[0].recordsMigrated").isEqualTo(25)
+          .jsonPath("$[0].recordsFailed").isEqualTo(1)
+      }
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/visits/VisitsMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/visits/VisitsMigrationIntTest.kt
@@ -6,6 +6,7 @@ import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilAsserted
 import org.awaitility.kotlin.untilCallTo
+import org.hamcrest.core.StringContains
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -70,6 +71,7 @@ class VisitsMigrationIntTest : SqsIntegrationTestBase() {
       visitMappingApi.stubRoomMapping()
       visitMappingApi.stubVisitMappingCreate()
       visitsApi.stubCreateVisit()
+      visitMappingApi.stubVisitMappingByMigrationId(count = 86)
 
       webTestClient.post().uri("/migrate/visits")
         .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS")))
@@ -125,6 +127,10 @@ class VisitsMigrationIntTest : SqsIntegrationTestBase() {
       visitMappingApi.stubVisitMappingCreate()
       visitsApi.stubCreateVisit()
 
+      // stub 25 migrated records and 1 fake a failure
+      visitMappingApi.stubVisitMappingByMigrationId(count = 25)
+      awsSqsDlqClient!!.sendMessage(dlqUrl, """{ "message": "some error" }""")
+
       webTestClient.post().uri("/migrate/visits")
         .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS")))
         .header("Content-Type", "application/json")
@@ -172,6 +178,10 @@ class VisitsMigrationIntTest : SqsIntegrationTestBase() {
         .jsonPath("$[0].estimatedRecordCount").isEqualTo(26)
         .jsonPath("$[0].migrationType").isEqualTo("VISITS")
         .jsonPath("$[0].status").isEqualTo("COMPLETED")
+        .jsonPath("$[0].filter").value(StringContains("SCON"))
+        .jsonPath("$[0].filter").value(StringContains("HEI"))
+        .jsonPath("$[0].recordsMigrated").isEqualTo(25)
+        .jsonPath("$[0].recordsFailed").isEqualTo(1)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitsMigrationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitsMigrationServiceTest.kt
@@ -373,6 +373,8 @@ internal class VisitsMigrationServiceTest {
       @BeforeEach
       internal fun setUp() {
         whenever(queueService.isItProbableThatThereAreStillMessagesToBeProcessed()).thenReturn(false)
+        whenever(queueService.countMessagesThatHaveFailed()).thenReturn(0)
+        whenever(visitMappingService.getMigrationCount(any())).thenReturn(0)
       }
 
       @Test
@@ -434,6 +436,9 @@ internal class VisitsMigrationServiceTest {
 
       @Test
       internal fun `will update migration history record when finishing off`() {
+        whenever(queueService.countMessagesThatHaveFailed()).thenReturn(2)
+        whenever(visitMappingService.getMigrationCount("2020-05-23T11:30:00")).thenReturn(21)
+
         service.migrateVisitsStatusCheck(
           MigrationContext(
             migrationId = "2020-05-23T11:30:00",
@@ -444,8 +449,8 @@ internal class VisitsMigrationServiceTest {
 
         verify(migrationHistoryService).recordMigrationCompleted(
           migrationId = eq("2020-05-23T11:30:00"),
-          recordsFailed = eq(0), // TODO - this should be the number of records that failed
-          recordsMigrated = eq(0) // TODO - this should be the number of records that were migrated
+          recordsFailed = eq(2),
+          recordsMigrated = eq(21)
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/VisitMappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/VisitMappingApiMockServer.kt
@@ -114,7 +114,7 @@ class VisitMappingApiMockServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
-  fun stubVisitMappingByMigrationId(whenCreated: String, count: Int = 278887) {
+  fun stubVisitMappingByMigrationId(whenCreated: String = "2020-01-01T11:10:00", count: Int = 278887) {
     stubFor(
       get(urlPathMatching("/mapping/migration-id/.*")).willReturn(
         aResponse()


### PR DESCRIPTION
- Reads DLQ to record number of failures
- Read visit migration table to read number of successes

The DLQ is not 100% reliable since there could DLQ messages on queue already, but will mention this in Run Book when done