### PR TITLE
SAA-1162: Update activities-api-docs.json and use returned AppointmentInstance

### DIFF
--- a/openapi-specs/activities-api-docs.json
+++ b/openapi-specs/activities-api-docs.json
@@ -7,7 +7,7 @@
       "name": "HMPPS Digital Studio",
       "email": "feedback@digital.justice.gov.uk"
     },
-    "version": "2023-09-08.10861.59afc87"
+    "version": "2023-09-12"
   },
   "servers": [
     {
@@ -65,8 +65,11 @@
           "required": true
         },
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "204": {
+            "description": "One or more prisoners were deallocated from the schedule."
+          },
+          "400": {
+            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -85,11 +88,8 @@
               }
             }
           },
-          "204": {
-            "description": "One or more prisoners were deallocated from the schedule."
-          },
-          "400": {
-            "description": "Bad request",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -141,8 +141,11 @@
           "required": true
         },
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "204": {
+            "description": "The scheduled instance was successfully un cancelled."
+          },
+          "400": {
+            "description": "The scheduled instance is not cancelled or it is in the past",
             "content": {
               "application/json": {
                 "schema": {
@@ -161,8 +164,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found, the scheduled instance does not exist",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -171,11 +174,8 @@
               }
             }
           },
-          "204": {
-            "description": "The scheduled instance was successfully un cancelled."
-          },
-          "400": {
-            "description": "The scheduled instance is not cancelled or it is in the past",
+          "404": {
+            "description": "Not Found, the scheduled instance does not exist",
             "content": {
               "application/json": {
                 "schema": {
@@ -217,22 +217,22 @@
           "required": true
         },
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "204": {
             "description": "Scheduled instance successfully cancelled",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -247,8 +247,8 @@
               }
             }
           },
-          "400": {
-            "description": "Bad request",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -387,8 +387,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -397,8 +397,8 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -410,17 +410,17 @@
         }
       }
     },
-    "/appointment-occurrences/{appointmentOccurrenceId}/cancel": {
+    "/appointments/{appointmentId}/cancel": {
       "put": {
         "tags": [
-          "appointment-occurrence-controller"
+          "appointment-controller"
         ],
-        "summary": "Cancel an appointment occurrence or series of appointment occurrences",
-        "description": "\n    Cancel an appointment occurrence or series of appointment occurrences based on the applyTo property.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "cancelAppointmentOccurrence",
+        "summary": "Cancel an appointment or series of appointments",
+        "description": "\n    Cancel an appointment or series of appointments based on the applyTo property.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "cancelAppointment",
         "parameters": [
           {
-            "name": "appointmentOccurrenceId",
+            "name": "appointmentId",
             "in": "path",
             "required": true,
             "schema": {
@@ -444,19 +444,19 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AppointmentOccurrenceCancelRequest"
+                "$ref": "#/components/schemas/AppointmentCancelRequest"
               }
             }
           },
           "required": true
         },
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "202": {
+            "description": "The appointment or series of appointments was cancelled.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/AppointmentSeries"
                 }
               }
             }
@@ -471,8 +471,8 @@
               }
             }
           },
-          "404": {
-            "description": "The appointment occurrence for this ID was not found.",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -481,12 +481,12 @@
               }
             }
           },
-          "202": {
-            "description": "The appointment occurrence or series of appointment occurrences was cancelled.",
+          "404": {
+            "description": "The appointment for this id was not found.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Appointment"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -547,6 +547,16 @@
               }
             }
           },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "403": {
             "description": "Forbidden, requires an appropriate role",
             "content": {
@@ -559,16 +569,6 @@
           },
           "404": {
             "description": "Schedule ID not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -618,8 +618,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "400": {
+            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -638,8 +638,8 @@
               }
             }
           },
-          "400": {
-            "description": "Bad request",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -734,8 +734,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "400": {
+            "description": "Invalid request",
             "content": {
               "application/json": {
                 "schema": {
@@ -754,8 +754,8 @@
               }
             }
           },
-          "404": {
-            "description": "Requested resource not found",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -764,8 +764,8 @@
               }
             }
           },
-          "400": {
-            "description": "Invalid request",
+          "404": {
+            "description": "Requested resource not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -844,8 +844,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "400": {
+            "description": "Invalid request",
             "content": {
               "application/json": {
                 "schema": {
@@ -864,8 +864,8 @@
               }
             }
           },
-          "404": {
-            "description": "Requested resource not found",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -874,8 +874,8 @@
               }
             }
           },
-          "400": {
-            "description": "Invalid request",
+          "404": {
+            "description": "Requested resource not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -929,12 +929,15 @@
           "required": true
         },
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "200": {
+            "description": "The allocations for the prisoners",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PrisonerAllocations"
+                  }
                 }
               }
             }
@@ -949,15 +952,12 @@
               }
             }
           },
-          "200": {
-            "description": "The allocations for the prisoners",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PrisonerAllocations"
-                  }
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -994,16 +994,6 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad request",
             "content": {
@@ -1016,6 +1006,16 @@
           },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -1046,12 +1046,12 @@
           "required": true
         },
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "200": {
+            "description": "The activity was migrated.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/ActivityMigrateResponse"
                 }
               }
             }
@@ -1076,12 +1076,12 @@
               }
             }
           },
-          "200": {
-            "description": "The activity was migrated.",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ActivityMigrateResponse"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1094,8 +1094,8 @@
         "tags": [
           "migrate-appointment-controller"
         ],
-        "summary": "Create an appointment or series of appointment occurrences",
-        "description": "\n    Create an appointment or series of appointment occurrences and allocate the supplied prisoner or prisoners to them.\n    \n\nRequires one of the following roles:\n* NOMIS_APPOINTMENTS",
+        "summary": "Migrate an appointment from NOMIS",
+        "description": "\n    Migrate an appointment creating an appointment series with one appointment that has the supplied prisoner allocated.\n    \n\nRequires one of the following roles:\n* NOMIS_APPOINTMENTS",
         "operationId": "migrateAppointment",
         "requestBody": {
           "content": {
@@ -1109,17 +1109,17 @@
         },
         "responses": {
           "201": {
-            "description": "The appointment or series of appointment occurrences was created.",
+            "description": "The appointment was migrated.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Appointment"
+                  "$ref": "#/components/schemas/AppointmentInstance"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "400": {
+            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -1128,8 +1128,8 @@
               }
             }
           },
-          "400": {
-            "description": "Bad request",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -1268,42 +1268,12 @@
           "required": true
         },
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "204": {
             "description": "The event IDS were acknowledged.",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Requested resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1317,51 +1287,6 @@
                 }
               }
             }
-          }
-        }
-      }
-    },
-    "/bulk-appointments": {
-      "post": {
-        "tags": [
-          "bulk-appointment-controller"
-        ],
-        "summary": "Bulk create a set of appointments",
-        "description": "\n    Create a list of appointments and allocate the supplied prisoner or prisoners to them.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "bulkCreateAppointment",
-        "parameters": [
-          {
-            "name": "Caseload-Id",
-            "in": "header",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BulkAppointmentsRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "The appointments were created.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkAppointment"
-                }
-              }
-            }
           },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
@@ -1373,8 +1298,18 @@
               }
             }
           },
-          "400": {
-            "description": "Bad request",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Requested resource not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -1436,16 +1371,6 @@
           "required": true
         },
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Search performed successfully",
             "content": {
@@ -1465,83 +1390,28 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
     },
-    "/appointments": {
+    "/appointments/{prisonCode}/search": {
       "post": {
         "tags": [
           "appointment-controller"
         ],
-        "summary": "Create an appointment or series of appointment occurrences",
-        "description": "\n    Create an appointment or series of appointment occurrences and allocate the supplied prisoner or prisoners to them.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "createAppointment",
-        "parameters": [
-          {
-            "name": "Caseload-Id",
-            "in": "header",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AppointmentCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "The appointment or series of appointment occurrences was created.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Appointment"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/appointment-occurrences/{prisonCode}/search": {
-      "post": {
-        "tags": [
-          "appointment-occurrence-controller"
-        ],
-        "summary": "Search for appointment occurrences within the specified prison",
-        "description": "\n    Uses the supplied prison code and search parameters to filter and return appointment occurrence search results.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "searchAppointmentOccurrences",
+        "summary": "Search for appointments within the specified prison",
+        "description": "\n    Uses the supplied prison code and search parameters to filter and return appointment search results.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "searchAppointments",
         "parameters": [
           {
             "name": "prisonCode",
@@ -1567,7 +1437,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AppointmentOccurrenceSearchRequest"
+                "$ref": "#/components/schemas/AppointmentSearchRequest"
               }
             }
           },
@@ -1581,8 +1451,18 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/AppointmentOccurrenceSearchResult"
+                    "$ref": "#/components/schemas/AppointmentSearchResult"
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1596,9 +1476,129 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/appointment-set": {
+      "post": {
+        "tags": [
+          "appointment-set-controller"
+        ],
+        "summary": "Create a set of appointments",
+        "description": "\n    Create a set of appointments that start on the same day and add the associated prisoner as the appointment attendee.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "createAppointmentSet",
+        "parameters": [
+          {
+            "name": "Caseload-Id",
+            "in": "header",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppointmentSetCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "The appointment set was created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppointmentSet"
+                }
+              }
+            }
           },
           "400": {
             "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/appointment-series": {
+      "post": {
+        "tags": [
+          "appointment-series-controller"
+        ],
+        "summary": "Create an appointment series with one or more appointments",
+        "description": "\n    Create an appointment series with one or more appointments and add the supplied prisoner or prisoners as appointment attendees.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "createAppointmentSeries",
+        "parameters": [
+          {
+            "name": "Caseload-Id",
+            "in": "header",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppointmentSeriesCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "The appointment series was created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppointmentSeries"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -1650,18 +1650,18 @@
           "required": true
         },
         "responses": {
-          "404": {
-            "description": "The activity schedule in the request for this ID was not found.",
+          "204": {
+            "description": "The waiting list entry was created and added to the schedule.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "type": "object"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "400": {
+            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -1680,8 +1680,8 @@
               }
             }
           },
-          "400": {
-            "description": "Bad request",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -1690,12 +1690,12 @@
               }
             }
           },
-          "204": {
-            "description": "The waiting list entry was created and added to the schedule.",
+          "404": {
+            "description": "The activity schedule in the request for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1745,8 +1745,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "400": {
+            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -1765,8 +1765,8 @@
               }
             }
           },
-          "400": {
-            "description": "Bad request",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -1809,26 +1809,6 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "The waiting list application for this ID was not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Waiting list application found",
             "content": {
@@ -1841,6 +1821,26 @@
           },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The waiting list application for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1900,6 +1900,26 @@
               }
             }
           },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "403": {
             "description": "Forbidden, requires an appropriate role",
             "content": {
@@ -1919,6 +1939,50 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/appointments/{appointmentId}": {
+      "get": {
+        "tags": [
+          "appointment-controller"
+        ],
+        "summary": "Get an appointment by its id",
+        "description": "Returns an appointment with its properties and references to NOMIS by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "getAppointmentById",
+        "parameters": [
+          {
+            "name": "appointmentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "Caseload-Id",
+            "in": "header",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Appointment found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Appointment"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
@@ -1930,8 +1994,8 @@
               }
             }
           },
-          "400": {
-            "description": "Bad request",
+          "404": {
+            "description": "The appointment for this id was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1941,19 +2005,17 @@
             }
           }
         }
-      }
-    },
-    "/appointment-occurrences/{appointmentOccurrenceId}": {
+      },
       "patch": {
         "tags": [
-          "appointment-occurrence-controller"
+          "appointment-controller"
         ],
-        "summary": "Update an appointment occurrence or series of appointment occurrences",
-        "description": "\n    Update an appointment occurrence or series of appointment occurrences based on the applyTo property.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "updateAppointmentOccurrence",
+        "summary": "Update an appointment or series of appointments",
+        "description": "\n    Update an appointment or series of appointments based on the applyTo property.\n    \n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "updateAppointment",
         "parameters": [
           {
-            "name": "appointmentOccurrenceId",
+            "name": "appointmentId",
             "in": "path",
             "required": true,
             "schema": {
@@ -1977,19 +2039,19 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AppointmentOccurrenceUpdateRequest"
+                "$ref": "#/components/schemas/AppointmentUpdateRequest"
               }
             }
           },
           "required": true
         },
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "202": {
+            "description": "The appointment or series of appointments was updated.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/AppointmentSeries"
                 }
               }
             }
@@ -2004,8 +2066,8 @@
               }
             }
           },
-          "404": {
-            "description": "The appointment occurrence for this ID was not found.",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -2014,12 +2076,12 @@
               }
             }
           },
-          "202": {
-            "description": "The appointment occurrence or series of appointment occurrences was updated.",
+          "404": {
+            "description": "The appointment for this id was not found.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Appointment"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2065,32 +2127,22 @@
           "required": true
         },
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Allocation ID not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "202": {
             "description": "The allocation was updated.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Allocation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2105,8 +2157,18 @@
               }
             }
           },
-          "400": {
-            "description": "Bad request",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Allocation ID not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -2167,8 +2229,18 @@
           "required": true
         },
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "202": {
+            "description": "The activity was updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Activity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -2187,22 +2259,12 @@
               }
             }
           },
-          "400": {
-            "description": "Bad request",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "The activity was updated.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Activity"
                 }
               }
             }
@@ -2325,12 +2387,12 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "200": {
+            "description": "Activity found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/ActivitySchedule"
                 }
               }
             }
@@ -2345,8 +2407,8 @@
               }
             }
           },
-          "404": {
-            "description": "The activity for this ID was not found.",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -2355,12 +2417,12 @@
               }
             }
           },
-          "200": {
-            "description": "Activity found",
+          "404": {
+            "description": "The activity for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ActivitySchedule"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2399,16 +2461,6 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "The waiting list applications for an activity schedule",
             "content": {
@@ -2422,8 +2474,8 @@
               }
             }
           },
-          "404": {
-            "description": "Schedule ID not found",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -2432,8 +2484,18 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Schedule ID not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -2474,8 +2536,18 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "200": {
+            "description": "Candidate suitability details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AllocationSuitability"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -2494,8 +2566,8 @@
               }
             }
           },
-          "400": {
-            "description": "Bad request",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -2510,16 +2582,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Candidate suitability details.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AllocationSuitability"
                 }
               }
             }
@@ -2640,8 +2702,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "400": {
+            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -2660,8 +2722,8 @@
               }
             }
           },
-          "400": {
-            "description": "Bad request",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -2714,16 +2776,6 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Scheduled instance found",
             "content": {
@@ -2736,6 +2788,16 @@
           },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -2790,8 +2852,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -2800,8 +2862,8 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -2842,16 +2904,6 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Prison rollout plan found",
             "content": {
@@ -2864,6 +2916,16 @@
           },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -2970,12 +3032,15 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "200": {
+            "description": "Successful call - zero or more scheduled instance records found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActivityScheduleInstance"
+                  }
                 }
               }
             }
@@ -2990,15 +3055,12 @@
               }
             }
           },
-          "200": {
-            "description": "Successful call - zero or more scheduled instance records found",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ActivityScheduleInstance"
-                  }
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3059,16 +3121,6 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Activity schedules found",
             "content": {
@@ -3084,6 +3136,16 @@
           },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -3114,16 +3176,6 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Prison pay bands found",
             "content": {
@@ -3139,6 +3191,16 @@
           },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -3206,8 +3268,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -3216,8 +3278,8 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -3257,26 +3319,6 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Category ID not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Activities within the category",
             "content": {
@@ -3292,6 +3334,26 @@
           },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Category ID not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -3331,12 +3393,15 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "200": {
+            "description": "Activities",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActivitySummary"
+                  }
                 }
               }
             }
@@ -3351,15 +3416,12 @@
               }
             }
           },
-          "200": {
-            "description": "Activities",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ActivitySummary"
-                  }
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3386,12 +3448,12 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "200": {
+            "description": "Prison regime found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/PrisonRegime"
                 }
               }
             }
@@ -3406,8 +3468,8 @@
               }
             }
           },
-          "404": {
-            "description": "The prison regime for this prison code was not found.",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -3416,12 +3478,12 @@
               }
             }
           },
-          "200": {
-            "description": "Prison regime found",
+          "404": {
+            "description": "The prison regime for this prison code was not found.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PrisonRegime"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3456,16 +3518,6 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Successful call - zero or more cell locations found",
             "content": {
@@ -3475,6 +3527,16 @@
                   "items": {
                     "$ref": "#/components/schemas/Location"
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3489,8 +3551,8 @@
               }
             }
           },
-          "404": {
-            "description": "Requested resource not found",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -3499,8 +3561,8 @@
               }
             }
           },
