### PR TITLE
SDIT-1247 Try to create mapping with DPS returns a 406

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsService.kt
@@ -3,20 +3,20 @@ package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.adjudications
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.function.client.awaitBody
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.adjudications.model.AdjudicationMigrateDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.adjudications.model.MigrateResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.adjudications.model.ReportedAdjudicationResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.awaitBodyOrNotAcceptable
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.awaitBodyOrNotFound
 
 @Service
 class AdjudicationsService(@Qualifier("adjudicationsApiWebClient") private val webClient: WebClient) {
-  suspend fun createAdjudication(adjudicationMigrateRequest: AdjudicationMigrateDto): MigrateResponse =
+  suspend fun createAdjudication(adjudicationMigrateRequest: AdjudicationMigrateDto): MigrateResponse? =
     webClient.post()
       .uri("/reported-adjudications/migrate")
       .bodyValue(adjudicationMigrateRequest)
       .retrieve()
-      .awaitBody()
+      .awaitBodyOrNotAcceptable()
 
   suspend fun getCharge(chargeNumber: String, prisonId: String): ReportedAdjudicationResponse? {
     return webClient.get()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/helpers/WebClientHelpers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/helpers/WebClientHelpers.kt
@@ -10,3 +10,8 @@ suspend inline fun <reified T : Any> WebClient.ResponseSpec.awaitBodyOrNotFound(
   this.bodyToMono<T>()
     .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
     .awaitSingleOrNull()
+
+suspend inline fun <reified T : Any> WebClient.ResponseSpec.awaitBodyOrNotAcceptable(): T? =
+  this.bodyToMono<T>()
+    .onErrorResume(WebClientResponseException.NotAcceptable::class.java) { Mono.empty() }
+    .awaitSingleOrNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/AdjudicationsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/AdjudicationsApiMockServer.kt
@@ -188,6 +188,23 @@ class AdjudicationsApiMockServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
+  fun stubCreateAdjudicationForMigrationWithError(status: Int) {
+    stubFor(
+      post(WireMock.urlMatching("/reported-adjudications/migrate")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(status)
+          .withBody(
+            """
+              {
+                "error": "some error"
+              }
+            """.trimIndent(),
+          ),
+      ),
+    )
+  }
+
   fun verifyCreatedAdjudicationForMigration(builder: RequestPatternBuilder.() -> RequestPatternBuilder = { this }) =
     verify(
       postRequestedFor(WireMock.urlEqualTo("/reported-adjudications/migrate")).builder(),


### PR DESCRIPTION
This wiring in the mapping creation service.

The scenario is as follows

- Try migrate adjudication
- DPS POST fails with timeout but does successfully migrate item
- No mapping is created due to POST timeout
- Retry message
- DPS POST now fails with a 406 (meaning adjudication already migrated)
- Ignore 406 but instead programmatically create mapping ourselves