### PR TITLE
SDIT-928 tactical short term change to "ignore" 4xx errors

### DIFF
--- a/helm_deploy/hmpps-prisoner-from-nomis-migration/values.yaml
+++ b/helm_deploy/hmpps-prisoner-from-nomis-migration/values.yaml
@@ -38,6 +38,7 @@ generic-service:
     FEATURE_EVENT_KEY_DATE_ADJUSTMENT_DELETED: true
     FEATURE_EVENT_NON_ASSOCIATION_DETAIL-UPSERTED: true
     FEATURE_EVENT_NON_ASSOCIATION_DETAIL-DELETED: true
+    FEATURE_ADJUDICATIONS_REPORT_MODE: false
     HMPPS_SQS_USE_WEB_TOKEN: true
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -24,6 +24,7 @@ generic-service:
     FEATURE_EVENT_KEY_DATE_ADJUSTMENT_DELETED: false
     FEATURE_EVENT_NON_ASSOCIATION_DETAIL-UPSERTED: false
     FEATURE_EVENT_NON_ASSOCIATION_DETAIL-DELETED: false
+    FEATURE_ADJUDICATIONS_REPORT_MODE: true
 
 generic-prometheus-alerts:
   businessHoursOnly: true


### PR DESCRIPTION
While DPS is understanding their mapping issues they will throw a 4xx error. For these, when we are in the special "reporting" mode, we ignore the error, but gather some stats