-          "400": {
-            "description": "Invalid request",
+          "404": {
+            "description": "Requested resource not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -3539,22 +3601,22 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Successful call - Location prefix found",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/LocationPrefixDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3569,8 +3631,8 @@
               }
             }
           },
-          "400": {
-            "description": "Invalid request",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -3601,16 +3663,6 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Successful call - zero or more location groups found",
             "content": {
@@ -3620,6 +3672,16 @@
                   "items": {
                     "$ref": "#/components/schemas/LocationGroup"
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -3634,8 +3696,8 @@
               }
             }
           },
-          "404": {
-            "description": "Requested resource not found",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -3644,8 +3706,8 @@
               }
             }
           },
-          "400": {
-            "description": "Invalid request",
+          "404": {
+            "description": "Requested resource not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -3739,16 +3801,6 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Search performed successfully",
             "content": {
@@ -3768,63 +3820,9 @@
                 }
               }
             }
-          }
-        }
-      }
-    },
-    "/bulk-appointment-details/{bulkAppointmentId}": {
-      "get": {
-        "tags": [
-          "bulk-appointment-details-controller"
-        ],
-        "summary": "Gets the details of a set of appointments created as part of a single bulk operation for display purposes",
-        "description": "Returns the displayable details of a set of appointments created as part of a single bulk operation by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "getBulkAppointmentDetailsById",
-        "parameters": [
-          {
-            "name": "bulkAppointmentId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
           },
-          {
-            "name": "Caseload-Id",
-            "in": "header",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Bulk appointment found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BulkAppointmentDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "The bulk appointment for this ID was not found.",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -3864,16 +3862,6 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Attendance list found",
             "content": {
@@ -3889,6 +3877,16 @@
           },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -3920,16 +3918,6 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Attendance found",
             "content": {
@@ -3942,6 +3930,16 @@
           },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -3972,16 +3970,6 @@
         "description": "\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
         "operationId": "getAttendanceReasons",
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Attendance reasons found",
             "content": {
@@ -4004,18 +3992,28 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
     },
-    "/appointments/{appointmentId}": {
+    "/appointments/{appointmentId}/details": {
       "get": {
         "tags": [
           "appointment-controller"
         ],
-        "summary": "Get an appointment by its id",
-        "description": "Returns an appointment and its details by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "getAppointmentById",
+        "summary": "Get the details of an appointment for display purposes by its id",
+        "description": "Returns the displayable details of an appointment by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "getAppointmentDetailsById",
         "parameters": [
           {
             "name": "appointmentId",
@@ -4039,12 +4037,12 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "The appointment for this ID was not found.",
+          "200": {
+            "description": "Appointment found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/AppointmentDetails"
                 }
               }
             }
@@ -4059,12 +4057,12 @@
               }
             }
           },
-          "200": {
-            "description": "Appointment found",
+          "404": {
+            "description": "The appointment for this id was not found.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Appointment"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4072,17 +4070,17 @@
         }
       }
     },
-    "/appointment-occurrence-details/{appointmentOccurrenceId}": {
+    "/appointment-set/{appointmentSetId}": {
       "get": {
         "tags": [
-          "appointment-occurrence-details-controller"
+          "appointment-set-controller"
         ],
-        "summary": "Gets the appointment occurrence details for display purposes identified by the appointment occurrence's id",
-        "description": "Returns the displayable details of an appointment occurrence by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "getAppointmentOccurrenceDetailsById",
+        "summary": "Get an appointment set by its id",
+        "description": "Returns an appointment set with its properties and references to NOMIS by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "getAppointmentSetById",
         "parameters": [
           {
-            "name": "appointmentOccurrenceId",
+            "name": "appointmentSetId",
             "in": "path",
             "required": true,
             "schema": {
@@ -4104,11 +4102,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Appointment Occurrence found",
+            "description": "Appointment set found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AppointmentOccurrenceDetails"
+                  "$ref": "#/components/schemas/AppointmentSet"
                 }
               }
             }
@@ -4124,7 +4122,199 @@
             }
           },
           "404": {
-            "description": "The appointment occurrence for this ID was not found.",
+            "description": "The appointment set for this id was not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/appointment-set/{appointmentSetId}/details": {
+      "get": {
+        "tags": [
+          "appointment-set-controller"
+        ],
+        "summary": "Get the details of an appointment set for display purposes by its id",
+        "description": "Returns the displayable details of an appointment set by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "getAppointmentSetDetailsById",
+        "parameters": [
+          {
+            "name": "appointmentSetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "Caseload-Id",
+            "in": "header",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Appointment set found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppointmentSetDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The appointment set for this id was not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/appointment-series/{appointmentSeriesId}": {
+      "get": {
+        "tags": [
+          "appointment-series-controller"
+        ],
+        "summary": "Get an appointment series by its id",
+        "description": "Returns an appointment series with its properties and references to NOMIS by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "getAppointmentSeriesById",
+        "parameters": [
+          {
+            "name": "appointmentSeriesId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "Caseload-Id",
+            "in": "header",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Appointment series found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppointmentSeries"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The appointment series for this id was not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/appointment-series/{appointmentSeriesId}/details": {
+      "get": {
+        "tags": [
+          "appointment-series-controller"
+        ],
+        "summary": "Get the details of an appointment series for display purposes by its id",
+        "description": "Returns the displayable details of an appointment series by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
+        "operationId": "getAppointmentDetailsById_1",
+        "parameters": [
+          {
+            "name": "appointmentSeriesId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "Caseload-Id",
+            "in": "header",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Appointment series found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppointmentSeriesDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The appointment series for this id was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4212,16 +4402,6 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "The appointment instance for this ID was not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Appointment instance found",
             "content": {
@@ -4241,67 +4421,13 @@
                 }
               }
             }
-          }
-        }
-      }
-    },
-    "/appointment-details/{appointmentId}": {
-      "get": {
-        "tags": [
-          "appointment-details-controller"
-        ],
-        "summary": "Gets the top level appointment details for display purposes identified by the appointment's id",
-        "description": "Returns the displayable details of an appointment by its unique identifier.\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
-        "operationId": "getAppointmentDetailsById",
-        "parameters": [
-          {
-            "name": "appointmentId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
           },
-          {
-            "name": "Caseload-Id",
-            "in": "header",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
           "404": {
-            "description": "The appointment for this ID was not found.",
+            "description": "The appointment instance for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Appointment found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppointmentDetails"
                 }
               }
             }
@@ -4318,16 +4444,6 @@
         "description": "\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
         "operationId": "getAppointmentCategories",
         "responses": {
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Appointment categories found",
             "content": {
@@ -4337,6 +4453,16 @@
                   "items": {
                     "$ref": "#/components/schemas/AppointmentCategorySummary"
                   }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4375,8 +4501,18 @@
           }
         ],
         "responses": {
-          "404": {
-            "description": "The allocation for this ID was not found.",
+          "200": {
+            "description": "allocation found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Allocation"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorised, requires a valid Oauth2 token",
             "content": {
               "application/json": {
                 "schema": {
@@ -4395,18 +4531,8 @@
               }
             }
           },
-          "200": {
-            "description": "allocation found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Allocation"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorised, requires a valid Oauth2 token",
+          "404": {
+            "description": "The allocation for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4427,12 +4553,15 @@
         "description": "\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN",
         "operationId": "getDeallocationReasons",
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "200": {
+            "description": "Deallocation reasons found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DeallocationReason"
+                  }
                 }
               }
             }
@@ -4447,15 +4576,12 @@
               }
             }
           },
-          "200": {
-            "description": "Deallocation reasons found",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DeallocationReason"
-                  }
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4472,12 +4598,15 @@
         "description": "\n\nRequires one of the following roles:\n* PRISON\n* ACTIVITY_ADMIN\n* NOMIS_ACTIVITIES",
         "operationId": "getCategories",
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "200": {
+            "description": "Activity categories found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActivityCategory"
+                  }
                 }
               }
             }
@@ -4492,15 +4621,12 @@
               }
             }
           },
-          "200": {
-            "description": "Activity categories found",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ActivityCategory"
-                  }
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4539,12 +4665,12 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "200": {
+            "description": "Activity found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/Activity"
                 }
               }
             }
@@ -4559,8 +4685,8 @@
               }
             }
           },
-          "404": {
-            "description": "The activity for this ID was not found.",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -4569,12 +4695,12 @@
               }
             }
           },
-          "200": {
-            "description": "Activity found",
+          "404": {
+            "description": "The activity for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Activity"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4602,12 +4728,12 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "200": {
+            "description": "Activity schedules",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/ActivityScheduleLite"
                 }
               }
             }
@@ -4622,12 +4748,12 @@
               }
             }
           },
-          "200": {
-            "description": "Activity schedules",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ActivityScheduleLite"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4675,12 +4801,12 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
+          "200": {
+            "description": "Activity found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/Activity"
                 }
               }
             }
@@ -4695,8 +4821,8 @@
               }
             }
           },
-          "404": {
-            "description": "The activity for this ID was not found.",
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -4705,12 +4831,12 @@
               }
             }
           },
-          "200": {
-            "description": "Activity found",
+          "404": {
+            "description": "The activity for this ID was not found.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Activity"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4738,16 +4864,6 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200": {
             "description": "Activity found",
             "content": {
@@ -4760,6 +4876,16 @@
           },
           "401": {
             "description": "Unauthorised, requires a valid Oauth2 token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
             "content": {
               "application/json": {
                 "schema": {
@@ -4811,15 +4937,8 @@
           }
         ],
         "responses": {
-          "403": {
-            "description": "Forbidden, requires an appropriate role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+          "200": {
+            "description": "The activity was deleted."
           },
           "400": {
             "description": "Bad request",
@@ -4841,8 +4960,15 @@
               }
             }
           },
-          "200": {
-            "description": "The activity was deleted."
+          "403": {
+            "description": "Forbidden, requires an appropriate role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -5083,7 +5209,7 @@
         },
         "description": "Request object for updating an attendance record"
       },
-      "AppointmentOccurrenceCancelRequest": {
+      "AppointmentCancelRequest": {
         "required": [
           "applyTo",
           "cancellationReasonId"
@@ -5098,27 +5224,28 @@
           },
           "applyTo": {
             "type": "string",
-            "description": "\n    Specifies which appointment occurrence or occurrences this cancellation should apply to.\n    Defaults to THIS_OCCURRENCE meaning the cancellation will be applied to the appointment occurrence specified by the\n    supplied id only.\n    ",
-            "example": "THIS_OCCURRENCE",
+            "description": "\n    Specifies which appointment or appointments this cancellation should apply to.\n    Defaults to THIS_APPOINTMENT meaning the cancellation will be applied to the appointment specified by the\n    supplied id only.\n    ",
+            "example": "THIS_APPOINTMENT",
             "enum": [
-              "THIS_OCCURRENCE",
-              "THIS_AND_ALL_FUTURE_OCCURRENCES",
-              "ALL_FUTURE_OCCURRENCES"
+              "THIS_APPOINTMENT",
+              "THIS_AND_ALL_FUTURE_APPOINTMENTS",
+              "ALL_FUTURE_APPOINTMENTS"
             ]
           }
         },
-        "description": "The cancel request with the appointment occurrence details and how to apply the cancellation"
+        "description": "The cancel request with the cancellation details and how to apply the cancellation"
       },
       "Appointment": {
         "required": [
-          "appointmentType",
+          "attendees",
           "categoryCode",
-          "created",
           "createdBy",
+          "createdTime",
           "id",
           "inCell",
-          "occurrences",
+          "isCancelled",
           "prisonCode",
+          "sequenceNumber",
           "startDate",
           "startTime"
         ],
@@ -5127,6 +5254,192 @@
           "id": {
             "type": "integer",
             "description": "The internally generated identifier for this appointment",
+            "format": "int64",
+            "example": 123456
+          },
+          "sequenceNumber": {
+            "type": "integer",
+            "description": "The sequence number of this appointment within the appointment series",
+            "format": "int32",
+            "example": 3
+          },
+          "prisonCode": {
+            "type": "string",
+            "description": "The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS",
+            "example": "SKI"
+          },
+          "categoryCode": {
+            "type": "string",
+            "description": "The NOMIS REFERENCE_CODES.CODE (DOMAIN = 'INT_SCH_RSN') value for mapping to NOMIS",
+            "example": "CHAP"
+          },
+          "customName": {
+            "type": "string",
+            "description": "\n    Free text name further describing the appointment. Used as part of the appointment name with the\n    format \"Custom name (Category description) if specified.\n    ",
+            "example": "Meeting with the governor"
+          },
+          "internalLocationId": {
+            "type": "integer",
+            "description": "\n    The NOMIS AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID value for mapping to NOMIS.\n    Will be null if in cell = true\n    ",
+            "format": "int64",
+            "example": 123
+          },
+          "inCell": {
+            "type": "boolean",
+            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
+            "example": false
+          },
+          "startDate": {
+            "type": "string",
+            "description": "The date this appointment is taking place on",
+            "format": "date"
+          },
+          "startTime": {
+            "type": "string",
+            "description": "The starting time of this appointment",
+            "format": "partial-time",
+            "example": "13:00"
+          },
+          "endTime": {
+            "type": "string",
+            "description": "The end time of this appointment",
+            "format": "partial-time",
+            "example": "13:30"
+          },
+          "extraInformation": {
+            "type": "string",
+            "description": "\n    Extra information for the prisoner or prisoners attending this appointment.\n    Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is\n    extra information via the unlock list.\n    ",
+            "example": "This appointment will help adjusting to life outside of prison"
+          },
+          "createdTime": {
+            "type": "string",
+            "description": "The date and time this appointment was created. Will not change",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that created the appointment.\n    Usually a NOMIS username\n    ",
+            "example": "AAA01U"
+          },
+          "updatedTime": {
+            "type": "string",
+            "description": "\n    The date and time this appointment was last changed.\n    Will be null if this appointment has not been altered since it was created\n    ",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that edited this appointment.\n    Will be null if this appointment has not been altered since it was created\n    ",
+            "example": "AAA01U"
+          },
+          "cancelledTime": {
+            "type": "string",
+            "description": "\n    The date and time this appointment was cancelled.\n    Will be null if this appointment has not been cancelled\n    ",
+            "format": "date-time"
+          },
+          "cancellationReasonId": {
+            "type": "integer",
+            "description": "\n    The id of the reason why this appointment was cancelled.\n    Will be null if this appointment has not been cancelled\n    ",
+            "format": "int64",
+            "example": 12345
+          },
+          "cancelledBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that cancelled this appointment.\n    Will be null if this appointment has not been cancelled\n    ",
+            "example": "AAA01U"
+          },
+          "attendees": {
+            "type": "array",
+            "description": "\n    The prisoner or prisoners attending this appointment. Single appointments such as medical will have one\n    attendee. A group appointment e.g. gym or chaplaincy sessions will have more than one attendee.\n    Attendees are at the appointment level supporting alteration of attendees in any future appointment.\n    ",
+            "items": {
+              "$ref": "#/components/schemas/AppointmentAttendee"
+            }
+          },
+          "isCancelled": {
+            "type": "boolean"
+          }
+        },
+        "description": "\n  Described on the UI as an \"Appointment\" and represents the scheduled event on a specific date and time.\n  All updates and cancellations happen at this appointment level with the parent appointment series being immutable.\n  "
+      },
+      "AppointmentAttendee": {
+        "required": [
+          "bookingId",
+          "id",
+          "prisonerNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "\n    The internally generated identifier for this prisoner attending a specific appointment in an appointment series or set.\n    N.B. this is used as the appointment instance id due to there being a one to one relationship between an appointment\n    attendee and appointment instances.\n    ",
+            "format": "int64",
+            "example": 123456
+          },
+          "prisonerNumber": {
+            "type": "string",
+            "description": "The NOMIS OFFENDERS.OFFENDER_ID_DISPLAY value for mapping to a prisoner record in NOMIS",
+            "example": "A1234BC"
+          },
+          "bookingId": {
+            "type": "integer",
+            "description": "The NOMIS OFFENDER_BOOKINGS.OFFENDER_BOOK_ID value for mapping to a prisoner booking record in NOMIS",
+            "format": "int64",
+            "example": 456
+          },
+          "addedTime": {
+            "type": "string",
+            "description": "\n    The date and time this attendee was added appointment.\n    Will be null if this attendee was part of the appointment when the appointment was created\n    ",
+            "format": "date-time"
+          },
+          "addedBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that added this attendee to the appointment.\n    Will be null if this attendee was part of the appointment when the appointment was created\n    ",
+            "example": "AAA01U"
+          },
+          "attended": {
+            "type": "boolean",
+            "description": "\n    Specifies whether the prisoner attended the specific appointment in an appointment series or set.\n    A null value means that the prisoner's attendance has not been recorded yet. \n    "
+          },
+          "attendanceRecordedTime": {
+            "type": "string",
+            "description": "\n    The date and time the attendance record the specific appointment in an appointment series or set was marked.\n    A null value means that the prisoner's attendance has not been recorded yet. \n    ",
+            "format": "date-time"
+          },
+          "attendanceRecordedBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that marked the attendance record the specific appointment in\n    an appointment series or set.\n    A null value means that the prisoner's attendance has not been recorded yet. \n    ",
+            "example": "AAA01U"
+          },
+          "removedTime": {
+            "type": "string",
+            "description": "\n    The date and time this attendee was removed from the appointment.\n    Will be null if this attendee has not been removed from the appointment\n    ",
+            "format": "date-time"
+          },
+          "removedBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that removed this attendee from the appointment.\n    Will be null if this attendee has not been removed from the appointment\n    ",
+            "example": "AAA01U"
+          }
+        },
+        "description": "\n  Described on the UI as an \"Attendee\". A prisoner attending a specific appointment in an appointment series or set.\n  "
+      },
+      "AppointmentSeries": {
+        "required": [
+          "appointmentType",
+          "appointments",
+          "categoryCode",
+          "createdBy",
+          "createdTime",
+          "id",
+          "inCell",
+          "prisonCode",
+          "startDate",
+          "startTime"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The internally generated identifier for this appointment series",
             "format": "int64",
             "example": 12345
           },
@@ -5149,9 +5462,9 @@
             "description": "The NOMIS REFERENCE_CODES.CODE (DOMAIN = 'INT_SCH_RSN') value for mapping to NOMIS",
             "example": "CHAP"
           },
