### PR TITLE
SDI-538 Mapping is now sentence/key date agnostic.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/MigrationSentencingMessageListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/MigrationSentencingMessageListener.kt
@@ -9,11 +9,11 @@ import org.springframework.jms.annotation.JmsListener
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.context
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing.SentencingMessages.CANCEL_MIGRATE_SENTENCING
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing.SentencingMessages.MIGRATE_SENTENCE_ADJUSTMENT
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing.SentencingMessages.MIGRATE_SENTENCE_ADJUSTMENTS
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing.SentencingMessages.MIGRATE_SENTENCE_ADJUSTMENTS_BY_PAGE
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing.SentencingMessages.MIGRATE_SENTENCING_ADJUSTMENT
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing.SentencingMessages.MIGRATE_SENTENCING_ADJUSTMENTS_BY_PAGE
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing.SentencingMessages.MIGRATE_SENTENCING_STATUS_CHECK
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing.SentencingMessages.RETRY_SENTENCE_ADJUSTMENT_MAPPING
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing.SentencingMessages.RETRY_SENTENCING_ADJUSTMENT_MAPPING
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationMessage
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.SENTENCING_QUEUE_ID
 
@@ -33,12 +33,12 @@ class MigrationSentencingMessageListener(
     val migrationMessage: MigrationMessage<SentencingMessages, *> = message.fromJson()
     kotlin.runCatching {
       when (migrationMessage.type) {
-        MIGRATE_SENTENCE_ADJUSTMENTS -> sentencingMigrationService.divideSentenceAdjustmentsByPage(context(message.fromJson()))
-        MIGRATE_SENTENCE_ADJUSTMENTS_BY_PAGE -> sentencingMigrationService.migrateSentenceAdjustmentsForPage(context(message.fromJson()))
-        MIGRATE_SENTENCE_ADJUSTMENT -> sentencingMigrationService.migrateSentenceAdjustment(context(message.fromJson()))
+        MIGRATE_SENTENCE_ADJUSTMENTS -> sentencingMigrationService.divideSentencingAdjustmentsByPage(context(message.fromJson()))
+        MIGRATE_SENTENCING_ADJUSTMENTS_BY_PAGE -> sentencingMigrationService.migrateSentenceAdjustmentsForPage(context(message.fromJson()))
+        MIGRATE_SENTENCING_ADJUSTMENT -> sentencingMigrationService.migrateSentencingAdjustment(context(message.fromJson()))
         MIGRATE_SENTENCING_STATUS_CHECK -> sentencingMigrationService.migrateSentencingStatusCheck(context(message.fromJson()))
         CANCEL_MIGRATE_SENTENCING -> sentencingMigrationService.cancelMigrateSentencingStatusCheck(context(message.fromJson()))
-        RETRY_SENTENCE_ADJUSTMENT_MAPPING -> sentencingMigrationService.retryCreateSentenceAdjustmentMapping(context(message.fromJson()))
+        RETRY_SENTENCING_ADJUSTMENT_MAPPING -> sentencingMigrationService.retryCreateSentenceAdjustmentMapping(context(message.fromJson()))
         // NG -> incentivesMigrationService.retryCreateIncentiveMapping(context(message.fromJson()))
         // SYNCHRONISE_CURRENT_INCENTIVE -> incentivesSynchronisationService.handleSynchroniseCurrentIncentiveMessage(context(message.fromJson()))
         // RETRY_INCENTIVE_SYNCHRONISATION_MAPPING -> incentivesSynchronisationService.retryCreateIncentiveMapping(context(message.fromJson()))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingMessages.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingMessages.kt
@@ -2,9 +2,9 @@ package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing
 
 enum class SentencingMessages {
   MIGRATE_SENTENCE_ADJUSTMENTS,
-  MIGRATE_SENTENCE_ADJUSTMENTS_BY_PAGE,
-  MIGRATE_SENTENCE_ADJUSTMENT,
+  MIGRATE_SENTENCING_ADJUSTMENTS_BY_PAGE,
+  MIGRATE_SENTENCING_ADJUSTMENT,
   MIGRATE_SENTENCING_STATUS_CHECK, // status check and cancel work at queue level. The queue is used by all Sentencing migration entity migrations
   CANCEL_MIGRATE_SENTENCING,
-  RETRY_SENTENCE_ADJUSTMENT_MAPPING,
+  RETRY_SENTENCING_ADJUSTMENT_MAPPING,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingService.kt
@@ -9,12 +9,12 @@ import java.time.LocalDate
 
 @Service
 class SentencingService(@Qualifier("sentencingApiWebClient") private val webClient: WebClient) {
-  fun migrateSentenceAdjustment(sentenceAdjustment: CreateSentenceAdjustment): CreateSentenceAdjustmentResponse =
+  fun migrateSentencingAdjustment(sentenceAdjustment: CreateSentenceAdjustment): CreateSentencingAdjustmentResponse =
     webClient.post()
       .uri("/migration/sentencing/sentence-adjustments")
       .bodyValue(sentenceAdjustment)
       .retrieve()
-      .bodyToMono(CreateSentenceAdjustmentResponse::class.java)
+      .bodyToMono(CreateSentencingAdjustmentResponse::class.java)
       .block()!!
 }
 
@@ -33,6 +33,6 @@ data class CreateSentenceAdjustment(
   val active: Boolean,
 )
 
-data class CreateSentenceAdjustmentResponse(
+data class CreateSentencingAdjustmentResponse(
   val id: Long,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/NomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/NomisApiService.kt
@@ -167,7 +167,7 @@ class NomisApiService(@Qualifier("nomisApiWebClient") private val webClient: Web
     toDate: LocalDate?,
     pageNumber: Long,
     pageSize: Long
-  ): PageImpl<SentenceAdjustmentId> =
+  ): PageImpl<NomisSentencingAdjustmentId> =
     webClient.get()
       .uri {
         it.path("/sentence-adjustments/ids")
@@ -178,7 +178,7 @@ class NomisApiService(@Qualifier("nomisApiWebClient") private val webClient: Web
           .build()
       }
       .retrieve()
-      .bodyToMono(typeReference<RestResponsePage<SentenceAdjustmentId>>())
+      .bodyToMono(typeReference<RestResponsePage<NomisSentencingAdjustmentId>>())
       .awaitSingle()
 
   fun getSentenceAdjustmentsBlocking(
@@ -186,7 +186,7 @@ class NomisApiService(@Qualifier("nomisApiWebClient") private val webClient: Web
     toDate: LocalDate?,
     pageNumber: Long,
     pageSize: Long
-  ): PageImpl<SentenceAdjustmentId> = runBlocking {
+  ): PageImpl<NomisSentencingAdjustmentId> = runBlocking {
     getSentenceAdjustments(
       fromDate,
       toDate,
@@ -229,8 +229,9 @@ data class IncentiveId(
   val sequence: Long,
 )
 
-data class SentenceAdjustmentId(
-  val sentenceAdjustmentId: Long,
+data class NomisSentencingAdjustmentId(
+  val adjustmentId: Long,
+  val adjustmentType: String,
 )
 
 data class NomisVisitor(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/sentencing/SentencingMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/sentencing/SentencingMigrationIntTest.kt
@@ -81,7 +81,7 @@ class SentencingMigrationIntTest : SqsIntegrationTestBase() {
       nomisApi.stubGetSentenceAdjustmentsInitialCount(86)
       nomisApi.stubMultipleGetSentenceAdjustmentsCounts(totalElements = 86, pageSize = 10)
       nomisApi.stubMultipleGetSentenceAdjustments(86)
-      mappingApi.stubAllNomisSentenceAdjustmentMappingNotFound()
+      mappingApi.stubAllNomisSentencingAdjustmentsMappingNotFound()
       mappingApi.stubSentenceAdjustmentMappingCreate()
 
       sentencingApi.stubCreateSentenceAdjustment()
@@ -126,7 +126,7 @@ class SentencingMigrationIntTest : SqsIntegrationTestBase() {
       nomisApi.stubMultipleGetSentenceAdjustmentsCounts(totalElements = 26, pageSize = 10)
       nomisApi.stubMultipleGetSentenceAdjustments(26)
       sentencingApi.stubCreateSentenceAdjustment()
-      mappingApi.stubAllNomisSentenceAdjustmentMappingNotFound()
+      mappingApi.stubAllNomisSentencingAdjustmentsMappingNotFound()
       mappingApi.stubSentenceAdjustmentMappingCreate()
 
       // stub 25 migrated records and 1 fake a failure
@@ -190,7 +190,7 @@ class SentencingMigrationIntTest : SqsIntegrationTestBase() {
       nomisApi.stubGetSentenceAdjustmentsInitialCount(1)
       nomisApi.stubMultipleGetSentenceAdjustmentsCounts(totalElements = 1, pageSize = 10)
       nomisApi.stubMultipleGetSentenceAdjustments(totalElements = 1)
-      mappingApi.stubAllNomisSentenceAdjustmentMappingNotFound()
+      mappingApi.stubAllNomisSentencingAdjustmentsMappingNotFound()
       sentencingApi.stubCreateSentenceAdjustment(654321)
       mappingApi.stubSentenceAdjustmentMappingCreateFailureFollowedBySuccess()
 
@@ -494,7 +494,7 @@ class SentencingMigrationIntTest : SqsIntegrationTestBase() {
       val count = 30L
       nomisApi.stubGetSentenceAdjustmentsInitialCount(count)
       nomisApi.stubMultipleGetSentenceAdjustmentsCounts(totalElements = count, pageSize = 10)
-      mappingApi.stubIncentiveMappingByMigrationId(count = count.toInt())
+      mappingApi.stubSentenceAdjustmentMappingByMigrationId(count = count.toInt())
 
       val migrationId = webTestClient.post().uri("/migrate/sentencing")
         .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_SENTENCING")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/MappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/MappingApiMockServer.kt
@@ -442,10 +442,10 @@ class MappingApiMockServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
-  fun stubAllNomisSentenceAdjustmentMappingNotFound() {
+  fun stubAllNomisSentencingAdjustmentsMappingNotFound() {
     stubFor(
       get(
-        urlPathMatching("/mapping/sentence-adjustments/nomis-sentencing-adjustment-id/\\d*")
+        urlPathMatching("/mapping/sentencing/adjustments/nomis-adjustment-type/SENTENCE/nomis-adjustment-id/\\d*")
       ).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
@@ -457,7 +457,7 @@ class MappingApiMockServer : WireMockServer(WIREMOCK_PORT) {
 
   fun stubSentenceAdjustmentMappingCreate() {
     stubFor(
-      post(urlEqualTo("/mapping/sentence-adjustments")).willReturn(
+      post(urlEqualTo("/mapping/sentencing/adjustments")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(HttpStatus.CREATED.value())
@@ -467,7 +467,7 @@ class MappingApiMockServer : WireMockServer(WIREMOCK_PORT) {
 
   fun stubSentenceAdjustmentMappingByMigrationId(whenCreated: String = "2020-01-01T11:10:00", count: Int = 278887) {
     stubFor(
-      get(urlPathMatching("/mapping/sentence-adjustments/migration-id/.*")).willReturn(
+      get(urlPathMatching("/mapping/sentencing/adjustments/migration-id/.*")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withBody(
@@ -476,7 +476,8 @@ class MappingApiMockServer : WireMockServer(WIREMOCK_PORT) {
     "content": [
         {
             "sentenceAdjustmentId": 191747,
-            "nomisSentenceAdjustmentId": 123,
+            "nomisAdjustmentId": 123,
+            "nomisAdjustmentType": "SENTENCE",
             "label": "2022-02-14T09:58:45",
             "whenCreated": "$whenCreated",
             "mappingType": "MIGRATED"
@@ -516,7 +517,7 @@ class MappingApiMockServer : WireMockServer(WIREMOCK_PORT) {
 
   fun stubSentenceAdjustmentMappingCreateFailureFollowedBySuccess() {
     stubFor(
-      post(urlPathEqualTo("/mapping/sentence-adjustments"))
+      post(urlPathEqualTo("/mapping/sentencing/adjustments"))
         .inScenario("Retry sentence-adjustment Scenario")
         .whenScenarioStateIs(STARTED)
         .willReturn(
@@ -528,7 +529,7 @@ class MappingApiMockServer : WireMockServer(WIREMOCK_PORT) {
     )
 
     stubFor(
-      post(urlPathEqualTo("/mapping/sentence-adjustments"))
+      post(urlPathEqualTo("/mapping/sentencing/adjustments"))
         .inScenario("Retry sentence-adjustment Scenario")
         .whenScenarioStateIs("Cause sentence-adjustment Success")
         .willReturn(
@@ -541,12 +542,12 @@ class MappingApiMockServer : WireMockServer(WIREMOCK_PORT) {
   }
 
   fun createSentenceAdjustmentMappingCount() =
-    findAll(postRequestedFor(urlPathEqualTo("/mapping/sentence-adjustments"))).count()
+    findAll(postRequestedFor(urlPathEqualTo("/mapping/sentencing/adjustments"))).count()
 
   fun verifyCreateMappingSentenceAdjustmentIds(nomsSentenceAdjustmentIds: Array<Long>, times: Int = 1) = nomsSentenceAdjustmentIds.forEach {
     verify(
       times,
-      postRequestedFor(urlPathEqualTo("/mapping/sentence-adjustments")).withRequestBody(
+      postRequestedFor(urlPathEqualTo("/mapping/sentencing/adjustments")).withRequestBody(
         matchingJsonPath(
           "sentenceAdjustmentId",
           equalTo("$it")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/NomisApiMockServer.kt
@@ -325,7 +325,7 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
         .withQueryParam("size", equalTo("1"))
         .willReturn(
           aResponse().withHeader("Content-Type", "application/json").withStatus(HttpStatus.OK.value())
-            .withBody(sentenceAdjustmentPagedResponse(totalElements = totalElements))
+            .withBody(sentencingAdjustmentPagedResponse(totalElements = totalElements))
         )
     )
   }
@@ -345,7 +345,7 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
           .willReturn(
             aResponse().withHeader("Content-Type", "application/json").withStatus(HttpStatus.OK.value())
               .withBody(
-                sentenceAdjustmentPagedResponse(
+                sentencingAdjustmentPagedResponse(
                   totalElements = totalElements,
                   sentenceAdjustmentIds = (startSentenceAdjustmentId..endBSentenceAdjustmentId).map { it },
                   pageNumber = page,
@@ -563,13 +563,13 @@ private fun incentiveResponse(
   """.trimIndent()
 }
 
-private fun sentenceAdjustmentPagedResponse(
+private fun sentencingAdjustmentPagedResponse(
   totalElements: Long = 10,
   sentenceAdjustmentIds: List<Long> = (0L..10L).toList(),
   pageSize: Long = 10,
   pageNumber: Long = 0,
 ): String {
-  val content = sentenceAdjustmentIds.map { """{ "sentenceAdjustmentId": $it }""" }
+  val content = sentenceAdjustmentIds.map { """{ "adjustmentId": $it, "adjustmentType": "SENTENCE" }""" }
     .joinToString { it }
   return """
 {


### PR DESCRIPTION
 So foundation change to migrate both types at same time.
 
 Where we referred to "sentence adjustments"  and that is now used to reference the 2 types of adjustments we now use the language "sentencing adjustments"; this includes "sentence adjustments" and "key date adjustments"