### PR TITLE
SDIT 927 mapping record change DTO and URL

### DIFF
--- a/openapi-specs/nomis-mapping-service-api-docs.json
+++ b/openapi-specs/nomis-mapping-service-api-docs.json
@@ -7,7 +7,7 @@
       "name": "HMPPS Digital Studio",
       "email": "feedback@digital.justice.gov.uk"
     },
-    "version": "2023-08-10.2694.07bc7cc"
+    "version": "2023-08-16.2738.6d0da08"
   },
   "servers": [
     {
@@ -136,7 +136,7 @@
         ],
         "summary": "Creates a new activity mapping",
         "description": "Creates a mapping between nomis id and Activity service id. Requires NOMIS_ACTIVITIES",
-        "operationId": "createMapping_6",
+        "operationId": "createMapping_7",
         "requestBody": {
           "content": {
             "application/json": {
@@ -662,6 +662,96 @@
         }
       }
     },
+    "/mapping/allocation/migration": {
+      "post": {
+        "tags": [
+          "allocation-migration-resource"
+        ],
+        "summary": "Creates a new allocation migration mapping",
+        "description": "Creates a mapping between nomis allocation id and Actvities allocation id. Requires NOMIS_ACTIVITIES",
+        "operationId": "createMapping_4",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AllocationMigrationMappingDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Mapping entry created"
+          },
+          "400": {
+            "description": "Nomis or activity schedule ids already exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mapping/adjudications/all": {
+      "post": {
+        "tags": [
+          "adjudications-mapping-resource"
+        ],
+        "summary": "Creates a new adjudication mapping along with associated hearings and punishments",
+        "description": "Creates a record of a adjudication number, hearing and punishment. Requires NOMIS_ADJUDICATIONS",
+        "operationId": "createAllMappings",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdjudicationAllMappingDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Mapping entry created"
+          },
+          "409": {
+            "description": "Adjudication with charge sequence already exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/mapping/adjudications": {
       "get": {
         "tags": [
@@ -702,7 +792,7 @@
         ],
         "summary": "Creates a new adjudication mapping",
         "description": "Creates a record of a adjudication number. Requires NOMIS_ADJUDICATIONS",
-        "operationId": "createMapping_4",
+        "operationId": "createMapping_5",
         "requestBody": {
           "content": {
             "application/json": {
@@ -747,7 +837,7 @@
         ],
         "summary": "Creates a new activity migration mapping",
         "description": "Creates a mapping between nomis id and up to 2 Activity service ids. Requires NOMIS_ACTIVITIES",
-        "operationId": "createMapping_5",
+        "operationId": "createMapping_6",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1881,6 +1971,158 @@
         }
       }
     },
+    "/mapping/allocations/migration/nomis-allocation-id/{nomisAllocationId}": {
+      "get": {
+        "tags": [
+          "allocation-migration-resource"
+        ],
+        "summary": "get mapping for an allocation migration",
+        "description": "Retrieves an allocation migration mapping by the nomis id. Requires role NOMIS_ACTIVITIES",
+        "operationId": "getMapping",
+        "parameters": [
+          {
+            "name": "nomisAllocationId",
+            "in": "path",
+            "description": "Nomis allocation Id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Nomis allocation Id",
+              "example": 12345
+            },
+            "example": 12345
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Mapping Information Returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AllocationMigrationMappingDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Id does not exist in mapping table",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mapping/allocations/migration/migration-id/{migrationId}": {
+      "get": {
+        "tags": [
+          "allocation-migration-resource"
+        ],
+        "summary": "get paged mappings by migration id",
+        "description": "Retrieve all allocation migration mappings for the given migration id (identifies a single migration run). Results are paged.",
+        "operationId": "getMigratedAllocationMappings",
+        "parameters": [
+          {
+            "name": "pageRequest",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Pageable"
+            }
+          },
+          {
+            "name": "migrationId",
+            "in": "path",
+            "description": "Migration Id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Migration Id",
+              "example": "2020-03-24T12:00:00"
+            },
+            "example": "2020-03-24T12:00:00"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Mapping page returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AllocationMigrationMappingDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mapping/allocations/migrated/latest": {
+      "get": {
+        "tags": [
+          "allocation-migration-resource"
+        ],
+        "summary": "get the latest mapping for an allocation migration",
+        "description": "Requires role NOMIS_ACTIVITIES",
+        "operationId": "getLatestMigratedMapping",
+        "responses": {
+          "200": {
+            "description": "Mapping Information Returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AllocationMigrationMappingDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No mappings found at all for any migration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/mapping/adjudications/migration-id/{migrationId}": {
       "get": {
         "tags": [
@@ -2145,7 +2387,7 @@
         ],
         "summary": "get mapping for an activity migration",
         "description": "Retrieves an activity migration mapping by course activity id. Requires role NOMIS_ACTIVITIES",
-        "operationId": "getMapping",
+        "operationId": "getMapping_1",
         "parameters": [
           {
             "name": "courseActivityId",
@@ -2255,7 +2497,7 @@
         ],
         "summary": "get the latest mapping for a migration",
         "description": "Requires role NOMIS_ACTIVITIES",
-        "operationId": "getLatestMigratedMapping",
+        "operationId": "getLatestMigratedMapping_1",
         "responses": {
           "200": {
             "description": "Mapping Information Returned",
@@ -2499,6 +2741,45 @@
         "responses": {
           "204": {
             "description": "Mapping deleted"
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mapping/adjudications/all/migration-id/{migrationId}": {
+      "delete": {
+        "tags": [
+          "adjudications-mapping-resource"
+        ],
+        "summary": "Delete all adjudication related mapping entries for the given migration id",
+        "description": "Delete mapping entries created during a single migration for adjudications and associated hearings and punishments",
+        "operationId": "deleteMappingsByMigrationId",
+        "parameters": [
+          {
+            "name": "migrationId",
+            "in": "path",
+            "description": "Migration Id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Migration Id",
+              "example": "2020-03-24T12:00:00"
+            },
+            "example": "2020-03-24T12:00:00"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Adjudication mappings deleted"
           },
           "401": {
             "description": "Unauthorized to access this endpoint",
@@ -2911,6 +3192,135 @@
         },
         "description": "NOMIS to Appointment mapping"
       },
+      "AllocationMigrationMappingDto": {
+        "required": [
+          "activityAllocationId",
+          "activityScheduleId",
+          "label",
+          "nomisAllocationId"
+        ],
+        "type": "object",
+        "properties": {
+          "nomisAllocationId": {
+            "type": "integer",
+            "description": "NOMIS allocation id",
+            "format": "int64"
+          },
+          "activityAllocationId": {
+            "type": "integer",
+            "description": "Activity allocation id",
+            "format": "int64"
+          },
+          "activityScheduleId": {
+            "type": "integer",
+            "description": "Activity schedule id",
+            "format": "int64"
+          },
+          "label": {
+            "maxLength": 20,
+            "minLength": 0,
+            "type": "string",
+            "description": "Label (a timestamp for migrated ids)"
+          },
+          "whenCreated": {
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
+            "type": "string",
+            "description": "Date-time the mapping was created",
+            "example": "2021-07-05T10:35:17"
+          }
+        },
+        "description": "NOMIS to Activities allocation mapping"
+      },
+      "AdjudicationAllMappingDto": {
+        "required": [
+          "adjudicationId",
+          "hearings",
+          "label",
+          "punishments"
+        ],
+        "type": "object",
+        "properties": {
+          "adjudicationId": {
+            "$ref": "#/components/schemas/AdjudicationMappingDto"
+          },
+          "hearings": {
+            "type": "array",
+            "description": "Adjudication hearing mapping",
+            "items": {
+              "$ref": "#/components/schemas/AdjudicationHearingMappingDto"
+            }
+          },
+          "punishments": {
+            "type": "array",
+            "description": "Adjudication punishment mapping",
+            "items": {
+              "$ref": "#/components/schemas/AdjudicationPunishmentMappingDto"
+            }
+          },
+          "label": {
+            "maxLength": 20,
+            "minLength": 0,
+            "type": "string",
+            "description": "Label (a timestamp for migrated ids)"
+          },
+          "mappingType": {
+            "maxLength": 20,
+            "minLength": 0,
+            "type": "string",
+            "description": "Mapping type",
+            "default": "MIGRATED",
+            "enum": [
+              "MIGRATED",
+              "ADJUDICATION_CREATED"
+            ]
+          }
+        },
+        "description": "Adjudication mapping for all entities in an adjudication"
+      },
+      "AdjudicationHearingMappingDto": {
+        "required": [
+          "dpsHearingId",
+          "nomisHearingId"
+        ],
+        "type": "object",
+        "properties": {
+          "nomisHearingId": {
+            "type": "integer",
+            "description": "NOMIS hearing id",
+            "format": "int64",
+            "example": 123456
+          },
+          "dpsHearingId": {
+            "type": "string",
+            "description": "DPS hearing id",
+            "example": "123456"
+          },
+          "label": {
+            "maxLength": 20,
+            "minLength": 0,
+            "type": "string",
+            "description": "Label (a timestamp for migrated ids)"
+          },
+          "mappingType": {
+            "maxLength": 20,
+            "minLength": 0,
+            "type": "string",
+            "description": "Mapping type",
+            "default": "ADJUDICATION_CREATED",
+            "enum": [
+              "MIGRATED",
+              "ADJUDICATION_CREATED"
+            ]
+          },
+          "whenCreated": {
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
+            "type": "string",
+            "description": "Date-time the mapping was created",
+            "example": "2021-07-05T10:35:17"
+          }
+        },
+        "description": "Adjudication hearing mapping"
+      },
       "AdjudicationMappingDto": {
         "required": [
           "adjudicationNumber",
@@ -2961,6 +3371,57 @@
           }
         },
         "description": "Adjudication mapping (same value for NOMIS and DPS)"
+      },
+      "AdjudicationPunishmentMappingDto": {
+        "required": [
+          "dpsPunishmentId",
+          "nomisBookingId",
+          "nomisSanctionSequence"
+        ],
+        "type": "object",
+        "properties": {
+          "nomisBookingId": {
+            "type": "integer",
+            "description": "NOMIS booking id",
+            "format": "int64",
+            "example": 123456
+          },
+          "nomisSanctionSequence": {
+            "type": "integer",
+            "description": "NOMIS sanction sequence",
+            "format": "int32",
+            "example": 4
+          },
+          "dpsPunishmentId": {
+            "type": "string",
+            "description": "DPS punishment id",
+            "example": "123456"
+          },
+          "label": {
+            "maxLength": 20,
+            "minLength": 0,
+            "type": "string",
+            "description": "Label (a timestamp for migrated ids)"
+          },
+          "mappingType": {
+            "maxLength": 20,
+            "minLength": 0,
+            "type": "string",
+            "description": "Mapping type",
+            "default": "ADJUDICATION_CREATED",
+            "enum": [
+              "MIGRATED",
+              "ADJUDICATION_CREATED"
+            ]
+          },
+          "whenCreated": {
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
+            "type": "string",
+            "description": "Date-time the mapping was created",
+            "example": "2021-07-05T10:35:17"
+          }
+        },
+        "description": "Adjudication punishment (aka award) mapping"
       },
       "ActivityMigrationMappingDto": {
         "required": [

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsMigrationMessageListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsMigrationMessageListener.kt
@@ -8,6 +8,7 @@ import io.opentelemetry.instrumentation.annotations.WithSpan
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.sqs.model.Message
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.MigrationMessageListener
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AdjudicationAllMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AdjudicationChargeIdResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AdjudicationResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.ADJUDICATIONS_QUEUE_ID
@@ -20,7 +21,7 @@ class AdjudicationsMigrationMessageListener(
   objectMapper: ObjectMapper,
   adjudicationsMigrationService: AdjudicationsMigrationService,
 ) :
-  MigrationMessageListener<AdjudicationsMigrationFilter, AdjudicationChargeIdResponse, AdjudicationResponse, AdjudicationMapping>(
+  MigrationMessageListener<AdjudicationsMigrationFilter, AdjudicationChargeIdResponse, AdjudicationResponse, AdjudicationAllMappingDto>(
     objectMapper,
     adjudicationsMigrationService,
   ) {
@@ -43,7 +44,7 @@ class AdjudicationsMigrationMessageListener(
     return objectMapper.readValue(json)
   }
 
-  override fun parseContextMapping(json: String): MigrationMessage<*, AdjudicationMapping> {
+  override fun parseContextMapping(json: String): MigrationMessage<*, AdjudicationAllMappingDto> {
     return objectMapper.readValue(json)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsMigrationService.kt
@@ -37,6 +37,9 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.adjudications.mod
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.adjudications.model.ReportingOfficer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.data.MigrationContext
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.MigrationMessageType
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AdjudicationAllMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AdjudicationAllMappingDto.MappingType
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AdjudicationMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AdjudicationChargeIdResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AdjudicationChargeResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AdjudicationResponse
@@ -238,7 +241,7 @@ class AdjudicationsMigrationService(
   @Value("\${complete-check.delay-seconds}") completeCheckDelaySeconds: Int,
   @Value("\${complete-check.count}") completeCheckCount: Int,
 ) :
-  MigrationService<AdjudicationsMigrationFilter, AdjudicationChargeIdResponse, AdjudicationResponse, AdjudicationMapping>(
+  MigrationService<AdjudicationsMigrationFilter, AdjudicationChargeIdResponse, AdjudicationResponse, AdjudicationAllMappingDto>(
     queueService = queueService,
     auditService = auditService,
     migrationHistoryService = migrationHistoryService,
@@ -307,12 +310,16 @@ class AdjudicationsMigrationService(
   private suspend fun createAdjudicationMapping(
     mapping: MigrateResponse,
     context: MigrationContext<*>,
-  ) = AdjudicationMapping(
-    adjudicationNumber = mapping.chargeNumberMapping.oicIncidentId,
-    chargeSequence = mapping.chargeNumberMapping.offenceSequence.toInt(),
-    chargeNumber = mapping.chargeNumberMapping.chargeNumber,
+  ) = AdjudicationAllMappingDto(
+    adjudicationId = AdjudicationMappingDto(
+      adjudicationNumber = mapping.chargeNumberMapping.oicIncidentId,
+      chargeSequence = mapping.chargeNumberMapping.offenceSequence.toInt(),
+      chargeNumber = mapping.chargeNumberMapping.chargeNumber,
+    ),
+    hearings = emptyList(),
+    punishments = emptyList(),
     label = context.migrationId,
-    mappingType = "MIGRATED",
+    mappingType = MappingType.MIGRATED,
   ).run {
     try {
       adjudicationsMappingService.createMapping(this)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/history/MigrationMapping.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/history/MigrationMapping.kt
@@ -14,6 +14,8 @@ abstract class MigrationMapping<MAPPING : Any>(
   val domainUrl: String,
   internal val webClient: WebClient,
 ) {
+  open fun createMappingUrl() = domainUrl
+
   open suspend fun findLatestMigration(): LatestMigration? = webClient.get()
     .uri("$domainUrl/migrated/latest")
     .retrieve()
@@ -51,7 +53,7 @@ abstract class MigrationMapping<MAPPING : Any>(
     errorJavaClass: ParameterizedTypeReference<DuplicateErrorResponse<MAPPING>>,
   ): CreateMappingResult<MAPPING> {
     return webClient.post()
-      .uri(domainUrl)
+      .uri(createMappingUrl())
       .bodyValue(
         mapping,
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsMigrationIntTest.kt
@@ -87,7 +87,7 @@ class AdjudicationsMigrationIntTest : SqsIntegrationTestBase() {
       nomisApi.stubMultipleGetAdjudicationIdCounts(totalElements = 21, pageSize = 10)
       nomisApi.stubMultipleGetAdjudications(1..21)
       mappingApi.stubAllMappingsNotFound(ADJUDICATIONS_GET_MAPPING_URL)
-      mappingApi.stubMappingCreate("/mapping/adjudications")
+      mappingApi.stubMappingCreate("/mapping/adjudications/all")
 
       adjudicationsApi.stubCreateAdjudicationForMigration()
       mappingApi.stubAdjudicationMappingByMigrationId(count = 21)
@@ -126,7 +126,7 @@ class AdjudicationsMigrationIntTest : SqsIntegrationTestBase() {
       await untilAsserted {
         assertThat(adjudicationsApi.createAdjudicationCount()).isEqualTo(21)
       }
-      assertThat(mappingApi.createMappingCount("/mapping/adjudications")).isEqualTo(21)
+      assertThat(mappingApi.createMappingCount("/mapping/adjudications/all")).isEqualTo(21)
     }
 
     @Test
@@ -155,7 +155,7 @@ class AdjudicationsMigrationIntTest : SqsIntegrationTestBase() {
         chargeSequence = chargeSequence,
         chargeNumber = chargeNumber,
       )
-      mappingApi.stubMappingCreate("/mapping/adjudications")
+      mappingApi.stubMappingCreate("/mapping/adjudications/all")
       mappingApi.stubAdjudicationMappingByMigrationId(count = 1)
 
       webTestClient.post().uri("/migrate/adjudications")
@@ -189,9 +189,9 @@ class AdjudicationsMigrationIntTest : SqsIntegrationTestBase() {
       }
 
       mappingApi.verifyCreateMappingAdjudication {
-        bodyWithJson("$.adjudicationNumber", equalTo("$adjudicationNumber"))
-        bodyWithJson("$.chargeSequence", equalTo("$chargeSequence"))
-        bodyWithJson("$.chargeNumber", equalTo(chargeNumber))
+        bodyWithJson("adjudicationId.adjudicationNumber", equalTo("$adjudicationNumber"))
+        bodyWithJson("adjudicationId.chargeSequence", equalTo("$chargeSequence"))
+        bodyWithJson("adjudicationId.chargeNumber", equalTo(chargeNumber))
       }
 
       verify(telemetryClient).trackEvent(
@@ -214,7 +214,7 @@ class AdjudicationsMigrationIntTest : SqsIntegrationTestBase() {
       nomisApi.stubMultipleGetAdjudications(1..3)
       adjudicationsApi.stubCreateAdjudicationForMigration(12345)
       mappingApi.stubAllMappingsNotFound(ADJUDICATIONS_GET_MAPPING_URL)
-      mappingApi.stubMappingCreate("/mapping/adjudications")
+      mappingApi.stubMappingCreate("/mapping/adjudications/all")
 
       // stub 10 migrated records and 1 fake a failure
       mappingApi.stubAdjudicationMappingByMigrationId(count = 2)
@@ -279,7 +279,7 @@ class AdjudicationsMigrationIntTest : SqsIntegrationTestBase() {
       nomisApi.stubGetAdjudication(adjudicationNumber = 654321, chargeSequence = 1)
       mappingApi.stubAllMappingsNotFound(ADJUDICATIONS_GET_MAPPING_URL)
       adjudicationsApi.stubCreateAdjudicationForMigration(654321L)
-      mappingApi.stubMappingCreateFailureFollowedBySuccess(url = "/mapping/adjudications")
+      mappingApi.stubMappingCreateFailureFollowedBySuccess(url = "/mapping/adjudications/all")
 
       webTestClient.post().uri("/migrate/adjudications")
         .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_ADJUDICATIONS")))
@@ -298,7 +298,7 @@ class AdjudicationsMigrationIntTest : SqsIntegrationTestBase() {
         .expectStatus().isAccepted
 
       // wait for all mappings to be created before verifying
-      await untilCallTo { mappingApi.createMappingCount("/mapping/adjudications") } matches { it == 2 }
+      await untilCallTo { mappingApi.createMappingCount("/mapping/adjudications/all") } matches { it == 2 }
 
       // check that one adjudication is created
       assertThat(adjudicationsApi.createAdjudicationCount()).isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsMigrationIntTest.kt
@@ -134,7 +134,7 @@ class AdjudicationsMigrationIntTest : SqsIntegrationTestBase() {
       val adjudicationNumber = 12345L
       val chargeSequence = 1
       val offenderNo = "A1234BC"
-      val chargeNumber = "12345/1"
+      val chargeNumber = "12345-1"
       val adjudicationPageResponse = adjudicationsIdsPagedResponse(
         adjudicationNumber = adjudicationNumber,
         chargeSequence = chargeSequence,
@@ -307,7 +307,7 @@ class AdjudicationsMigrationIntTest : SqsIntegrationTestBase() {
       mappingApi.verifyCreateMappingAdjudication(
         adjudicationNumber = 654321,
         chargeSequence = 1,
-        chargeNumber = "654321/1",
+        chargeNumber = "654321-1",
         times = 2,
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/AdjudicationsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/AdjudicationsApiMockServer.kt
@@ -51,7 +51,7 @@ class AdjudicationsApiMockServer : WireMockServer(WIREMOCK_PORT) {
   fun stubCreateAdjudicationForMigration(
     adjudicationNumber: Long = 654321,
     chargeSequence: Int = 1,
-    chargeNumber: String = "654321/1",
+    chargeNumber: String = "654321-1",
   ) {
     stubFor(
       post(WireMock.urlMatching("/reported-adjudications/migrate")).willReturn(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/MappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/MappingApiMockServer.kt
@@ -458,16 +458,16 @@ class MappingApiMockServer : WireMockServer(WIREMOCK_PORT) {
   ) {
     verify(
       times,
-      postRequestedFor(urlPathEqualTo("/mapping/adjudications"))
-        .withRequestBody(matchingJsonPath("adjudicationNumber", equalTo(adjudicationNumber.toString())))
-        .withRequestBody(matchingJsonPath("chargeSequence", equalTo(chargeSequence.toString())))
-        .withRequestBody(matchingJsonPath("chargeNumber", equalTo(chargeNumber))),
+      postRequestedFor(urlPathEqualTo("/mapping/adjudications/all"))
+        .withRequestBody(matchingJsonPath("adjudicationId.adjudicationNumber", equalTo(adjudicationNumber.toString())))
+        .withRequestBody(matchingJsonPath("adjudicationId.chargeSequence", equalTo(chargeSequence.toString())))
+        .withRequestBody(matchingJsonPath("adjudicationId.chargeNumber", equalTo(chargeNumber))),
     )
   }
 
   fun verifyCreateMappingAdjudication(builder: RequestPatternBuilder.() -> RequestPatternBuilder = { this }) =
     verify(
-      postRequestedFor(urlEqualTo("/mapping/adjudications")).builder(),
+      postRequestedFor(urlEqualTo("/mapping/adjudications/all")).builder(),
     )
 
   private fun pageContent(content: String, count: Int) = """


### PR DESCRIPTION
This uses new endpoint that will eventually  create all mappings (hearings etc) in one go.

This means the DTO for create and read are now different
This means the base URL for create and read are now different (the base class assumed they were the same)

TODO - add hearing and punishment mappings to DTO