-          "appointmentDescription": {
+          "customName": {
             "type": "string",
-            "description": "\n    Free text description for an appointment. This is used to add more context to the appointment category.\n    ",
+            "description": "\n    Free text name further describing the appointment series. Used as part of the appointment name with the\n    format \"Custom name (Category description) if specified.\n    ",
             "example": "Meeting with the governor"
           },
           "internalLocationId": {
@@ -5162,209 +5475,74 @@
           },
           "inCell": {
             "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
+            "description": "\n    Flag to indicate if the location of the appointment series is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
             "example": false
           },
           "startDate": {
             "type": "string",
-            "description": "The date of the appointment or first appointment occurrence in the series",
+            "description": "The date of the first appointment in the series",
             "format": "date"
           },
           "startTime": {
             "type": "string",
-            "description": "The starting time of the appointment or first appointment occurrence in the series",
+            "description": "The starting time of the appointment or appointments in the series",
             "format": "partial-time",
             "example": "09:00"
           },
           "endTime": {
             "type": "string",
-            "description": "The end time of the appointment or first appointment occurrence in the series",
+            "description": "The end time of the appointment or appointments in the series",
             "format": "partial-time",
             "example": "10:30"
           },
-          "repeat": {
-            "$ref": "#/components/schemas/AppointmentRepeat"
+          "schedule": {
+            "$ref": "#/components/schemas/AppointmentSeriesSchedule"
           },
-          "comment": {
+          "extraInformation": {
             "type": "string",
-            "description": "\n    Notes relating to the appointment.\n    The default value if no notes are specified at the occurrence or instance levels\n    ",
+            "description": "\n    Extra information for the prisoner or prisoners attending the appointment or appointments in the series.\n    Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is\n    extra information via the unlock list.\n    ",
             "example": "This appointment will help adjusting to life outside of prison"
           },
-          "created": {
+          "createdTime": {
             "type": "string",
-            "description": "The date and time this appointment was created. Will not change",
+            "description": "The date and time this appointment series was created. Will not change",
             "format": "date-time"
           },
           "createdBy": {
             "type": "string",
-            "description": "\n    The username of the user authenticated via HMPPS auth that created the appointment.\n    Usually a NOMIS username\n    ",
+            "description": "\n    The username of the user authenticated via HMPPS auth that created the appointment series.\n    Usually a NOMIS username\n    ",
             "example": "AAA01U"
           },
-          "updated": {
+          "updatedTime": {
             "type": "string",
-            "description": "\n    The date and time one or more occurrences of this appointment was last changed.\n    ",
+            "description": "\n    The date and time one or more appointments in this series was last changed.\n    Will be null if no appointments in the series have been altered since they were created\n    ",
             "format": "date-time"
           },
           "updatedBy": {
             "type": "string",
-            "description": "\n    The username of the user authenticated via HMPPS auth that last edited one or more occurrences of this appointment.\n    ",
+            "description": "\n    The username of the user authenticated via HMPPS auth that last edited one or more appointments in this series.\n    Will be null if no appointments in the series have been altered since they were created\n    ",
             "example": "AAA01U"
           },
-          "occurrences": {
+          "appointments": {
             "type": "array",
-            "description": "\n    The individual occurrence or occurrences of this appointment. Non recurring appointments will have a single\n    appointment occurrence containing the same property values as the parent appointment. The same start date, time\n    and end time. Recurring appointments will have a series of occurrences. The first in the series will also\n    contain the same property values as the parent appointment and subsequent occurrences will have start dates\n    following on from the original start date incremented as specified by the appointment's schedule. Each occurrence\n    can be edited independently of the parent. All properties of an occurrence override those of the parent appointment\n    with a null coalesce back to the parent for nullable properties. The full series of occurrences specified by the\n    schedule will be created in advance.\n    ",
+            "description": "\n    The individual appointment or appointments in this series. Non recurring appointment series will have a single\n    appointment containing the same property values as the parent appointment series. The same start date, time\n    and end time. Recurring appointment series will have one or more appointments. The first in the series will also\n    contain the same property values as the parent appointment series and subsequent appointments will have start dates\n    following on from the original start date incremented as specified by the series' schedule. Each appointment\n    can be edited independently of the parent. All properties of an appointment are separate to those of the parent\n    appointment series. The full series of appointments specified by the schedule will have been created in advance.\n    ",
             "items": {
-              "$ref": "#/components/schemas/AppointmentOccurrence"
+              "$ref": "#/components/schemas/Appointment"
             }
           }
         },
-        "description": "\n  Described on the UI as an \"Appointment series\" and only shown for repeat appointments.\n  The top level of the standard appointment hierarchy containing the initial property values common to all appointment\n  occurrences in the series.\n  Contains the collection of all the child appointment occurrences in the series plus the repeat definition if the appointment repeats.\n  The properties at this level cannot be changed via the API however the child occurrence property values can be changed\n  independently to support rescheduling, cancelling and altered attendee lists per occurrence.\n  N.B. there is no collection of allocated prisoners at this top level as all allocations are per occurrence. This is to\n  support attendee modification for each scheduled occurrence and to prevent altering the past by editing allocations\n  in an appointment series where some occurrences have past.\n  "
+        "description": "\n  Described on the UI as an \"Appointment series\" and only shown for repeat appointments.\n  The top level of the standard appointment hierarchy containing the initial property values common to all appointments\n  in the series.\n  Contains the collection of all the child appointments in the series plus the schedule definition if the appointment series repeats.\n  The properties at this level cannot be changed via the API however the child appointment property values can be changed\n  independently to support rescheduling, cancelling and altered attendee lists per appointment.\n  N.B. there is no collection of attending prisoners at this top level as all attendees are per appointment. This is to\n  support attendee modification for each scheduled appointment and to prevent altering the past by editing attendees\n  in an appointment series where some appointments have past.\n  "
       },
-      "AppointmentOccurrence": {
+      "AppointmentSeriesSchedule": {
         "required": [
-          "allocations",
-          "categoryCode",
-          "id",
-          "inCell",
-          "isCancelled",
-          "sequenceNumber",
-          "startDate",
-          "startTime"
+          "frequency",
+          "numberOfAppointments"
         ],
         "type": "object",
         "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The internally generated identifier for this appointment occurrence",
-            "format": "int64",
-            "example": 123456
-          },
-          "sequenceNumber": {
-            "type": "integer",
-            "description": "The sequence number of this appointment occurrence within the recurring appointment series",
-            "format": "int32",
-            "example": 3
-          },
-          "categoryCode": {
+          "frequency": {
             "type": "string",
-            "description": "The NOMIS REFERENCE_CODES.CODE (DOMAIN = 'INT_SCH_RSN') value for mapping to NOMIS",
-            "example": "CHAP"
-          },
-          "appointmentDescription": {
-            "type": "string",
-            "description": "\n    Free text description for an appointment occurrence. This is used to add more context to the appointment category.\n    ",
-            "example": "Meeting with the governor"
-          },
-          "internalLocationId": {
-            "type": "integer",
-            "description": "\n    The NOMIS AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID value for mapping to NOMIS.\n    Will be null if in cell = true\n    ",
-            "format": "int64",
-            "example": 123
-          },
-          "inCell": {
-            "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment occurrence is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
-            "example": false
-          },
-          "startDate": {
-            "type": "string",
-            "description": "The date this appointment occurrence is taking place on",
-            "format": "date"
-          },
-          "startTime": {
-            "type": "string",
-            "description": "The starting time of this appointment occurrence",
-            "format": "partial-time",
-            "example": "13:00"
-          },
-          "endTime": {
-            "type": "string",
-            "description": "The end time of this appointment occurrence",
-            "format": "partial-time",
-            "example": "13:30"
-          },
-          "comment": {
-            "type": "string",
-            "description": "\n    Notes relating to this appointment occurrence.\n    The comment value from the parent appointment will be used if this is null\n    ",
-            "example": "This appointment occurrence has been rescheduled due to staff availability"
-          },
-          "cancelled": {
-            "type": "string",
-            "description": "\n    The time at which this appointment occurrence was cancelled (if applicable).\n    ",
-            "format": "date-time"
-          },
-          "cancellationReasonId": {
-            "type": "integer",
-            "description": "\n    The ID of the reason why this appointment occurrence was cancelled (if applicable).\n    ",
-            "format": "int64",
-            "example": 12345
-          },
-          "cancelledBy": {
-            "type": "string",
-            "description": "\n    The username of the user authenticated via HMPPS auth that cancelled this appointment instance (if applicable).\n    Usually a NOMIS username. Will be null if the appointment occurrence has not been altered independently from the\n    parent appointment since it was created\n    ",
-            "example": "AAA01U"
-          },
-          "updated": {
-            "type": "string",
-            "description": "\n    The date and time this appointment occurrence was last changed.\n    ",
-            "format": "date-time"
-          },
-          "updatedBy": {
-            "type": "string",
-            "description": "\n    The username of the user authenticated via HMPPS auth that edited this appointment instance.\n    ",
-            "example": "AAA01U"
-          },
-          "allocations": {
-            "type": "array",
-            "description": "\n    The prisoner or prisoners attending this appointment occurrence. Single appointments such as medical will have one\n    allocation record. A group appointment e.g. gym or chaplaincy sessions will have more than one allocation record.\n    Allocations are at the occurrence level supporting alteration of attendees in any future occurrence.\n    When viewing or editing a recurring appointment, the allocations from the next appointment occurrence in the series\n    will be used.\n    ",
-            "items": {
-              "$ref": "#/components/schemas/AppointmentOccurrenceAllocation"
-            }
-          },
-          "isCancelled": {
-            "type": "boolean"
-          }
-        },
-        "description": "\n  Described on the UI as an \"Appointment\" and represents the scheduled event on a specific date and time.\n  All updates and cancellations happen at this occurrence level with the parent appointment being immutable.\n  "
-      },
-      "AppointmentOccurrenceAllocation": {
-        "required": [
-          "bookingId",
-          "id",
-          "prisonerNumber"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "\n    The internally generated identifier for this appointment occurrence allocation.\n    N.B. this is used as the appointment instance id due to there being a one to one relationship between appointment\n    occurrence allocations and appointment instances.\n    ",
-            "format": "int64",
-            "example": 123456
-          },
-          "prisonerNumber": {
-            "type": "string",
-            "description": "The NOMIS OFFENDERS.OFFENDER_ID_DISPLAY value for mapping to a prisoner record in NOMIS",
-            "example": "A1234BC"
-          },
-          "bookingId": {
-            "type": "integer",
-            "description": "The NOMIS OFFENDER_BOOKINGS.OFFENDER_BOOK_ID value for mapping to a prisoner booking record in NOMIS",
-            "format": "int64",
-            "example": 456
-          }
-        },
-        "description": "\n  Described on the UI as an \"Attendee\". The allocation of a prisoner to an appointment occurrence.\n  "
-      },
-      "AppointmentRepeat": {
-        "required": [
-          "count",
-          "period"
-        ],
-        "type": "object",
-        "properties": {
-          "period": {
-            "type": "string",
-            "description": "\n    The period or frequency of the occurrences in the repeating appointment series. When they will repeat and how often\n    ",
+            "description": "\n    The frequency of the appointments in the repeating appointment series. When they will repeat and how often\n    ",
             "example": "WEEKLY",
             "enum": [
               "WEEKDAY",
@@ -5374,15 +5552,15 @@
               "MONTHLY"
             ]
           },
-          "count": {
+          "numberOfAppointments": {
             "minimum": 1,
             "type": "integer",
-            "description": "\n    The total number of occurrences in the appointment series\n    ",
+            "description": "\n    The original total number of appointments in the appointment series i.e. the number that were created initially\n    without excluding any that were subsequently cancelled or deleted\n    ",
             "format": "int32",
             "example": 6
           }
         },
-        "description": "\n  Describes how an appointment will repeat. The period or frequency of those occurrences and how many occurrences there\n  will be in total in the series.\n  "
+        "description": "\n  Describes the schedule of the appointment i.e. how the appointments in the series will repeat. The frequency of\n  those appointments and how many appointments there will be in total in the series.\n  "
       },
       "PrisonerAllocationRequest": {
         "required": [
@@ -5530,28 +5708,23 @@
             "format": "int64",
             "example": 9999
           },
+          "appointmentSeriesId": {
+            "type": "integer",
+            "description": "For appointments from SAA the ID for the appointment series, or null when from NOMIS",
+            "format": "int64",
+            "example": 9999
+          },
           "appointmentId": {
             "type": "integer",
             "description": "For appointments from SAA the ID for the appointment, or null when from NOMIS",
             "format": "int64",
             "example": 9999
           },
-          "appointmentOccurrenceId": {
+          "appointmentAttendeeId": {
             "type": "integer",
-            "description": "For appointments from SAA the ID for the appointment occurrence, or null when from NOMIS",
+            "description": "For appointments from SAA the ID for the appointment attendee, or null when from NOMIS",
             "format": "int64",
             "example": 9999
-          },
-          "appointmentInstanceId": {
-            "type": "integer",
-            "description": "For appointments from SAA the ID for the appointment instance, or null when from NOMIS",
-            "format": "int64",
-            "example": 9999
-          },
-          "appointmentDescription": {
-            "type": "string",
-            "description": "For appointments from SAA the optional appointment description",
-            "example": "Meeting with the governor"
           },
           "oicHearingId": {
             "type": "integer",
@@ -6337,6 +6510,140 @@
         },
         "description": "The migration request with the appointment details"
       },
+      "AppointmentInstance": {
+        "required": [
+          "appointmentAttendeeId",
+          "appointmentDate",
+          "appointmentId",
+          "appointmentSeriesId",
+          "appointmentType",
+          "bookingId",
+          "categoryCode",
+          "createdBy",
+          "createdTime",
+          "id",
+          "inCell",
+          "prisonCode",
+          "prisonerNumber",
+          "startTime"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "\n    The internally generated identifier for this appointment instance. N.B. this is the appointment attendee id due to\n    there being a one to one relationship between an appointment attendee and appointment instances.\n    ",
+            "format": "int64",
+            "example": 123456
+          },
+          "appointmentSeriesId": {
+            "type": "integer",
+            "description": "The internally generated identifier for the appointment series",
+            "format": "int64",
+            "example": 1234
+          },
+          "appointmentId": {
+            "type": "integer",
+            "description": "The internally generated identifier for the appointment",
+            "format": "int64",
+            "example": 12345
+          },
+          "appointmentAttendeeId": {
+            "type": "integer",
+            "description": "\n    The internally generated identifier for the appointment attendee. N.B. this is used as the appointment instance id\n    due to there being a one to one relationship between an appointment attendee and appointment instances.\n    ",
+            "format": "int64",
+            "example": 123456
+          },
+          "appointmentType": {
+            "type": "string",
+            "description": "The appointment type (INDIVIDUAL or GROUP)",
+            "example": "INDIVIDUAL",
+            "enum": [
+              "INDIVIDUAL",
+              "GROUP"
+            ]
+          },
+          "prisonCode": {
+            "type": "string",
+            "description": "The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS",
+            "example": "SKI"
+          },
+          "prisonerNumber": {
+            "type": "string",
+            "description": "The NOMIS OFFENDERS.OFFENDER_ID_DISPLAY value for mapping to a prisoner record in NOMIS",
+            "example": "A1234BC"
+          },
+          "bookingId": {
+            "type": "integer",
+            "description": "The NOMIS OFFENDER_BOOKINGS.OFFENDER_BOOK_ID value for mapping to a prisoner booking record in NOMIS",
+            "format": "int64",
+            "example": 456
+          },
+          "categoryCode": {
+            "type": "string",
+            "description": "The NOMIS REFERENCE_CODES.CODE (DOMAIN = 'INT_SCH_RSN') value for mapping to NOMIS",
+            "example": "CHAP"
+          },
+          "customName": {
+            "type": "string",
+            "description": "\n    Free text name further describing the appointment instance. Used as part of the appointment name with the\n    format \"Appointment description (Category description) if specified.\n    ",
+            "example": "Meeting with the governor"
+          },
+          "internalLocationId": {
+            "type": "integer",
+            "description": "\n    The NOMIS AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID value for mapping to NOMIS.\n    Will be null if in cell = true\n    ",
+            "format": "int64",
+            "example": 123
+          },
+          "inCell": {
+            "type": "boolean",
+            "description": "\n    Flag to indicate if the location of the appointment instance is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
+            "example": false
+          },
+          "appointmentDate": {
+            "type": "string",
+            "description": "The date of the appointment instance",
+            "format": "date"
+          },
+          "startTime": {
+            "type": "string",
+            "description": "The starting time of the appointment instance",
+            "format": "partial-time",
+            "example": "09:00"
+          },
+          "endTime": {
+            "type": "string",
+            "description": "The end time of the appointment instance",
+            "format": "partial-time",
+            "example": "10:30"
+          },
+          "extraInformation": {
+            "type": "string",
+            "description": "\n    Extra information for the prisoner attending this appointment instance.\n    Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is\n    extra information via the unlock list.\n    ",
+            "example": "This appointment will help adjusting to life outside of prison"
+          },
+          "createdTime": {
+            "type": "string",
+            "description": "The date and time this appointment instance was created. Will not change",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that created the appointment instance.\n    Usually a NOMIS username\n    ",
+            "example": "AAA01U"
+          },
+          "updatedTime": {
+            "type": "string",
+            "description": "\n    The date and time this appointment instance was last changed.\n    Will be null if this appointment instance has not been altered since it was created\n    ",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that edited this appointment instance.\n    Will be null if this appointment instance has not been altered since it was created\n    ",
+            "example": "AAA01U"
+          }
+        },
+        "description": "\n  Represents an appointment instance for a specific prisoner to attend at the specified location, date and time.\n  The fully denormalised representation of the appointment series, appointments and attendees equivalent to a row in\n  the NOMIS OFFENDER_IND_SCHEDULES table.\n  Appointment instances do not exist as database records and are the product of the join between appointment attendees,\n  appointments and appointment series. \n  The appointment attendee id is used for the appointment instance id as there is a one to one relationship between an\n  appointment attendee and appointment instances.\n  Appointment instances are used primarily for the one way sync to NOMIS.\n  "
+      },
       "EventAcknowledgeRequest": {
         "required": [
           "eventReviewIds"
@@ -6359,168 +6666,6 @@
           }
         },
         "description": "The prisoner allocation request details"
-      },
-      "BulkAppointmentsRequest": {
-        "required": [
-          "appointments",
-          "categoryCode",
-          "inCell",
-          "internalLocationId",
-          "prisonCode",
-          "startDate"
-        ],
-        "type": "object",
-        "properties": {
-          "prisonCode": {
-            "maxLength": 3,
-            "minLength": 0,
-            "type": "string",
-            "description": "The NOMIS prison code where these appointments takes place",
-            "example": "PVI"
-          },
-          "categoryCode": {
-            "type": "string",
-            "description": "The NOMIS reference code for these appointments. Must exist and be active",
-            "example": "CHAP"
-          },
-          "appointmentDescription": {
-            "maxLength": 40,
-            "minLength": 0,
-            "type": "string",
-            "description": "\n    Free text description for these appointments.  This is used to add more context to the appointment category.\n    ",
-            "example": "Meeting with the governor"
-          },
-          "internalLocationId": {
-            "type": "integer",
-            "description": "\n    The NOMIS internal location id within the specified prison. This must be supplied if inCell is false.\n    The internal location id must exist, must be within the prison specified by the prisonCode property and be active. \n    ",
-            "format": "int64",
-            "example": 123
-          },
-          "inCell": {
-            "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointments is in cell rather than an internal prison location.\n    Internal location id will be ignored if inCell is true\n    ",
-            "example": false
-          },
-          "startDate": {
-            "type": "string",
-            "description": "The date of the appointments",
-            "format": "date"
-          },
-          "appointments": {
-            "type": "array",
-            "description": "\n    The list of appointments to create\n    ",
-            "items": {
-              "$ref": "#/components/schemas/IndividualAppointment"
-            }
-          }
-        },
-        "description": "The create request containing the new appointments"
-      },
-      "IndividualAppointment": {
-        "required": [
-          "comment",
-          "endTime",
-          "prisonerNumber",
-          "startTime"
-        ],
-        "type": "object",
-        "properties": {
-          "prisonerNumber": {
-            "type": "string",
-            "description": "The prisoner to allocate to the created appointment",
-            "example": "A1234BC"
-          },
-          "startTime": {
-            "type": "string",
-            "description": "The starting time of the appointment",
-            "format": "partial-time",
-            "example": "09:00"
-          },
-          "endTime": {
-            "type": "string",
-            "description": "The end time of the appointment",
-            "format": "partial-time",
-            "example": "10:30"
-          },
-          "comment": {
-            "maxLength": 4000,
-            "minLength": 0,
-            "type": "string",
-            "description": "\n    Notes relating to the appointment.\n    ",
-            "example": "This appointment will help adjusting to life outside of prison"
-          }
-        },
-        "description": "\n    The list of appointments to create\n    "
-      },
-      "BulkAppointment": {
-        "required": [
-          "appointments",
-          "categoryCode",
-          "created",
-          "createdBy",
-          "id",
-          "inCell",
-          "prisonCode",
-          "startDate"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The internally generated identifier for this set of appointments",
-            "format": "int64",
-            "example": 12345
-          },
-          "prisonCode": {
-            "type": "string",
-            "description": "The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS",
-            "example": "SKI"
-          },
-          "categoryCode": {
-            "type": "string",
-            "description": "The NOMIS REFERENCE_CODES.CODE (DOMAIN = 'INT_SCH_RSN') value for mapping to NOMIS",
-            "example": "CHAP"
-          },
-          "appointmentDescription": {
-            "type": "string",
-            "description": "\n    Free text description for an appointment.  This is used to add more context to the appointment category.\n    ",
-            "example": "Meeting with the governor"
-          },
-          "internalLocationId": {
-            "type": "integer",
-            "description": "\n    The NOMIS AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID value for mapping to NOMIS.\n    Will be null if in cell = true\n    ",
-            "format": "int64",
-            "example": 123
-          },
-          "inCell": {
-            "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
-            "example": false
-          },
-          "startDate": {
-            "type": "string",
-            "description": "The date of the appointment or first appointment occurrence in the series",
-            "format": "date"
-          },
-          "appointments": {
-            "type": "array",
-            "description": "The set of appointments created in bulk",
-            "items": {
-              "$ref": "#/components/schemas/Appointment"
-            }
-          },
-          "created": {
-            "type": "string",
-            "description": "The date and time this set of appointment was created in bulk. Will not change",
-            "format": "date-time"
-          },
-          "createdBy": {
-            "type": "string",
-            "description": "\n    The username of the user authenticated via HMPPS auth that created this set of appointments in bulk.\n    Usually a NOMIS username\n    ",
-            "example": "AAA01U"
-          }
-        },
-        "description": "\n  Described on the UI as an \"Appointment set\" or \"set of back-to-back appointments\".\n  Contains the initial property values common to all appointments in the set.\n  The properties at this level cannot be changed via the API.\n  "
       },
       "AuditRecordSearchFilters": {
         "type": "object",
@@ -6561,7 +6706,7 @@
               "APPOINTMENT_CANCELLED_ON_TRANSFER",
               "APPOINTMENT_SERIES_CREATED",
               "APPOINTMENT_DELETED",
-              "APPOINTMENT_OCCURRENCE_EDITED",
+              "APPOINTMENT_EDITED",
               "BONUS_PAYMENT_MADE_FOR_ACTIVITY_ATTENDANCE",
               "APPOINTMENT_SET_CREATED",
               "INCENTIVE_LEVEL_WARNING_GIVEN_FOR_ACTIVITY_ATTENDANCE",
@@ -6643,7 +6788,7 @@
               "APPOINTMENT_CANCELLED_ON_TRANSFER",
               "APPOINTMENT_SERIES_CREATED",
               "APPOINTMENT_DELETED",
-              "APPOINTMENT_OCCURRENCE_EDITED",
+              "APPOINTMENT_EDITED",
               "BONUS_PAYMENT_MADE_FOR_ACTIVITY_ATTENDANCE",
               "APPOINTMENT_SET_CREATED",
               "INCENTIVE_LEVEL_WARNING_GIVEN_FOR_ACTIVITY_ATTENDANCE",
@@ -6721,101 +6866,7 @@
         },
         "description": "The result of an audit record search"
       },
-      "AppointmentCreateRequest": {
-        "required": [
-          "appointmentType",
-          "categoryCode",
-          "endTime",
-          "inCell",
-          "prisonCode",
-          "prisonerNumbers",
-          "startDate",
-          "startTime"
-        ],
-        "type": "object",
-        "properties": {
-          "appointmentType": {
-            "type": "string",
-            "description": "The appointment type (INDIVIDUAL or GROUP)",
-            "example": "INDIVIDUAL",
-            "enum": [
-              "INDIVIDUAL",
-              "GROUP"
-            ]
-          },
-          "prisonCode": {
-            "maxLength": 3,
-            "minLength": 0,
-            "type": "string",
-            "description": "The NOMIS prison code where this appointment takes place",
-            "example": "PVI"
-          },
-          "prisonerNumbers": {
-            "type": "array",
-            "description": "The prisoner or prisoners to allocate to the created appointment or series of appointment occurrences",
-            "example": [
-              "A1234BC"
-            ],
-            "items": {
-              "type": "string",
-              "description": "The prisoner or prisoners to allocate to the created appointment or series of appointment occurrences",
-              "example": "[\"A1234BC\"]"
-            }
-          },
-          "categoryCode": {
-            "type": "string",
-            "description": "The NOMIS reference code for this appointment. Must exist and be active",
-            "example": "CHAP"
-          },
-          "appointmentDescription": {
-            "maxLength": 40,
-            "minLength": 0,
-            "type": "string",
-            "description": "\n    Free text description for an appointment.  This is used to add more context to the appointment category.\n    ",
-            "example": "Meeting with the governor"
-          },
-          "internalLocationId": {
-            "type": "integer",
-            "description": "\n    The NOMIS internal location id within the specified prison. This must be supplied if inCell is false.\n    The internal location id must exist, must be within the prison specified by the prisonCode property and be active. \n    ",
-            "format": "int64",
-            "example": 123
-          },
-          "inCell": {
-            "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location id will be ignored if inCell is true\n    ",
-            "example": false
-          },
-          "startDate": {
-            "type": "string",
-            "description": "The date of the appointment or first appointment occurrence in the series",
-            "format": "date"
-          },
-          "startTime": {
-            "type": "string",
-            "description": "The starting time of the appointment or first appointment occurrence in the series",
-            "format": "partial-time",
-            "example": "09:00"
-          },
-          "endTime": {
-            "type": "string",
-            "description": "The end time of the appointment or first appointment occurrence in the series",
-            "format": "partial-time",
-            "example": "10:30"
-          },
-          "repeat": {
-            "$ref": "#/components/schemas/AppointmentRepeat"
-          },
-          "comment": {
-            "maxLength": 4000,
-            "minLength": 0,
-            "type": "string",
-            "description": "\n    Notes relating to the appointment.\n    The default value if no notes are specified at the occurrence or instance levels\n    ",
-            "example": "This appointment will help adjusting to life outside of prison"
-          }
-        },
-        "description": "The create request with the new appointment or series of appointment occurrences details"
-      },
-      "AppointmentOccurrenceSearchRequest": {
+      "AppointmentSearchRequest": {
         "required": [
           "startDate"
         ],
@@ -6823,7 +6874,7 @@
         "properties": {
           "appointmentType": {
             "type": "string",
-            "description": "\n    The appointment type (INDIVIDUAL or GROUP) match with the parent appointments. Will restrict the search results to\n    appointment occurrences that have a parent appointment with the matching type when this search parameter is supplied.\n    ",
+            "description": "\n    The appointment type (INDIVIDUAL or GROUP) to match with the appointment series. Will restrict the search results to\n    appointments that are part of a series with the matching type when this search parameter is supplied.\n    ",
             "example": "INDIVIDUAL",
             "enum": [
               "INDIVIDUAL",
@@ -6832,17 +6883,17 @@
           },
           "startDate": {
             "type": "string",
-            "description": "\n    The start date to match with the appointment occurrences. Will restrict the search results to appointment\n    occurrences that have the matching start date when this search parameter is supplied but no end date is supplied.\n    When an end date is also supplied, the search uses a date range and will restrict the search results to appointment\n    occurrences that have a start date within the date range.\n    ",
+            "description": "\n    The start date to match with the appointments. Will restrict the search results to appointments\n    that have the matching start date when this search parameter is supplied but no end date is supplied.\n    When an end date is also supplied, the search uses a date range and will restrict the search results to\n    appointments that have a start date within the date range.\n    ",
             "format": "date"
           },
           "endDate": {
             "type": "string",
-            "description": "\n    The end date of the date range to match with the appointment occurrences. Start date must be supplied if an end date\n    is specified. Will restrict the search results to appointment occurrences that have a start date within the date range.\n    ",
+            "description": "\n    The end date of the date range to match with the appointments. Start date must be supplied if an end date\n    is specified. Will restrict the search results to appointments that have a start date within the date range.\n    ",
             "format": "date"
           },
           "timeSlot": {
             "type": "string",
-            "description": "\n    The time slot to match with the appointment occurrences. Will restrict the search results to appointment occurrences\n    that have a start time between the times defined by the prison for that time slot when this search parameter is\n    supplied.\n    ",
+            "description": "\n    The time slot to match with the appointments. Will restrict the search results to appointments that have a start\n    time between the times defined by the prison for that time slot when this search parameter is supplied.\n    ",
             "example": "PM",
             "enum": [
               "AM",
@@ -6852,39 +6903,67 @@
           },
           "categoryCode": {
             "type": "string",
-            "description": "\n    The NOMIS reference code to match with the parent appointments. Will restrict the search results to appointment\n    occurrences that have a parent appointment with the matching category code when this search parameter is supplied.\n    ",
+            "description": "\n    The NOMIS reference code to match with the appointments. Will restrict the search results to appointments\n    that have the matching category code when this search parameter is supplied.\n    ",
             "example": "GYMW"
           },
           "internalLocationId": {
             "type": "integer",
-            "description": "\n    The NOMIS internal location id to match with the appointment occurrences. Will restrict the search results to\n    appointment occurrences that have the matching internal location id when this search parameter is supplied.\n    ",
+            "description": "\n    The NOMIS internal location id to match with the appointments. Will restrict the search results to\n    appointments that have the matching internal location id when this search parameter is supplied.\n    ",
             "format": "int64",
             "example": 123
           },
           "inCell": {
             "type": "boolean",
-            "description": "\n    The in cell flag value to match with the appointment occurrences. Will restrict the search results to appointment\n    occurrences that have the matching in cell value when this search parameter is supplied.\n    ",
+            "description": "\n    The in cell flag value to match with the appointments. Will restrict the search results to appointments\n    that have the matching in cell value when this search parameter is supplied.\n    ",
             "example": false
           },
           "prisonerNumbers": {
             "type": "array",
-            "description": "\n    The allocated prisoner or prisoners to match with the appointment occurrences. Will restrict the search results to\n    appointment occurrences that have the at least one of the supplied prisoner numbers allocated to them when this\n    search parameter is supplied.\n    ",
+            "description": "\n    The allocated prisoner or prisoners to match with the appointments. Will restrict the search results to\n    appointments that have the at least one of the supplied prisoner numbers attending when this search parameter\n    is supplied.\n    ",
             "example": [
               "A1234BC"
             ],
             "items": {
               "type": "string",
-              "description": "\n    The allocated prisoner or prisoners to match with the appointment occurrences. Will restrict the search results to\n    appointment occurrences that have the at least one of the supplied prisoner numbers allocated to them when this\n    search parameter is supplied.\n    ",
+              "description": "\n    The allocated prisoner or prisoners to match with the appointments. Will restrict the search results to\n    appointments that have the at least one of the supplied prisoner numbers attending when this search parameter\n    is supplied.\n    ",
               "example": "[\"A1234BC\"]"
             }
           },
           "createdBy": {
             "type": "string",
-            "description": "\n    The username of the user authenticated via HMPPS auth to match with the parent appointments. Will restrict the\n    search results to appointment occurrences that have a parent appointment created by this username when this search\n    parameter is supplied.\n    ",
+            "description": "\n    The username of the user authenticated via HMPPS auth to match with the appointments. Will restrict the\n    search results to appointments that were created by this username when this search parameter is supplied.\n    ",
             "example": "AAA01U"
           }
         },
-        "description": "The search parameters to use to filter appointment occurrences"
+        "description": "The search parameters to use to filter appointments"
+      },
+      "AppointmentAttendeeSearchResult": {
+        "required": [
+          "appointmentAttendeeId",
+          "bookingId",
+          "prisonerNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "appointmentAttendeeId": {
+            "type": "integer",
+            "description": "\n    The internally generated identifier for this prisoner attending a specific appointment in an appointment series or set.\n    N.B. this is used as the appointment instance id due to there being a one to one relationship between an appointment\n    attendee and appointment instances.\n    ",
+            "format": "int64",
+            "example": 123456
+          },
+          "prisonerNumber": {
+            "type": "string",
+            "description": "The NOMIS OFFENDERS.OFFENDER_ID_DISPLAY value for mapping to a prisoner record in NOMIS",
+            "example": "A1234BC"
+          },
+          "bookingId": {
+            "type": "integer",
+            "description": "The NOMIS OFFENDER_BOOKINGS.OFFENDER_BOOK_ID value for mapping to a prisoner booking record in NOMIS",
+            "format": "int64",
+            "example": 456
+          }
+        },
+        "description": "\n  Summary search result details of a specific appointment attendee found via search. Contains properties needed to\n  make additional API calls and to populate a table of search results.\n  "
       },
       "AppointmentCategorySummary": {
         "required": [
@@ -6933,13 +7012,13 @@
         },
         "description": "\n  Summarises an appointment location for display purposes. Contains only properties needed to make additional API calls\n  and to display. NOMIS is the current system of record for appointment locations and they are managed there.\n  "
       },
-      "AppointmentOccurrenceSearchResult": {
+      "AppointmentSearchResult": {
         "required": [
-          "allocations",
           "appointmentId",
           "appointmentName",
-          "appointmentOccurrenceId",
+          "appointmentSeriesId",
           "appointmentType",
+          "attendees",
           "category",
           "inCell",
           "isCancelled",
@@ -6954,21 +7033,21 @@
         ],
         "type": "object",
         "properties": {
-          "appointmentId": {
+          "appointmentSeriesId": {
             "type": "integer",
-            "description": "The internally generated identifier for the parent appointment",
+            "description": "The internally generated identifier for the appointment series",
             "format": "int64",
             "example": 12345
           },
-          "appointmentOccurrenceId": {
+          "appointmentId": {
             "type": "integer",
-            "description": "The internally generated identifier for this appointment occurrence",
+            "description": "The internally generated identifier for this appointment",
             "format": "int64",
             "example": 123456
           },
           "appointmentType": {
             "type": "string",
-            "description": "The parent appointment's type (INDIVIDUAL or GROUP)",
+            "description": "The type of the appointment series (INDIVIDUAL or GROUP)",
             "example": "INDIVIDUAL",
             "enum": [
               "INDIVIDUAL",
@@ -6977,26 +7056,26 @@
           },
           "prisonCode": {
             "type": "string",
-            "description": "\n    The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS.\n    Note, this property does not exist on the appointment occurrences and is therefore consistent across all occurrences\n    ",
+            "description": "\n    The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS.\n    ",
             "example": "SKI"
           },
           "appointmentName": {
             "type": "string",
-            "description": "\n    The appointment name\n    "
+            "description": "\n    The appointment's name combining the optional custom name with the category description. If custom name has been\n    specified, the name format will be \"Custom name (Category description)\" \n    "
           },
-          "allocations": {
+          "attendees": {
             "type": "array",
-            "description": "\n    The prisoner or prisoners attending this appointment occurrence. Appointments of type INDIVIDUAL will have one\n    prisoner allocated to each appointment occurrence. Appointments of type GROUP can have more than one prisoner\n    allocated to each appointment occurrence\n    ",
+            "description": "\n    The prisoner or prisoners attending this appointment. Appointments of type INDIVIDUAL will have one\n    prisoner attending to each appointment. Appointments of type GROUP can have more than one prisoner\n    attending each appointment\n    ",
             "items": {
-              "$ref": "#/components/schemas/AppointmentOccurrenceAllocation"
+              "$ref": "#/components/schemas/AppointmentAttendeeSearchResult"
             }
           },
           "category": {
             "$ref": "#/components/schemas/AppointmentCategorySummary"
           },
-          "appointmentDescription": {
+          "customName": {
             "type": "string",
-            "description": "\n    Free text description for an appointment.  This is used to add more context to the appointment category.\n    ",
+            "description": "\n    Free text name further describing the appointment. Used as part of the appointment name with the\n    format \"Custom name (Category description) if specified.\n    ",
             "example": "Meeting with the governor"
           },
           "internalLocation": {
@@ -7009,55 +7088,309 @@
           },
           "startDate": {
             "type": "string",
-            "description": "The date this appointment occurrence is taking place on",
+            "description": "The date this appointment is taking place on",
             "format": "date"
           },
           "startTime": {
             "type": "string",
-            "description": "The starting time of this appointment occurrence",
+            "description": "The starting time of this appointment",
             "format": "partial-time",
             "example": "13:00"
           },
           "endTime": {
             "type": "string",
-            "description": "The end time of this appointment occurrence",
+            "description": "The end time of this appointment",
             "format": "partial-time",
             "example": "13:30"
           },
           "isRepeat": {
             "type": "boolean",
-            "description": "Indicates whether the parent appointment was specified to repeat",
+            "description": "Indicates whether the appointment series was specified to repeat via its schedule",
             "example": false
           },
           "sequenceNumber": {
             "type": "integer",
-            "description": "The sequence number of this appointment occurrence within the recurring appointment series",
+            "description": "The sequence number of this appointment within the appointment series",
             "format": "int32",
             "example": 3
           },
           "maxSequenceNumber": {
             "type": "integer",
-            "description": "The sequence number of the final appointment occurrence within the recurring appointment series",
+            "description": "The sequence number of the final appointment within the appointment series",
             "format": "int32",
             "example": 6
           },
           "isEdited": {
             "type": "boolean",
-            "description": "Indicates whether this appointment occurrence has been changed from its original state",
+            "description": "Indicates whether this appointment has been changed from its original state",
             "example": false
           },
           "isCancelled": {
             "type": "boolean",
-            "description": "Indicates whether this appointment occurrence has been cancelled",
+            "description": "Indicates whether this appointment has been cancelled",
             "example": false
           },
           "isExpired": {
             "type": "boolean",
-            "description": "Indicates whether this appointment occurrence has expired",
+            "description": "Indicates whether this appointment has expired",
             "example": false
           }
         },
-        "description": "\n  Summary search result details of a specific appointment occurrence found via search. Will contain copies of the parent\n  appointment's properties unless they have been changed on this appointment occurrence. Contains properties needed to\n  make additional API calls and to populate a table of search results.\n  "
+        "description": "\n  Summary search result details of a specific appointment found via search. Contains properties needed to\n  make additional API calls and to populate a table of search results.\n  "
+      },
+      "AppointmentSetAppointment": {
+        "required": [
+          "endTime",
+          "prisonerNumber",
+          "startTime"
+        ],
+        "type": "object",
+        "properties": {
+          "prisonerNumber": {
+            "type": "string",
+            "description": "The prisoner attending the appointment",
+            "example": "A1234BC"
+          },
+          "startTime": {
+            "type": "string",
+            "description": "The starting time of the appointment",
+            "format": "partial-time",
+            "example": "09:00"
+          },
+          "endTime": {
+            "type": "string",
+            "description": "The end time of the appointment",
+            "format": "partial-time",
+            "example": "10:30"
+          },
+          "extraInformation": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "description": "\n    Extra information for the prisoner or prisoners attending the appointment. Shown only on the appointments details\n    page and on printed movement slips. Wing staff will be notified there is extra information via the unlock list.\n    ",
+            "example": "This appointment will help adjusting to life outside of prison"
+          }
+        },
+        "description": "\n    The list of appointments to create\n    "
+      },
+      "AppointmentSetCreateRequest": {
+        "required": [
+          "appointments",
+          "categoryCode",
+          "inCell",
+          "prisonCode",
+          "startDate"
+        ],
+        "type": "object",
+        "properties": {
+          "prisonCode": {
+            "maxLength": 3,
+            "minLength": 0,
+            "type": "string",
+            "description": "The NOMIS prison code where these appointments takes place",
+            "example": "PVI"
+          },
+          "categoryCode": {
+            "type": "string",
+            "description": "The NOMIS reference code for these appointments. Must exist and be active",
+            "example": "CHAP"
+          },
+          "customName": {
+            "maxLength": 40,
+            "minLength": 0,
+            "type": "string",
+            "description": "\n    Free text name further describing the appointment series. Will be used to create the appointment name using the\n    format \"Custom name (Category description) if specified.\n    ",
+            "example": "Meeting with the governor"
+          },
+          "internalLocationId": {
+            "type": "integer",
+            "description": "\n    The NOMIS internal location id within the specified prison. This must be supplied if inCell is false.\n    The internal location id must exist, must be within the prison specified by the prisonCode property and be active. \n    ",
+            "format": "int64",
+            "example": 123
+          },
+          "inCell": {
+            "type": "boolean",
+            "description": "\n    Flag to indicate if the location of the appointments is in cell rather than an internal prison location.\n    Internal location id will be ignored if inCell is true\n    ",
+            "example": false
+          },
+          "startDate": {
+            "type": "string",
+            "description": "The date of the appointments",
+            "format": "date"
+          },
+          "appointments": {
+            "type": "array",
+            "description": "\n    The list of appointments to create\n    ",
+            "items": {
+              "$ref": "#/components/schemas/AppointmentSetAppointment"
+            }
+          }
+        },
+        "description": "The create request with the new appointment set details"
+      },
+      "AppointmentSet": {
+        "required": [
+          "appointments",
+          "categoryCode",
+          "createdBy",
+          "createdTime",
+          "id",
+          "inCell",
+          "prisonCode",
+          "startDate"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The internally generated identifier for this appointment set",
+            "format": "int64",
+            "example": 12345
+          },
+          "prisonCode": {
+            "type": "string",
+            "description": "The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS",
+            "example": "SKI"
+          },
+          "categoryCode": {
+            "type": "string",
+            "description": "The NOMIS REFERENCE_CODES.CODE (DOMAIN = 'INT_SCH_RSN') value for mapping to NOMIS",
+            "example": "CHAP"
+          },
+          "customName": {
+            "type": "string",
+            "description": "\n    Free text name further describing the appointment set. Used as part of the appointment name with the\n    format \"Custom name (Category description) if specified.\n    ",
+            "example": "Meeting with the governor"
+          },
+          "internalLocationId": {
+            "type": "integer",
+            "description": "\n    The NOMIS AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID value for mapping to NOMIS.\n    Will be null if in cell = true\n    ",
+            "format": "int64",
+            "example": 123
+          },
+          "inCell": {
+            "type": "boolean",
+            "description": "\n    Flag to indicate if the location of the appointment set is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
+            "example": false
+          },
+          "startDate": {
+            "type": "string",
+            "description": "The date of the first appointment in each appointment series in the set",
+            "format": "date"
+          },
+          "appointments": {
+            "type": "array",
+            "description": "The appointments in the set",
+            "items": {
+              "$ref": "#/components/schemas/Appointment"
+            }
+          },
+          "createdTime": {
+            "type": "string",
+            "description": "The date and time this appointment set was created. Will not change",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "\n    The username of the user authenticated via HMPPS auth that created this appointment set.\n    Usually a NOMIS username\n    ",
+            "example": "AAA01U"
+          }
+        },
+        "description": "\n  Described on the UI as an \"Appointment set\" or \"set of back-to-back appointments\".\n  Contains the initial property values common to all appointment series and appointments in the set.\n  The properties at this level cannot be changed via the API.\n  "
+      },
+      "AppointmentSeriesCreateRequest": {
+        "required": [
+          "appointmentType",
+          "categoryCode",
+          "endTime",
+          "inCell",
+          "prisonCode",
+          "prisonerNumbers",
+          "startDate",
+          "startTime"
+        ],
+        "type": "object",
+        "properties": {
+          "appointmentType": {
+            "type": "string",
+            "description": "The appointment type (INDIVIDUAL or GROUP)",
+            "example": "INDIVIDUAL",
+            "enum": [
+              "INDIVIDUAL",
+              "GROUP"
+            ]
+          },
+          "prisonCode": {
+            "maxLength": 3,
+            "minLength": 0,
+            "type": "string",
+            "description": "The NOMIS prison code where this appointment series takes place",
+            "example": "PVI"
+          },
+          "prisonerNumbers": {
+            "type": "array",
+            "description": "The prisoner or prisoners attending the appointment or appointments in the series",
+            "example": [
+              "A1234BC"
+            ],
+            "items": {
+              "type": "string",
+              "description": "The prisoner or prisoners attending the appointment or appointments in the series",
+              "example": "[\"A1234BC\"]"
+            }
+          },
+          "categoryCode": {
+            "type": "string",
+            "description": "The NOMIS reference code for this appointment. Must exist and be active",
+            "example": "CHAP"
+          },
+          "customName": {
+            "maxLength": 40,
+            "minLength": 0,
+            "type": "string",
+            "description": "\n    Free text name further describing the appointment series. Will be used to create the appointment name using the\n    format \"Custom name (Category description) if specified.\n    ",
+            "example": "Meeting with the governor"
+          },
+          "internalLocationId": {
+            "type": "integer",
+            "description": "\n    The NOMIS internal location id within the specified prison. This must be supplied if inCell is false.\n    The internal location id must exist, must be within the prison specified by the prisonCode property and be active. \n    ",
+            "format": "int64",
+            "example": 123
+          },
+          "inCell": {
+            "type": "boolean",
+            "description": "\n    Flag to indicate if the location of the appointment series is in cell rather than an internal prison location.\n    Internal location id will be ignored if inCell is true\n    ",
+            "example": false
+          },
+          "startDate": {
+            "type": "string",
+            "description": "The date of the first appointment in the series",
+            "format": "date"
+          },
+          "startTime": {
+            "type": "string",
+            "description": "The starting time of the appointment or appointments in the series",
+            "format": "partial-time",
+            "example": "09:00"
+          },
+          "endTime": {
+            "type": "string",
+            "description": "The end time of the appointment or appointments in the series",
+            "format": "partial-time",
+            "example": "10:30"
+          },
+          "schedule": {
+            "$ref": "#/components/schemas/AppointmentSeriesSchedule"
+          },
+          "extraInformation": {
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string",
+            "description": "\n    Extra information for the prisoner or prisoners attending the appointment or appointments in the series.\n    Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is\n    extra information via the unlock list.\n    ",
+            "example": "This appointment will help adjusting to life outside of prison"
+          }
+        },
+        "description": "The create request with the new appointment series details"
       },
       "WaitingListApplicationRequest": {
         "required": [
@@ -8659,7 +8992,7 @@
         },
         "description": "Describes a single waiting list application for a prisoner who is waiting to be allocated to an activity."
       },
-      "AppointmentOccurrenceUpdateRequest": {
+      "AppointmentUpdateRequest": {
         "required": [
           "applyTo",
           "isPropertyUpdate"
@@ -8668,81 +9001,83 @@
         "properties": {
           "categoryCode": {
             "type": "string",
-            "description": "\n    The updated NOMIS reference code for the parent appointment. Must exist and be active.\n    NOTE: updating the category will apply to all appointment occurrences as the category is associated with the\n    parent appointment only. The value for applyTo will be ignored.\n    ",
+            "description": "\n    The updated NOMIS reference code. Must exist and be active.\n    ",
             "example": "GYMW"
           },
           "internalLocationId": {
             "type": "integer",
-            "description": "\n    The updated NOMIS internal location id within the specified prison. This must be supplied if inCell is false.\n    The internal location id must exist, must be within the prison specified by the prisonCode property on the\n    parent appointment and be active. \n    ",
+            "description": "\n    The updated NOMIS internal location id within the specified prison. This must be supplied if inCell is false.\n    The internal location id must exist, must be within the prison specified by the prisonCode property on the\n    appointment and be active. \n    ",
             "format": "int64",
             "example": 123
           },
           "inCell": {
             "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment occurrence is in cell rather than an internal prison location.\n    Internal location id will be ignored if inCell is true\n    ",
+            "description": "\n    Flag to indicate if the location of the appointment or appointments is in cell rather than an internal prison location.\n    Internal location id will be ignored if inCell is true\n    ",
             "example": false
           },
           "startDate": {
             "type": "string",
-            "description": "\n    The updated date of the appointment occurrence. NOTE: this property specifies the day or date of all or all future\n    occurrences when used in conjunction with the applyTo property\n    ",
+            "description": "\n    The updated date of the appointment. NOTE: this property specifies the start date to use along with the existing\n    schedule frequency to move all appointments that will take place after the appointment when used in conjunction\n    with the applyTo property\n    ",
             "format": "date"
           },
           "startTime": {
             "type": "string",
-            "description": "The updated starting time of the appointment occurrence",
+            "description": "The updated starting time",
             "format": "partial-time",
             "example": "09:00"
           },
           "endTime": {
             "type": "string",
-            "description": "The updated end time of the appointment occurrence",
+            "description": "The updated end time",
             "format": "partial-time",
             "example": "10:30"
           },
-          "comment": {
+          "extraInformation": {
+            "maxLength": 4000,
+            "minLength": 0,
             "type": "string",
-            "description": "Updated notes relating to the appointment occurrence",
-            "example": "This appointment occurrence has been rescheduled due to staff availability"
+            "description": "\n    Updated extra information for the prisoner or prisoners attending the appointment or appointments.\n    Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is\n    extra information via the unlock list.\n    ",
+            "example": "This appointment will help adjusting to life outside of prison"
           },
           "removePrisonerNumbers": {
             "type": "array",
-            "description": "The prisoner or prisoners to deallocate from the appointment occurrence",
+            "description": "The prisoner or prisoners to remove from the appointment or appointments",
             "example": [
               "A1234BC"
             ],
             "items": {
               "type": "string",
-              "description": "The prisoner or prisoners to deallocate from the appointment occurrence",
+              "description": "The prisoner or prisoners to remove from the appointment or appointments",
               "example": "[\"A1234BC\"]"
             }
           },
           "addPrisonerNumbers": {
             "type": "array",
-            "description": "The replacement prisoner or prisoners to allocate to the appointment occurrence",
+            "description": "The new prisoner or prisoners that will be attending the appointment or appointments",
             "example": [
               "A1234BC"
             ],
             "items": {
               "type": "string",
-              "description": "The replacement prisoner or prisoners to allocate to the appointment occurrence",
+              "description": "The new prisoner or prisoners that will be attending the appointment or appointments",
               "example": "[\"A1234BC\"]"
             }
           },
           "applyTo": {
             "type": "string",
-            "description": "\n    Specifies which appointment occurrence or occurrences this update should apply to.\n    Defaults to THIS_OCCURRENCE meaning the update will be applied to the appointment occurrence specified by the\n    supplied id only.\n    ",
-            "example": "THIS_OCCURRENCE",
+            "description": "\n    Specifies which appointment or appointments this update should apply to.\n    Defaults to THIS_APPOINTMENT meaning the update will be applied to the appointment specified by the\n    supplied id only.\n    ",
+            "example": "THIS_APPOINTMENT",
             "enum": [
-              "THIS_OCCURRENCE",
-              "THIS_AND_ALL_FUTURE_OCCURRENCES",
-              "ALL_FUTURE_OCCURRENCES"
+              "THIS_APPOINTMENT",
+              "THIS_AND_ALL_FUTURE_APPOINTMENTS",
+              "ALL_FUTURE_APPOINTMENTS"
             ]
           },
           "isPropertyUpdate": {
             "type": "boolean"
           }
         },
-        "description": "The update request with the new appointment occurrence details and how to apply the update"
+        "description": "The update request with the new appointment details and how to apply the update"
       },
       "AllocationUpdateRequest": {
         "type": "object",
@@ -9620,15 +9955,15 @@
           "sort": {
             "$ref": "#/components/schemas/SortObject"
           },
-          "first": {
-            "type": "boolean"
+          "numberOfElements": {
+            "type": "integer",
+            "format": "int32"
           },
           "pageable": {
             "$ref": "#/components/schemas/PageableObject"
           },
-          "numberOfElements": {
-            "type": "integer",
-            "format": "int32"
+          "first": {
+            "type": "boolean"
           },
           "last": {
             "type": "boolean"
@@ -9648,11 +9983,11 @@
           "sort": {
             "$ref": "#/components/schemas/SortObject"
           },
-          "pageSize": {
+          "pageNumber": {
             "type": "integer",
             "format": "int32"
           },
-          "pageNumber": {
+          "pageSize": {
             "type": "integer",
             "format": "int32"
           },
@@ -9670,10 +10005,10 @@
           "empty": {
             "type": "boolean"
           },
-          "sorted": {
+          "unsorted": {
             "type": "boolean"
           },
-          "unsorted": {
+          "sorted": {
             "type": "boolean"
           }
         }
@@ -10227,324 +10562,6 @@
         },
         "description": "The result of an event review search"
       },
-      "AppointmentOccurrenceDetails": {
-        "required": [
-          "appointmentId",
-          "appointmentName",
-          "appointmentType",
-          "category",
-          "created",
-          "createdBy",
-          "id",
-          "inCell",
-          "isCancelled",
-          "isEdited",
-          "isExpired",
-          "prisonCode",
-          "prisoners",
-          "sequenceNumber",
-          "startDate",
-          "startTime"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The internally generated identifier for this appointment occurrence",
-            "format": "int64",
-            "example": 123456
-          },
-          "appointmentId": {
-            "type": "integer",
-            "description": "The internally generated identifier for the parent appointment",
-            "format": "int64",
-            "example": 12345
-          },
-          "bulkAppointment": {
-            "$ref": "#/components/schemas/BulkAppointmentSummary"
-          },
-          "appointmentType": {
-            "type": "string",
-            "description": "The appointment type (INDIVIDUAL or GROUP)",
-            "example": "INDIVIDUAL",
-            "enum": [
-              "INDIVIDUAL",
-              "GROUP"
-            ]
-          },
-          "sequenceNumber": {
-            "type": "integer",
-            "description": "The sequence number of this appointment occurrence within the recurring appointment series",
-            "format": "int32",
-            "example": 3
-          },
-          "prisonCode": {
-            "type": "string",
-            "description": "\n    The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS.\n    Note, this property does not exist on the appointment occurrences and is therefore consistent across all occurrences\n    ",
-            "example": "SKI"
-          },
-          "appointmentName": {
-            "type": "string",
-            "description": "\n    The appointment occurrence's name\n    "
-          },
-          "prisoners": {
-            "type": "array",
-            "description": "\n    Summary of the prisoner or prisoners allocated to this appointment occurrence. Prisoners are allocated at the\n    occurrence level to allow for per occurrence allocation changes.\n    ",
-            "items": {
-              "$ref": "#/components/schemas/PrisonerSummary"
-            }
-          },
-          "category": {
-            "$ref": "#/components/schemas/AppointmentCategorySummary"
-          },
-          "appointmentDescription": {
-            "type": "string",
-            "description": "\n    Free text description for an appointment occurrence. This is used to add more context to the category.\n    ",
-            "example": "Meeting with the governor"
-          },
-          "internalLocation": {
-            "$ref": "#/components/schemas/AppointmentLocationSummary"
-          },
-          "inCell": {
-            "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location will be null if in cell = true\n    ",
-            "example": false
-          },
-          "startDate": {
-            "type": "string",
-            "description": "The date this appointment occurrence is taking place on",
-            "format": "date"
-          },
-          "startTime": {
-            "type": "string",
-            "description": "The starting time of this appointment occurrence",
-            "format": "partial-time",
-            "example": "13:00"
-          },
-          "endTime": {
-            "type": "string",
-            "description": "The end time of this appointment occurrence",
-            "format": "partial-time",
-            "example": "13:30"
-          },
-          "comment": {
-            "type": "string",
-            "description": "\n    Notes relating to this appointment occurrence. Can be different to the parent appointment if this occurrence has\n    been edited.\n    ",
-            "example": "This appointment occurrence has been rescheduled due to staff availability"
-          },
-          "repeat": {
-            "$ref": "#/components/schemas/AppointmentRepeat"
-          },
-          "isEdited": {
-            "type": "boolean",
-            "description": "\n    Indicates that this appointment occurrence has been independently changed from the original state it was in when\n    it was created as part of a recurring series\n    ",
-            "example": false
-          },
-          "isCancelled": {
-            "type": "boolean",
-            "description": "\n    Indicates that this appointment occurrence has been cancelled\n    ",
-            "example": false
-          },
-          "isExpired": {
-            "type": "boolean",
-            "description": "\n    Indicates that this appointment occurrence has expired\n    ",
-            "example": false
-          },
-          "created": {
-            "type": "string",
-            "description": "The date and time the parent appointment was created. Will not change",
-            "format": "date-time"
-          },
-          "createdBy": {
-            "$ref": "#/components/schemas/UserSummary"
-          },
-          "updated": {
-            "type": "string",
-            "description": "\n    The date and time this appointment occurrence was last edited.\n    ",
-            "format": "date-time"
-          },
-          "updatedBy": {
-            "$ref": "#/components/schemas/UserSummary"
-          },
-          "cancelled": {
-            "type": "string",
-            "description": "\n    The date and time this appointment occurrence was cancelled\n    ",
-            "format": "date-time"
-          },
-          "cancelledBy": {
-            "$ref": "#/components/schemas/UserSummary"
-          }
-        },
-        "description": "\n  Described on the UI as an \"Appointment\" and represents the scheduled event on a specific date and time.\n  Contains the full details of all the appointment occurrence properties, any properties specified by the parent\n  appointment and the summary collection of prisoners allocated to this occurrence.\n  All updates and cancellations happen at this occurrence level with the parent appointment being immutable.\n  "
-      },
-      "BulkAppointmentDetails": {
-        "required": [
-          "appointmentName",
-          "category",
-          "created",
-          "createdBy",
-          "id",
-          "inCell",
-          "occurrences",
-          "prisonCode",
-          "startDate"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The internally generated identifier for this set of appointments",
-            "format": "int64",
-            "example": 12345
-          },
-          "prisonCode": {
-            "type": "string",
-            "description": "\n    The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS.\n    Note, this property does not exist on the appointment occurrences and is therefore consistent across all occurrences\n    ",
-            "example": "SKI"
-          },
-          "appointmentName": {
-            "type": "string",
-            "description": "\n    The appointment name\n    "
-          },
-          "category": {
-            "$ref": "#/components/schemas/AppointmentCategorySummary"
-          },
-          "appointmentDescription": {
-            "type": "string",
-            "description": "\n    Free text description used to create the set of appointments in bulk. This is used to add more context to the appointment category.\n    ",
-            "example": "Meeting with the governor"
-          },
-          "internalLocation": {
-            "$ref": "#/components/schemas/AppointmentLocationSummary"
-          },
-          "inCell": {
-            "type": "boolean",
-            "description": "\n    Flag to indicate if the location used to create the set of appointments in bulk was in cell rather than an internal prison location.\n    Internal location will be null if in cell = true\n    ",
-            "example": false
-          },
-          "startDate": {
-            "type": "string",
-            "description": "The date used to create the set of appointments in bulk",
-            "format": "date"
-          },
-          "occurrences": {
-            "type": "array",
-            "description": "The details of the set of appointment occurrences created in bulk",
-            "items": {
-              "$ref": "#/components/schemas/AppointmentOccurrenceDetails"
-            }
-          },
-          "created": {
-            "type": "string",
-            "description": "The date and time this set of appointments was created in bulk. Will not change",
-            "format": "date-time"
-          },
-          "createdBy": {
-            "$ref": "#/components/schemas/UserSummary"
-          }
-        },
-        "description": "\n  Described on the UI as an \"Appointment set\" or \"set of back-to-back appointments\".\n  Contains the full details of the initial property values common to all appointments in the set for display purposes.\n  The properties at this level cannot be changed via the API.\n  "
-      },
-      "BulkAppointmentSummary": {
-        "required": [
-          "appointmentCount",
-          "id"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The internally generated identifier for this set of appointments",
-            "format": "int64",
-            "example": 12345
-          },
-          "appointmentCount": {
-            "type": "integer",
-            "description": "\n    The number of appointments in the set created in bulk\n    ",
-            "format": "int32",
-            "example": 3
-          }
-        },
-        "description": "\n  Described on the UI as an \"Appointment set\" or \"set of back-to-back appointments\".\n  Contains the limited summary information needed to display the fact that an appointment occurrence was created as\n  part of a set.\n  "
-      },
-      "PrisonerSummary": {
-        "required": [
-          "bookingId",
-          "cellLocation",
-          "firstName",
-          "lastName",
-          "prisonCode",
-          "prisonerNumber"
-        ],
-        "type": "object",
-        "properties": {
-          "prisonerNumber": {
-            "type": "string",
-            "description": "The NOMIS OFFENDERS.OFFENDER_ID_DISPLAY value for mapping to a prisoner record in NOMIS",
-            "example": "A1234BC"
-          },
-          "bookingId": {
-            "type": "integer",
-            "description": "The NOMIS OFFENDER_BOOKINGS.OFFENDER_BOOK_ID value for mapping to a prisoner booking record in NOMIS",
-            "format": "int64",
-            "example": 456
-          },
-          "firstName": {
-            "type": "string",
-            "description": "The prisoner's first name",
-            "example": "Albert"
-          },
-          "lastName": {
-            "type": "string",
-            "description": "The prisoner's first name",
-            "example": "Abbot"
-          },
-          "prisonCode": {
-            "type": "string",
-            "description": "\n    The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS.\n    ",
-            "example": "SKI"
-          },
-          "cellLocation": {
-            "type": "string",
-            "description": "\n    The prisoner's residential cell location when inside the prison.\n    ",
-            "example": "A-1-002"
-          }
-        },
-        "description": "\n    Summary of the prisoner or prisoners allocated to the first future occurrence (or most recent past occurrence if all\n    occurrences are in the past) of this appointment. Prisoners are allocated at the occurrence level to allow for per\n    occurrence allocation changes. The occurrence summary does not contain any information on the allocated prisoners\n    as the expected usage is to show a summary of the occurrences then a link to display the full occurrence details.\n    "
-      },
-      "UserSummary": {
-        "required": [
-          "firstName",
-          "id",
-          "lastName",
-          "username"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The NOMIS STAFF_MEMBERS.STAFF_ID value for mapping to NOMIS.",
-            "format": "int64",
-            "example": 36
-          },
-          "username": {
-            "type": "string",
-            "description": "The NOMIS STAFF_USER_ACCOUNTS.USERNAME value for mapping to NOMIS",
-            "example": "AAA01U"
-          },
-          "firstName": {
-            "type": "string",
-            "description": "The user's first name",
-            "example": "Alice"
-          },
-          "lastName": {
-            "type": "string",
-            "description": "The user's last name",
-            "example": "Akbar"
-          }
-        },
-        "description": "\n    The summary of the last user to edit this appointment occurrence.\n    "
-      },
       "AllAttendance": {
         "required": [
           "activityId",
@@ -10631,48 +10648,405 @@
         },
         "description": "\n  Represents the key data required to report on attendance \n  "
       },
-      "AppointmentInstance": {
+      "AppointmentAttendeeSummary": {
         "required": [
-          "appointmentDate",
-          "appointmentId",
-          "appointmentOccurrenceAllocationId",
-          "appointmentOccurrenceId",
+          "id",
+          "prisoner"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "\n    The internally generated identifier for this prisoner attending a specific appointment in an appointment series or set.\n    N.B. this is used as the appointment instance id due to there being a one to one relationship between an appointment\n    attendee and appointment instances.\n    ",
+            "format": "int64",
+            "example": 123456
+          },
+          "prisoner": {
+            "$ref": "#/components/schemas/PrisonerSummary"
+          },
+          "attended": {
+            "type": "boolean",
+            "description": "\n    Specifies whether the prisoner attended the specific appointment in an appointment series or set.\n    A null value means that the prisoner's attendance has not been recorded yet. \n    "
+          }
+        },
+        "description": "\n  Described on the UI as an \"Attendee\". A prisoner attending a specific appointment in an appointment series or set.\n  Contains the limited summary information needed to display the prisoner information and whether they attended or not.\n  "
+      },
+      "AppointmentDetails": {
+        "required": [
+          "appointmentName",
           "appointmentType",
-          "bookingId",
-          "categoryCode",
-          "created",
+          "attendees",
+          "category",
           "createdBy",
+          "createdTime",
           "id",
           "inCell",
+          "isCancelled",
+          "isEdited",
+          "isExpired",
           "prisonCode",
-          "prisonerNumber",
+          "sequenceNumber",
+          "startDate",
           "startTime"
         ],
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "description": "\n    The internally generated identifier for this appointment instance. N.B. this is the appointment occurrence\n    allocation id due to there being a one to one relationship between appointment occurrence allocations and\n    appointment instances.\n    ",
+            "description": "The internally generated identifier for this appointment",
             "format": "int64",
             "example": 123456
           },
-          "appointmentId": {
-            "type": "integer",
-            "description": "The internally generated identifier for the appointment",
-            "format": "int64",
-            "example": 1234
+          "appointmentSeries": {
+            "$ref": "#/components/schemas/AppointmentSeriesSummary"
           },
-          "appointmentOccurrenceId": {
+          "appointmentSet": {
+            "$ref": "#/components/schemas/AppointmentSetSummary"
+          },
+          "appointmentType": {
+            "type": "string",
+            "description": "The appointment type (INDIVIDUAL or GROUP)",
+            "example": "INDIVIDUAL",
+            "enum": [
+              "INDIVIDUAL",
+              "GROUP"
+            ]
+          },
+          "sequenceNumber": {
             "type": "integer",
-            "description": "The internally generated identifier for the appointment occurrence",
+            "description": "The sequence number of this appointment within the appointment series",
+            "format": "int32",
+            "example": 3
+          },
+          "prisonCode": {
+            "type": "string",
+            "description": "The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS",
+            "example": "SKI"
+          },
+          "appointmentName": {
+            "type": "string",
+            "description": "\n    The appointment's name combining the optional custom name with the category description. If custom name has been\n    specified, the name format will be \"Custom name (Category description)\" \n    "
+          },
+          "attendees": {
+            "type": "array",
+            "description": "\n    Summary of the prisoner or prisoners attending this appointment and their attendance record if any.\n    Attendees are at the appointment level to allow for per appointment attendee changes.\n    ",
+            "items": {
+              "$ref": "#/components/schemas/AppointmentAttendeeSummary"
+            }
+          },
+          "category": {
+            "$ref": "#/components/schemas/AppointmentCategorySummary"
+          },
+          "customName": {
+            "type": "string",
+            "description": "\n    Free text name further describing the appointment. Used as part of the appointment name with the\n    format \"Custom name (Category description) if specified.\n    ",
+            "example": "Meeting with the governor"
+          },
+          "internalLocation": {
+            "$ref": "#/components/schemas/AppointmentLocationSummary"
+          },
+          "inCell": {
+            "type": "boolean",
+            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location will be null if in cell = true\n    ",
+            "example": false
+          },
+          "startDate": {
+            "type": "string",
+            "description": "The date this appointment is taking place on",
+            "format": "date"
+          },
+          "startTime": {
+            "type": "string",
+            "description": "The starting time of this appointment",
+            "format": "partial-time",
+            "example": "13:00"
+          },
+          "endTime": {
+            "type": "string",
+            "description": "The end time of this appointment",
+            "format": "partial-time",
+            "example": "13:30"
+          },
+          "isExpired": {
+            "type": "boolean",
+            "description": "\n    Indicates that this appointment has expired i.e. it's start date and time is in the past\n    ",
+            "example": false
+          },
+          "extraInformation": {
+            "type": "string",
+            "description": "\n    Extra information for the prisoner or prisoners attending this appointment.\n    Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is\n    extra information via the unlock list.\n    ",
+            "example": "This appointment will help adjusting to life outside of prison"
+          },
+          "createdTime": {
+            "type": "string",
+            "description": "The date and time this appointment was created. Will not change",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "$ref": "#/components/schemas/UserSummary"
+          },
+          "isEdited": {
+            "type": "boolean",
+            "description": "\n    Indicates that this appointment has been independently changed from the original state it was in when\n    it was created as part of an appointment series\n    ",
+            "example": false
+          },
+          "updatedTime": {
+            "type": "string",
+            "description": "\n    The date and time this appointment was last changed.\n    Will be null if this appointment has not been altered since it was created\n    ",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "$ref": "#/components/schemas/UserSummary"
+          },
+          "isCancelled": {
+            "type": "boolean",
+            "description": "\n    Indicates that this appointment has been cancelled\n    ",
+            "example": false
+          },
+          "cancelledTime": {
+            "type": "string",
+            "description": "\n    The date and time this appointment was cancelled.\n    Will be null if this appointment has not been cancelled\n    ",
+            "format": "date-time"
+          },
+          "cancelledBy": {
+            "$ref": "#/components/schemas/UserSummary"
+          }
+        },
+        "description": "\n  Described on the UI as an \"Appointment\" and represents the scheduled event on a specific date and time.\n  Contains the full details of all the appointment properties and the summary collection of prisoners attending this appointment.\n  An appointment is part of either a series of an appointments on a schedule or a set of appointments on the same day.\n  The summary information of which appointment collection they are part of is included in these details.\n  All updates and cancellations happen at this appointment level with the parent appointment series being immutable.\n  "
+      },
+      "AppointmentSeriesSummary": {
+        "required": [
+          "appointmentCount",
+          "id",
+          "scheduledAppointmentCount"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The internally generated identifier for this appointment series",
             "format": "int64",
             "example": 12345
           },
-          "appointmentOccurrenceAllocationId": {
+          "schedule": {
+            "$ref": "#/components/schemas/AppointmentSeriesSchedule"
+          },
+          "appointmentCount": {
             "type": "integer",
-            "description": "\n    The internally generated identifier for the appointment occurrence allocation. N.B. this is used as the appointment\n    instance id due to there being a one to one relationship between appointment occurrence allocations and appointment\n    instances.\n    ",
+            "description": "\n    The total count of appointments in the series that have not been deleted. Counts both appointments in the past and\n    those scheduled.\n    ",
+            "format": "int32"
+          },
+          "scheduledAppointmentCount": {
+            "type": "integer",
+            "description": "\n    The count of the remaining scheduled appointments in the series that have not been cancelled or deleted.\n    ",
+            "format": "int32"
+          }
+        },
+        "description": "\n  Described on the UI as an \"Appointment series\" and only shown for repeat appointments.\n  The top level of the standard appointment hierarchy containing summary information of a limited set of the initial\n  property values common to all appointments in the series as well as the count of appointments in the series.\n  The properties at this level cannot be changed via the API however the child appointment property values can be changed\n  independently to support rescheduling, cancelling and altered attendee lists per appointment.\n  N.B. there is no collection of attending prisoners at this top level as all attendees are per appointment. This is to\n  support attendee modification for each scheduled appointment and to prevent altering the past by editing attendees\n  in an appointment series where some appointments have past.\n  "
+      },
+      "AppointmentSetSummary": {
+        "required": [
+          "appointmentCount",
+          "id",
+          "scheduledAppointmentCount"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The internally generated identifier for this appointment set",
             "format": "int64",
-            "example": 123456
+            "example": 12345
+          },
+          "appointmentCount": {
+            "type": "integer",
+            "description": "\n    The number of appointments in the set that have not been deleted. Counts both appointments in the past and\n    those scheduled.\n    ",
+            "format": "int32",
+            "example": 3
+          },
+          "scheduledAppointmentCount": {
+            "type": "integer",
+            "description": "\n    The count of the remaining scheduled appointments in the set that have not been cancelled or deleted.\n    ",
+            "format": "int32"
+          }
+        },
+        "description": "\n  Described on the UI as an \"Appointment set\" or \"set of back-to-back appointments\".\n  Contains the limited summary information needed to display the fact that an appointment was created as part of a set.\n  "
+      },
+      "PrisonerSummary": {
+        "required": [
+          "bookingId",
+          "cellLocation",
+          "firstName",
+          "lastName",
+          "prisonCode",
+          "prisonerNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "prisonerNumber": {
+            "type": "string",
+            "description": "The NOMIS OFFENDERS.OFFENDER_ID_DISPLAY value for mapping to a prisoner record in NOMIS",
+            "example": "A1234BC"
+          },
+          "bookingId": {
+            "type": "integer",
+            "description": "The NOMIS OFFENDER_BOOKINGS.OFFENDER_BOOK_ID value for mapping to a prisoner booking record in NOMIS",
+            "format": "int64",
+            "example": 456
+          },
+          "firstName": {
+            "type": "string",
+            "description": "The prisoner's first name",
+            "example": "Albert"
+          },
+          "lastName": {
+            "type": "string",
+            "description": "The prisoner's first name",
+            "example": "Abbot"
+          },
+          "prisonCode": {
+            "type": "string",
+            "description": "\n    The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS.\n    ",
+            "example": "SKI"
+          },
+          "cellLocation": {
+            "type": "string",
+            "description": "\n    The prisoner's residential cell location when inside the prison.\n    ",
+            "example": "A-1-002"
+          }
+        },
+        "description": "Summary of the prisoner attending the appointment"
+      },
+      "UserSummary": {
+        "required": [
+          "firstName",
+          "id",
+          "lastName",
+          "username"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The NOMIS STAFF_MEMBERS.STAFF_ID value for mapping to NOMIS.",
+            "format": "int64",
+            "example": 36
+          },
+          "username": {
+            "type": "string",
+            "description": "The NOMIS STAFF_USER_ACCOUNTS.USERNAME value for mapping to NOMIS",
+            "example": "AAA01U"
+          },
+          "firstName": {
+            "type": "string",
+            "description": "The user's first name",
+            "example": "Alice"
+          },
+          "lastName": {
+            "type": "string",
+            "description": "The user's last name",
+            "example": "Akbar"
+          }
+        },
+        "description": "\n    The summary of the user that last edited one or more appointments in this series.\n    Will be null if no appointments in the series have been altered since they were created\n    "
+      },
+      "AppointmentSetDetails": {
+        "required": [
+          "appointmentName",
+          "appointments",
+          "category",
+          "createdBy",
+          "createdTime",
+          "id",
+          "inCell",
+          "prisonCode",
+          "startDate"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The internally generated identifier for this appointment set",
+            "format": "int64",
+            "example": 12345
+          },
+          "prisonCode": {
+            "type": "string",
+            "description": "The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS",
+            "example": "SKI"
+          },
+          "appointmentName": {
+            "type": "string",
+            "description": "\n    The appointment set's name combining the optional custom name with the category description. If custom name has been\n    specified, the name format will be \"Custom name (Category description)\" \n    "
+          },
+          "category": {
+            "$ref": "#/components/schemas/AppointmentCategorySummary"
+          },
+          "customName": {
+            "type": "string",
+            "description": "\n    Free text name further describing the appointment set. Used as part of the appointment name with the\n    format \"Custom name (Category description) if specified.\n    ",
+            "example": "Meeting with the governor"
+          },
+          "internalLocation": {
+            "$ref": "#/components/schemas/AppointmentLocationSummary"
+          },
+          "inCell": {
+            "type": "boolean",
+            "description": "\n    Flag to indicate if the location of the appointment series in the set is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
+            "example": false
+          },
+          "startDate": {
+            "type": "string",
+            "description": "The date of the first appointment in each appointment series in the set",
+            "format": "date"
+          },
+          "appointments": {
+            "type": "array",
+            "description": "The details of all the appointments in the the set",
+            "items": {
+              "$ref": "#/components/schemas/AppointmentDetails"
+            }
+          },
+          "createdTime": {
+            "type": "string",
+            "description": "The date and time this appointment set was created. Will not change",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "$ref": "#/components/schemas/UserSummary"
+          },
+          "updatedTime": {
+            "type": "string",
+            "description": "\n    The date and time one or more appointments in this set was last changed.\n    Will be null if no appointments in the set have been altered since they were created\n    ",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "$ref": "#/components/schemas/UserSummary"
+          }
+        },
+        "description": "\n  Described on the UI as an \"Appointment set\" or \"set of back-to-back appointments\".\n  Contains the full details of the initial property values common to all appointments in the set for display purposes.\n  The properties at this level cannot be changed via the API.\n  "
+      },
+      "AppointmentSeriesDetails": {
+        "required": [
+          "appointmentName",
+          "appointmentType",
+          "appointments",
+          "category",
+          "createdBy",
+          "createdTime",
+          "id",
+          "inCell",
+          "prisonCode",
+          "startDate",
+          "startTime"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The internally generated identifier for this appointment series",
+            "format": "int64",
+            "example": 12345
           },
           "appointmentType": {
             "type": "string",
@@ -10688,137 +11062,16 @@
             "description": "The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS",
             "example": "SKI"
           },
-          "prisonerNumber": {
-            "type": "string",
-            "description": "The NOMIS OFFENDERS.OFFENDER_ID_DISPLAY value for mapping to a prisoner record in NOMIS",
-            "example": "A1234BC"
-          },
-          "bookingId": {
-            "type": "integer",
-            "description": "The NOMIS OFFENDER_BOOKINGS.OFFENDER_BOOK_ID value for mapping to a prisoner booking record in NOMIS",
-            "format": "int64",
-            "example": 456
-          },
-          "categoryCode": {
-            "type": "string",
-            "description": "The NOMIS REFERENCE_CODES.CODE (DOMAIN = 'INT_SCH_RSN') value for mapping to NOMIS",
-            "example": "CHAP"
-          },
-          "appointmentDescription": {
-            "type": "string",
-            "description": "\n    Free text description for an appointment. This is used to add more context to the appointment category.\n    ",
-            "example": "Meeting with the governor"
-          },
-          "internalLocationId": {
-            "type": "integer",
-            "description": "\n    The NOMIS AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID value for mapping to NOMIS.\n    Will be null if in cell = true\n    ",
-            "format": "int64",
-            "example": 123
-          },
-          "inCell": {
-            "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
-            "example": false
-          },
-          "appointmentDate": {
-            "type": "string",
-            "description": "The date of the appointment instance",
-            "format": "date"
-          },
-          "startTime": {
-            "type": "string",
-            "description": "The starting time of the appointment instance",
-            "format": "partial-time",
-            "example": "09:00"
-          },
-          "endTime": {
-            "type": "string",
-            "description": "The end time of the appointment instance",
-            "format": "partial-time",
-            "example": "10:30"
-          },
-          "comment": {
-            "type": "string",
-            "description": "\n    Notes relating to the appointment instance.\n    Could support adding a note specific to an individual prisoner's attendance of a specific group appointment\n    occurrence. Something that is supported within existing systems\n    ",
-            "example": "This appointment will help prisoner A1234BC adjust to life outside of prison"
-          },
-          "created": {
-            "type": "string",
-            "description": "The date and time this appointment instance was created. Will not change",
-            "format": "date-time"
-          },
-          "createdBy": {
-            "type": "string",
-            "description": "\n    The username of the user authenticated via HMPPS auth that created the appointment instance.\n    Usually a NOMIS username\n    ",
-            "example": "AAA01U"
-          },
-          "updated": {
-            "type": "string",
-            "description": "\n    The date and time this appointment instance was last changed.\n    Will be null if the appointment instance has not been altered since it was created\n    ",
-            "format": "date-time"
-          },
-          "updatedBy": {
-            "type": "string",
-            "description": "\n    The username of the user authenticated via HMPPS auth that edited the appointment instance.\n    Will be null if the appointment instance has not been altered since it was created\n    ",
-            "example": "AAA01U"
-          }
-        },
-        "description": "\n  Represents an appointment instance for a specific prisoner to attend at the specified location, date and time.\n  The fully denormalised representation of the appointments, appointment occurrences and allocations equivalent to a\n  row in the NOMIS OFFENDER_IND_SCHEDULES table.\n  Appointment instances do not exist as database records and are the product of the join between appointment occurrence\n  allocations, appointment occurrences and appointments. \n  The appointment occurrence allocation id is used for the appointment instance id as there is a one to one relationship\n  between appointment occurrence allocations and appointment instances.\n  Appointment instances are used primarily for the one way sync to NOMIS.\n  "
-      },
-      "AppointmentDetails": {
-        "required": [
-          "appointmentName",
-          "appointmentType",
-          "category",
-          "created",
-          "createdBy",
-          "id",
-          "inCell",
-          "occurrences",
-          "prisonCode",
-          "prisoners",
-          "startDate",
-          "startTime"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The internally generated identifier for this appointment",
-            "format": "int64",
-            "example": 12345
-          },
-          "appointmentType": {
-            "type": "string",
-            "description": "The appointment type (INDIVIDUAL or GROUP)",
-            "example": "INDIVIDUAL",
-            "enum": [
-              "INDIVIDUAL",
-              "GROUP"
-            ]
-          },
-          "prisonCode": {
-            "type": "string",
-            "description": "\n    The NOMIS AGENCY_LOCATIONS.AGY_LOC_ID value for mapping to NOMIS.\n    Note, this property does not exist on the appointment occurrences and is therefore consistent across all occurrences\n    ",
-            "example": "SKI"
-          },
           "appointmentName": {
             "type": "string",
-            "description": "\n    The appointment name\n    "
-          },
-          "prisoners": {
-            "type": "array",
-            "description": "\n    Summary of the prisoner or prisoners allocated to the first future occurrence (or most recent past occurrence if all\n    occurrences are in the past) of this appointment. Prisoners are allocated at the occurrence level to allow for per\n    occurrence allocation changes. The occurrence summary does not contain any information on the allocated prisoners\n    as the expected usage is to show a summary of the occurrences then a link to display the full occurrence details.\n    ",
-            "items": {
-              "$ref": "#/components/schemas/PrisonerSummary"
-            }
+            "description": "\n    The appointment series' name combining the optional custom name with the category description. If custom name has been\n    specified, the name format will be \"Custom name (Category description)\" \n    "
           },
           "category": {
             "$ref": "#/components/schemas/AppointmentCategorySummary"
           },
-          "appointmentDescription": {
+          "customName": {
             "type": "string",
-            "description": "\n    Free text description for an appointment. This is used to add more context to the appointment category.\n    ",
+            "description": "\n    Free text name further describing the appointment series. Used as part of the appointment name with the\n    format \"Custom name (Category description) if specified.\n    ",
             "example": "Meeting with the governor"
           },
           "internalLocation": {
@@ -10826,66 +11079,63 @@
           },
           "inCell": {
             "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location will be null if in cell = true\n    ",
+            "description": "\n    Flag to indicate if the location of the appointment series is in cell rather than an internal prison location.\n    Internal location id should be null if in cell = true\n    ",
             "example": false
           },
           "startDate": {
             "type": "string",
-            "description": "The date of the appointment or first appointment occurrence in the series",
+            "description": "The date of the first appointment in the series",
             "format": "date"
           },
           "startTime": {
             "type": "string",
-            "description": "The starting time of the appointment or first appointment occurrence in the series",
+            "description": "The starting time of the appointment or appointments in the series",
             "format": "partial-time",
             "example": "09:00"
           },
           "endTime": {
             "type": "string",
-            "description": "The end time of the appointment or first appointment occurrence in the series",
+            "description": "The end time of the appointment or appointments in the series",
             "format": "partial-time",
             "example": "10:30"
           },
-          "repeat": {
-            "$ref": "#/components/schemas/AppointmentRepeat"
+          "schedule": {
+            "$ref": "#/components/schemas/AppointmentSeriesSchedule"
           },
-          "comment": {
+          "extraInformation": {
             "type": "string",
-            "description": "\n    Notes relating to the appointment\n    ",
+            "description": "\n    Extra information for the prisoner or prisoners attending the appointment or appointments in the series.\n    Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is\n    extra information via the unlock list.\n    ",
             "example": "This appointment will help adjusting to life outside of prison"
           },
-          "created": {
+          "createdTime": {
             "type": "string",
-            "description": "The date and time this appointment was created. Will not change",
+            "description": "The date and time this appointment series was created. Will not change",
             "format": "date-time"
           },
           "createdBy": {
             "$ref": "#/components/schemas/UserSummary"
           },
-          "updated": {
+          "updatedTime": {
             "type": "string",
-            "description": "\n    The date and time one or more occurrences of this appointment was last changed.\n    ",
+            "description": "\n    The date and time one or more appointments in this series was last changed.\n    Will be null if no appointments in the series have been altered since they were created\n    ",
             "format": "date-time"
           },
           "updatedBy": {
             "$ref": "#/components/schemas/UserSummary"
           },
-          "occurrences": {
+          "appointments": {
             "type": "array",
-            "description": "\n    Summary of the individual occurrence or occurrences of this appointment. Non recurring appointments will have a single\n    appointment occurrence containing the same property values as the parent appointment. The same start date, time\n    and end time. Recurring appointments will have a series of occurrences. The first in the series will also\n    contain the same property values as the parent appointment and subsequent occurrences will have start dates\n    following on from the original start date incremented as specified by the appointment's schedule. Each occurrence\n    can be edited independently of the parent. All properties of an occurrence override those of the parent appointment\n    with a null coalesce back to the parent for nullable properties. The full series of occurrences specified by the\n    schedule will be created in advance.\n    ",
+            "description": "\n    Summary of the individual appointment or appointments in this series both expired and scheduled.\n    Non recurring appointment series will have a single appointment containing the same property values as the parent\n    appointment series. The same start date, time and end time. Recurring appointment series will have one or more\n    appointments. The first in the series will also contain the same property values as the parent appointment series\n    and subsequent appointments will have start dates following on from the original start date incremented as specified\n    by the series' schedule. Each appointment can be edited independently of the parent. All properties of an\n    appointment are separate to those of the parent appointment series.\n    The full series of appointments specified by the schedule will have been created in advance.\n    ",
             "items": {
-              "$ref": "#/components/schemas/AppointmentOccurrenceSummary"
+              "$ref": "#/components/schemas/AppointmentSummary"
             }
           }
         },
-        "description": "\n  Described on the UI as an \"Appointment series\" and only shown for repeat appointments.\n  The top level of the standard appointment hierarchy containing full details of the initial property values common to\n  all appointment occurrences in the series for display purposes.\n  Contains the summary collection of all the child appointment occurrences in the series plus the repeat definition if\n  the appointment repeats.\n  The properties at this level cannot be changed via the API however the child occurrence property values can be changed\n  independently to support rescheduling, cancelling and altered attendee lists per occurrence.\n  N.B. there is no collection of allocated prisoners at this top level as all allocations are per occurrence. This is to\n  support attendee modification for each scheduled occurrence and to prevent altering the past by editing allocations\n  in an appointment series where some occurrences have past.\n  "
+        "description": "\n  Described on the UI as an \"Appointment series\" and only shown for repeat appointments.\n  The top level of the standard appointment hierarchy containing full details of the initial property values common to\n  all appointments in the series for display purposes.\n  Contains the summary collection of all the child appointments in the series plus the schedule definition if the\n  appointment series repeats.\n  The properties at this level cannot be changed via the API however the child appointment property values can be changed\n  independently to support rescheduling, cancelling and altered attendee lists per appointment.\n  N.B. there is no collection of attending prisoners at this top level as all attendees are per appointment. This is to\n  support attendee modification for each scheduled appointment and to prevent altering the past by editing attendees\n  in an appointment series where some appointments have past.\n  "
       },
-      "AppointmentOccurrenceSummary": {
+      "AppointmentSummary": {
         "required": [
-          "appointmentName",
-          "category",
           "id",
-          "inCell",
           "isCancelled",
           "isEdited",
           "sequenceNumber",
@@ -10896,78 +11146,45 @@
         "properties": {
           "id": {
             "type": "integer",
-            "description": "The internally generated identifier for this appointment occurrence",
+            "description": "The internally generated identifier for this appointment",
             "format": "int64",
             "example": 123456
           },
           "sequenceNumber": {
             "type": "integer",
-            "description": "The sequence number of this appointment occurrence within the recurring appointment series",
+            "description": "The sequence number of this appointment within the appointment series",
             "format": "int32",
             "example": 3
           },
-          "appointmentName": {
-            "type": "string",
-            "description": "\n    The appointment occurrence's name\n    "
-          },
-          "category": {
-            "$ref": "#/components/schemas/AppointmentCategorySummary"
-          },
-          "appointmentDescription": {
-            "type": "string",
-            "description": "\n    Free text description for an appointment occurrence. This is used to add more context to the category.\n    ",
-            "example": "Meeting with the governor"
-          },
-          "internalLocation": {
-            "$ref": "#/components/schemas/AppointmentLocationSummary"
-          },
-          "inCell": {
-            "type": "boolean",
-            "description": "\n    Flag to indicate if the location of the appointment is in cell rather than an internal prison location.\n    Internal location will be null if in cell = true\n    ",
-            "example": false
-          },
           "startDate": {
             "type": "string",
-            "description": "The date this appointment occurrence is taking place on",
+            "description": "The date this appointment is taking place on",
             "format": "date"
           },
           "startTime": {
             "type": "string",
-            "description": "The starting time of this appointment occurrence",
+            "description": "The starting time of this appointment",
             "format": "partial-time",
             "example": "13:00"
           },
           "endTime": {
             "type": "string",
-            "description": "The end time of this appointment occurrence",
+            "description": "The end time of this appointment",
             "format": "partial-time",
             "example": "13:30"
           },
-          "comment": {
-            "type": "string",
-            "description": "\n    Notes relating to this appointment occurrence. Can be different to the parent appointment if this occurrence has\n    been edited.\n    ",
-            "example": "This appointment occurrence has been rescheduled due to staff availability"
-          },
           "isEdited": {
             "type": "boolean",
-            "description": "\n    Indicates that this appointment occurrence has been independently changed from the original state it was in when\n    it was created as part of a recurring series\n    ",
+            "description": "\n    Indicates that this appointment has been independently changed from the original state it was in when\n    it was created as part of an appointment series\n    ",
             "example": false
           },
           "isCancelled": {
             "type": "boolean",
-            "description": "\n    Indicates that this appointment occurrence has been cancelled\n    ",
+            "description": "\n    Indicates that this appointment has been cancelled\n    ",
             "example": false
-          },
-          "updated": {
-            "type": "string",
-            "description": "\n    The date and time this appointment occurrence was last edited.\n    ",
-            "format": "date-time"
-          },
-          "updatedBy": {
-            "$ref": "#/components/schemas/UserSummary"
           }
         },
-        "description": "\n  Described on the UI as an \"Appointment\" and represents the scheduled event on a specific date and time.\n  Contains the summary information of a limited set of the appointment occurrence properties. N.B. does not contain \n  information on the prisoners allocated to this occurrence to improve API performance.\n  All updates and cancellations happen at this occurrence level with the parent appointment being immutable.\n  "
+        "description": "\n  Described on the UI as an \"Appointment\" and represents the scheduled event on a specific date and time.\n  Contains the summary information of a limited set the appointment properties. N.B. does not contain \n  information on the prisoners attending this appointment to improve API performance.\n  All updates and cancellations happen at this appointment level with the parent appointment series or set being immutable.\n  "
       },
       "ActivityBasic": {
         "required": [

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/appointments/AppointmentsMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/appointments/AppointmentsMigrationService.kt
@@ -73,7 +73,7 @@ class AppointmentsMigrationService(
         val appointment = nomisApiService.getAppointment(eventId)
 
         val migratedAppointment = appointmentsService.createAppointment(appointment.toAppointment())
-        val id = migratedAppointment.occurrences.first().allocations.first().id
+        val id = migratedAppointment.id
         createAppointmentMapping(
           nomisEventId = eventId,
           appointmentInstanceId = id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/appointments/AppointmentsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/appointments/AppointmentsService.kt
@@ -4,12 +4,12 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBody
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.activities.model.Appointment
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.activities.model.AppointmentInstance
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.activities.model.AppointmentMigrateRequest
 
 @Service
 class AppointmentsService(@Qualifier("activitiesApiWebClient") private val webClient: WebClient) {
-  suspend fun createAppointment(appointmentMigrateRequest: AppointmentMigrateRequest): Appointment =
+  suspend fun createAppointment(appointmentMigrateRequest: AppointmentMigrateRequest): AppointmentInstance =
     webClient.post()
       .uri("/migrate-appointment")
       .bodyValue(appointmentMigrateRequest)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/appointments/AppointmentsMigrationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/appointments/AppointmentsMigrationServiceTest.kt
@@ -29,10 +29,8 @@ import org.mockito.kotlin.whenever
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.activities.model.Appointment
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.activities.model.AppointmentInstance
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.activities.model.AppointmentMigrateRequest
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.activities.model.AppointmentOccurrence
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.activities.model.AppointmentOccurrenceAllocation
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.data.MigrationContext
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.CreateMappingResult
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.DuplicateErrorResponse
@@ -826,7 +824,7 @@ internal class AppointmentsMigrationServiceTest {
         aNomisAppointmentResponse(),
       )
 
-      whenever(appointmentsService.createAppointment(any())).thenReturn(sampleAppointment(999))
+      whenever(appointmentsService.createAppointment(any())).thenReturn(sampleAppointmentInstance(999))
       whenever(appointmentsMappingService.createMapping(any(), any())).thenReturn(CreateMappingResult<AppointmentMapping>())
     }
 
@@ -885,7 +883,7 @@ internal class AppointmentsMigrationServiceTest {
         whenever(nomisApiService.getAppointment(any())).thenReturn(
           aNomisAppointmentResponse(),
         )
-        whenever(appointmentsService.createAppointment(any())).thenReturn(sampleAppointment(999))
+        whenever(appointmentsService.createAppointment(any())).thenReturn(sampleAppointmentInstance(999))
 
         service.migrateNomisEntity(
           MigrationContext(
@@ -911,7 +909,7 @@ internal class AppointmentsMigrationServiceTest {
     fun `will not throw exception (and place message back on queue) but create a new retry message`(): Unit =
       runBlocking {
         whenever(nomisApiService.getAppointment(any())).thenReturn(aNomisAppointmentResponse())
-        whenever(appointmentsService.createAppointment(any())).thenReturn(sampleAppointment(999))
+        whenever(appointmentsService.createAppointment(any())).thenReturn(sampleAppointmentInstance(999))
 
         whenever(
           appointmentsMappingService.createMapping(
@@ -999,29 +997,22 @@ internal class AppointmentsMigrationServiceTest {
   }
 }
 
-fun sampleAppointment(appointmentInstanceId: Long) = Appointment(
-  id = 100,
-  appointmentType = Appointment.AppointmentType.INDIVIDUAL,
+fun sampleAppointmentInstance(appointmentInstanceId: Long) = AppointmentInstance(
+  id = appointmentInstanceId,
+  appointmentSeriesId = 10,
+  appointmentId = 50,
+  appointmentAttendeeId = appointmentInstanceId,
+  appointmentType = AppointmentInstance.AppointmentType.INDIVIDUAL,
   prisonCode = "MDI",
-  startDate = LocalDate.parse("2020-05-23"),
+  prisonerNumber = "A1234AA",
+  bookingId = 4567,
+  categoryCode = "MEDO",
+  inCell = false,
+  appointmentDate = LocalDate.parse("2020-05-23"),
   startTime = "11:30",
   endTime = "12:30",
-  comment = "some comment",
-  inCell = false,
-  categoryCode = "",
-  occurrences = listOf(
-    AppointmentOccurrence(
-      1,
-      1,
-      "MEDO",
-      false,
-      LocalDate.parse("2020-05-23"),
-      "11:30",
-      listOf(AppointmentOccurrenceAllocation(appointmentInstanceId, "A1234AA", 4567)),
-      isCancelled = false,
-    ),
-  ),
-  created = LocalDateTime.parse("2023-01-01T12:00:00"),
+  extraInformation = "some comment",
+  createdTime = LocalDateTime.parse("2023-01-01T12:00:00"),
   createdBy = "ITAG_USER",
 )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/ActivitiesApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/ActivitiesApiMockServer.kt
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.springframework.http.HttpStatus
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.appointments.sampleAppointment
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.appointments.sampleAppointmentInstance
 
 class ActivitiesApiExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
   companion object {
@@ -58,7 +58,7 @@ class ActivitiesApiMockServer : WireMockServer(WIREMOCK_PORT) {
   }
 
   fun stubCreateAppointmentForMigration(appointmentInstanceId: Long) {
-    val response = objectMapper.writeValueAsString(sampleAppointment(appointmentInstanceId))
+    val response = objectMapper.writeValueAsString(sampleAppointmentInstance(appointmentInstanceId))
 
     stubFor(
       post(urlMatching("/migrate-appointment"))


### PR DESCRIPTION
There were some fairly substantial changes to the appointments part of the activities API. This was to bring the taxonomy in line with the UI. In brief:

- Appointment Occurrence -> Appointment - the event at a specific date, time and location
- Appointment -> Appointment Series - a collection of Appointments on a regular cadence defined by a schedule
- Bulk Appointment -> Appointment Set - a collection of Appointments taking place on the same date and in the same location but at optionally different times
- Appointment Occurrence Allocation -> Appointment Attendee - a prisoner attending a specific appointment

Additionally some key properties have been renamed to match the UI labels or an activities convention:

- appointmentDescription -> customName
- comments -> extraInformation
- created -> createdTime
- updated -> updatedTime
- cancelled -> cancelledTime

The change that affects appointments migration is that the migrate appointment endpoint now returns an appointment instance to facilitate easier mapping. This PR updates the OpenAPI specification and makes the associated modifications to the codebase.