### PR TITLE
SDI-702 Always try to delete adjustment even when last update came from DPS

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsSynchronisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsSynchronisationService.kt
@@ -65,13 +65,6 @@ class SentencingAdjustmentsSynchronisationService(
   }
 
   suspend fun synchroniseSentenceAdjustmentDelete(event: SentenceAdjustmentOffenderEvent) {
-    if (event.auditModuleName == "DPS_SYNCHRONISATION") {
-      telemetryClient.trackEvent(
-        "sentence-adjustment-delete-synchronisation-skipped",
-        event.toTelemetryProperties(),
-      )
-      return
-    }
     sentencingAdjustmentsMappingService.findNomisSentencingAdjustmentMapping(
       nomisAdjustmentId = event.adjustmentId,
       nomisAdjustmentCategory = "SENTENCE",
@@ -121,13 +114,6 @@ class SentencingAdjustmentsSynchronisationService(
   }
 
   suspend fun synchroniseKeyDateAdjustmentDelete(event: KeyDateAdjustmentOffenderEvent) {
-    if (event.auditModuleName == "DPS_SYNCHRONISATION") {
-      telemetryClient.trackEvent(
-        "key-date-adjustment-delete-synchronisation-skipped",
-        event.toTelemetryProperties(),
-      )
-      return
-    }
     sentencingAdjustmentsMappingService.findNomisSentencingAdjustmentMapping(
       nomisAdjustmentId = event.adjustmentId,
       nomisAdjustmentCategory = "KEY-DATE",


### PR DESCRIPTION
To prevent infinite synchronisation in the 2-way sync, both services checks what service made the change and suppress forwarding create/updates/deletes.

The exception is for DELETEs since there is no way of knowing if NOMIS or DPS initiated the delete (since the audit column is not updated).

So this change assumes the DELETE in the sentencing service and mapping are idempotent and will no error if a DELETE is called on an already deleted element.