### PR TITLE
SDI-702 Allow DPS delete to return 404 without error

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/helpers/WebClientHelpers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/helpers/WebClientHelpers.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers
+
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.reactive.function.client.bodyToMono
+import reactor.core.publisher.Mono
+
+suspend inline fun <reified T : Any> WebClient.ResponseSpec.awaitBodyOrNotFound(): T? =
+  this.bodyToMono<T>()
+    .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
+    .awaitSingleOrNull()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingService.kt
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBody
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.awaitBodyOrNotFound
 import java.time.LocalDate
 
 @Service
@@ -38,12 +39,13 @@ class SentencingService(@Qualifier("sentencingApiWebClient") private val webClie
       .retrieve()
       .awaitBody()
 
-  suspend fun deleteSentencingAdjustment(adjustmentId: String): Unit =
+  suspend fun deleteSentencingAdjustment(adjustmentId: String) {
     webClient.delete()
       .uri("/legacy/adjustments/$adjustmentId")
       .header("Content-Type", LEGACY_CONTENT_TYPE)
       .retrieve()
-      .awaitBody()
+      .awaitBodyOrNotFound<Unit>()
+  }
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingServiceTest.kt
@@ -174,22 +174,42 @@ internal class SentencingServiceTest {
   @Nested
   @DisplayName("DELETE /legacy/adjustments")
   inner class DeleteAdjustmentForSynchronisation {
-    @BeforeEach
-    internal fun setUp() {
-      sentencingApi.stubDeleteSentencingAdjustmentForSynchronisation(adjustmentId = ADJUSTMENT_ID)
-      runBlocking {
-        sentencingService.deleteSentencingAdjustment(
-          ADJUSTMENT_ID,
+    @Nested
+    inner class AdjustmentExists {
+      @BeforeEach
+      internal fun setUp() {
+        sentencingApi.stubDeleteSentencingAdjustmentForSynchronisation(adjustmentId = ADJUSTMENT_ID)
+        runBlocking {
+          sentencingService.deleteSentencingAdjustment(
+            ADJUSTMENT_ID,
+          )
+        }
+      }
+
+      @Test
+      fun `should call api with OAuth2 token`() {
+        sentencingApi.verify(
+          deleteRequestedFor(urlEqualTo("/legacy/adjustments/$ADJUSTMENT_ID"))
+            .withHeader("Authorization", equalTo("Bearer ABCDE")),
         )
       }
     }
 
-    @Test
-    fun `should call api with OAuth2 token`() {
-      sentencingApi.verify(
-        deleteRequestedFor(urlEqualTo("/legacy/adjustments/$ADJUSTMENT_ID"))
-          .withHeader("Authorization", equalTo("Bearer ABCDE")),
-      )
+    @Nested
+    inner class AdjustmentAlreadyDeleted {
+      @BeforeEach
+      internal fun setUp() {
+        sentencingApi.stubDeleteSentencingAdjustmentForSynchronisationNotFound(adjustmentId = ADJUSTMENT_ID)
+      }
+
+      @Test
+      fun `should ignore 404 error`() {
+        runBlocking {
+          sentencingService.deleteSentencingAdjustment(
+            ADJUSTMENT_ID,
+          )
+        }
+      }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/SentencingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/SentencingApiMockServer.kt
@@ -90,6 +90,16 @@ class SentencingApiMockServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
+  fun stubDeleteSentencingAdjustmentForSynchronisationNotFound(adjustmentId: String = "654321") {
+    stubFor(
+      delete(WireMock.urlMatching("/legacy/adjustments/$adjustmentId")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(HttpStatus.NOT_FOUND.value()),
+      ),
+    )
+  }
+
   fun createSentenceAdjustmentCount() =
     findAll(WireMock.postRequestedFor(WireMock.urlMatching("/legacy/adjustments/migration"))).count()
 


### PR DESCRIPTION
This allows this theoretical edge case to work:

* Adjustment created in DPS
* Adjustment delete in DPS
* Update service deletes NOMIS record 
* Triggers messages this service so this service also attempts to delete adjustment that has already been deleted
* Update service deletes Mapping
* Call to DPS service returns 404 since adjustment is already deleted

So treat DELETE in DPS as idempotent 