### PR TITLE
SDIT-1112 Fix flaky non-assoc tests

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/activities/ActivitiesMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/activities/ActivitiesMigrationIntTest.kt
@@ -83,7 +83,7 @@ class ActivitiesMigrationIntTest : SqsIntegrationTestBase() {
         }
 
     private fun waitUntilCompleted() =
-      await.atMost(Duration.ofSeconds(31)) untilAsserted {
+      await atMost Duration.ofSeconds(31) untilAsserted {
         verify(telemetryClient).trackEvent(
           eq("activity-migration-completed"),
           any(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/activities/AllocationMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/activities/AllocationMigrationIntTest.kt
@@ -87,7 +87,7 @@ class AllocationMigrationIntTest : SqsIntegrationTestBase() {
         }
 
     private fun waitUntilCompleted() =
-      await.atMost(Duration.ofSeconds(31)) untilAsserted {
+      await atMost Duration.ofSeconds(31) untilAsserted {
         verify(telemetryClient).trackEvent(
           eq("activity-allocation-migration-completed"),
           any(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/nonassociations/NonAssociationsSynchronisationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/nonassociations/NonAssociationsSynchronisationIntTest.kt
@@ -480,21 +480,23 @@ class NonAssociationsSynchronisationIntTest : SqsIntegrationTestBase() {
           // doesn't retry
           mappingApi.verifyCreateMappingNonAssociation(arrayOf(duplicationNonAssociationId), times = 1)
 
-          verify(telemetryClient).trackEvent(
-            eq("from-nomis-synch-non-association-duplicate"),
-            check {
-              assertThat(it["duplicateNonAssociationId"]).isEqualTo("$duplicationNonAssociationId")
-              assertThat(it["duplicateFirstOffenderNo"]).isEqualTo("A1234BC")
-              assertThat(it["duplicateSecondOffenderNo"]).isEqualTo("D5678EF")
-              assertThat(it["duplicateNomisTypeSequence"]).isEqualTo("2")
-              assertThat(it["existingNonAssociationId"]).isEqualTo("$NON_ASSOCIATION_ID")
-              assertThat(it["existingFirstOffenderNo"]).isEqualTo("A1234BC")
-              assertThat(it["existingSecondOffenderNo"]).isEqualTo("D5678EF")
-              assertThat(it["existingNomisTypeSequence"]).isEqualTo("2")
-              assertThat(it["migrationId"]).isNull()
-            },
-            isNull(),
-          )
+          await untilAsserted {
+            verify(telemetryClient).trackEvent(
+              eq("from-nomis-synch-non-association-duplicate"),
+              check {
+                assertThat(it["duplicateNonAssociationId"]).isEqualTo("$duplicationNonAssociationId")
+                assertThat(it["duplicateFirstOffenderNo"]).isEqualTo("A1234BC")
+                assertThat(it["duplicateSecondOffenderNo"]).isEqualTo("D5678EF")
+                assertThat(it["duplicateNomisTypeSequence"]).isEqualTo("2")
+                assertThat(it["existingNonAssociationId"]).isEqualTo("$NON_ASSOCIATION_ID")
+                assertThat(it["existingFirstOffenderNo"]).isEqualTo("A1234BC")
+                assertThat(it["existingSecondOffenderNo"]).isEqualTo("D5678EF")
+                assertThat(it["existingNomisTypeSequence"]).isEqualTo("2")
+                assertThat(it["migrationId"]).isNull()
+              },
+              isNull(),
+            )
+          }
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingSynchronisationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingSynchronisationIntTest.kt
@@ -351,19 +351,21 @@ class SentencingSynchronisationIntTest : SqsIntegrationTestBase() {
         // doesn't retry
         mappingApi.verifyCreateMappingSentenceAdjustmentIds(arrayOf(ADJUSTMENT_ID), times = 1)
 
-        verify(telemetryClient).trackEvent(
-          eq("from-nomis-synch-adjustment-duplicate"),
-          check {
-            assertThat(it["migrationId"]).isNull()
-            assertThat(it["existingAdjustmentId"]).isEqualTo("10")
-            assertThat(it["duplicateAdjustmentId"]).isEqualTo(ADJUSTMENT_ID)
-            assertThat(it["existingNomisAdjustmentId"]).isEqualTo("$NOMIS_ADJUSTMENT_ID")
-            assertThat(it["duplicateNomisAdjustmentId"]).isEqualTo("$NOMIS_ADJUSTMENT_ID")
-            assertThat(it["existingNomisAdjustmentCategory"]).isEqualTo("SENTENCE")
-            assertThat(it["duplicateNomisAdjustmentCategory"]).isEqualTo("SENTENCE")
-          },
-          isNull(),
-        )
+        await untilAsserted {
+          verify(telemetryClient).trackEvent(
+            eq("from-nomis-synch-adjustment-duplicate"),
+            check {
+              assertThat(it["migrationId"]).isNull()
+              assertThat(it["existingAdjustmentId"]).isEqualTo("10")
+              assertThat(it["duplicateAdjustmentId"]).isEqualTo(ADJUSTMENT_ID)
+              assertThat(it["existingNomisAdjustmentId"]).isEqualTo("$NOMIS_ADJUSTMENT_ID")
+              assertThat(it["duplicateNomisAdjustmentId"]).isEqualTo("$NOMIS_ADJUSTMENT_ID")
+              assertThat(it["existingNomisAdjustmentCategory"]).isEqualTo("SENTENCE")
+              assertThat(it["duplicateNomisAdjustmentCategory"]).isEqualTo("SENTENCE")
+            },
+            isNull(),
+          )
+        }
       }
     }
 


### PR DESCRIPTION
Add the performMigration() solution rather than just waiting untilAsserted inline in each test