### PR TITLE
SDI-104 Add Visits specific history endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/resources/MigrationHistoryResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/resources/MigrationHistoryResource.kt
@@ -23,7 +23,7 @@ import java.time.LocalDateTime
 @RestController
 @RequestMapping("/", produces = [MediaType.APPLICATION_JSON_VALUE])
 class MigrationHistoryResource(private val migrationHistoryService: MigrationHistoryService) {
-  @PreAuthorize("hasRole('ROLE_MIGRATE_VISITS')")
+  @PreAuthorize("hasRole('ROLE_MIGRATION_ADMIN')")
   @GetMapping("/history")
   @Operation(
     summary = "Lists all filtered migration history records un-paged",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitMigrationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/visits/VisitMigrationResource.kt
@@ -1,23 +1,34 @@
 package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.visits
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus.ACCEPTED
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.HistoryFilter
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationHistoryService
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationType
+import java.time.LocalDateTime
 import javax.validation.Valid
 
 @RestController
 @RequestMapping("/migrate", produces = [MediaType.APPLICATION_JSON_VALUE])
-class VisitMigrationResource(private val visitsMigrationService: VisitsMigrationService) {
+class VisitMigrationResource(
+  private val visitsMigrationService: VisitsMigrationService,
+  private val migrationHistoryService: MigrationHistoryService
+) {
   @PreAuthorize("hasRole('ROLE_MIGRATE_VISITS')")
   @PostMapping("/visits")
   @ResponseStatus(value = ACCEPTED)
@@ -51,4 +62,59 @@ class VisitMigrationResource(private val visitsMigrationService: VisitsMigration
   )
   fun migrateVisits(@RequestBody @Valid migrationFilter: VisitsMigrationFilter) =
     visitsMigrationService.migrateVisits(migrationFilter)
+
+  @PreAuthorize("hasRole('ROLE_MIGRATE_VISITS')")
+  @GetMapping("/visits/history")
+  @Operation(
+    summary = "Lists all filtered migration history records un-paged for visits",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "All visit migration history records",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))]
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))]
+      )
+    ]
+  )
+  suspend fun getAll(
+    @Parameter(
+      description = "Only include migrations started after this date time",
+      example = "2020-03-23T12:00:00",
+    )
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @RequestParam fromDateTime: LocalDateTime? = null,
+
+    @Parameter(
+      description = "Only include migrations started before this date time",
+      example = "2020-03-24T12:00:00",
+    )
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @RequestParam toDateTime: LocalDateTime? = null,
+
+    @Parameter(
+      description = "When true only include migrations that had at least one failure",
+      example = "false",
+    ) @RequestParam includeOnlyFailures: Boolean = false,
+
+    @Parameter(
+      description = "Specify the prison associated with the migration",
+      example = "HEI",
+    ) @RequestParam prisonId: String? = null,
+  ) = migrationHistoryService.findAll(
+    HistoryFilter(
+      migrationTypes = listOf(MigrationType.VISITS.name),
+      fromDateTime = fromDateTime,
+      toDateTime = toDateTime,
+      includeOnlyFailures = includeOnlyFailures,
+      filterContains = prisonId?.let { """"prisonIds":["$it"]""" }
+    )
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/history/MigrationHistoryIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/history/MigrationHistoryIntTest.kt
@@ -25,6 +25,7 @@ class MigrationHistoryIntTest : SqsIntegrationTestBase() {
     internal fun createHistoryRecords() {
 
       runBlocking {
+        migrationHistoryRepository.deleteAll()
         migrationHistoryRepository.save(
           MigrationHistory(
             migrationId = "2020-01-01T00:00:00",
@@ -139,7 +140,7 @@ class MigrationHistoryIntTest : SqsIntegrationTestBase() {
     @Test
     internal fun `can read all records with no filter`() {
       webTestClient.get().uri("/history")
-        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATION_ADMIN")))
         .header("Content-Type", "application/json")
         .exchange()
         .expectStatus().isOk
@@ -158,7 +159,7 @@ class MigrationHistoryIntTest : SqsIntegrationTestBase() {
           .queryParam("migrationTypes", "VISITS")
           .build()
       }
-        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATION_ADMIN")))
         .header("Content-Type", "application/json")
         .exchange()
         .expectStatus().isOk
@@ -174,7 +175,7 @@ class MigrationHistoryIntTest : SqsIntegrationTestBase() {
           .queryParam("migrationTypes", "BANANAS")
           .build()
       }
-        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATION_ADMIN")))
         .header("Content-Type", "application/json")
         .exchange()
         .expectStatus().isOk
@@ -187,7 +188,7 @@ class MigrationHistoryIntTest : SqsIntegrationTestBase() {
           .queryParam("migrationTypes", "VISITS")
           .build()
       }
-        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATION_ADMIN")))
         .header("Content-Type", "application/json")
         .exchange()
         .expectStatus().isOk
@@ -202,7 +203,7 @@ class MigrationHistoryIntTest : SqsIntegrationTestBase() {
           .queryParam("fromDateTime", "2020-01-02T02:00:00")
           .build()
       }
-        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATION_ADMIN")))
         .header("Content-Type", "application/json")
         .exchange()
         .expectStatus().isOk
@@ -219,7 +220,7 @@ class MigrationHistoryIntTest : SqsIntegrationTestBase() {
           .queryParam("toDateTime", "2020-01-02T00:00:00")
           .build()
       }
-        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATION_ADMIN")))
         .header("Content-Type", "application/json")
         .exchange()
         .expectStatus().isOk
@@ -237,7 +238,7 @@ class MigrationHistoryIntTest : SqsIntegrationTestBase() {
           .queryParam("toDateTime", "2020-01-03T02:00:01")
           .build()
       }
-        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATION_ADMIN")))
         .header("Content-Type", "application/json")
         .exchange()
         .expectStatus().isOk
@@ -253,7 +254,7 @@ class MigrationHistoryIntTest : SqsIntegrationTestBase() {
           .queryParam("includeOnlyFailures", "true")
           .build()
       }
-        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATION_ADMIN")))
         .header("Content-Type", "application/json")
         .exchange()
         .expectStatus().isOk
@@ -270,7 +271,7 @@ class MigrationHistoryIntTest : SqsIntegrationTestBase() {
           .queryParam("filterContains", "WWI")
           .build()
       }
-        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATION_ADMIN")))
         .header("Content-Type", "application/json")
         .exchange()
         .expectStatus().isOk
@@ -283,7 +284,7 @@ class MigrationHistoryIntTest : SqsIntegrationTestBase() {
           .queryParam("filterContains", "visitTypes")
           .build()
       }
-        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_VISITS")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATION_ADMIN")))
         .header("Content-Type", "application/json")
         .exchange()
         .expectStatus().isOk


### PR DESCRIPTION
- Generic `history` endpoint now protected by admin role
- Visits specific version of endpoint 

This is required for 2 reasons:

- Visit migration users should only see visit migrations
- Has ability to understand the filter, so can easily and reliable filter by prison