### PR TITLE
SDIT-1429 Populate Adjudication nomisSplitRecord from NOMIS hasMultipleCharges

### DIFF
--- a/openapi-specs/adjudications-api-docs.json
+++ b/openapi-specs/adjudications-api-docs.json
@@ -12,7 +12,7 @@
       "name": "MIT",
       "url": "https://opensource.org/license/mit-0"
     },
-    "version": "2023-12-21.9824.e5be2a5"
+    "version": "2024-01-17.10093.d951d3a"
   },
   "servers": [
     {
@@ -221,109 +221,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ReportedAdjudicationStatusRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ReportedAdjudicationResponse"
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "406": {
-            "description": "Not able to process the request because the header “Accept” does not match with any of the content types this endpoint can handle",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Too many requests",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "parameters": [
-        {
-          "name": "Active-Caseload",
-          "in": "header",
-          "description": "Current Caseload for request",
-          "required": true,
-          "schema": {
-            "type": "string"
-          },
-          "example": "MDI"
-        }
-      ]
-    },
-    "/reported-adjudications/{chargeNumber}/repair": {
-      "put": {
-        "tags": [
-          "31. Outcomes"
-        ],
-        "summary": "repairs a broken adjudication by providing the outcome that takes precedence",
-        "operationId": "repair",
-        "parameters": [
-          {
-            "name": "chargeNumber",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RepairRequest"
               }
             }
           },
@@ -1396,6 +1293,7 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "reported adjudication status codes",
               "enum": [
                 "ACCEPTED",
                 "REJECTED",
@@ -1412,7 +1310,9 @@
                 "ADJOURNED",
                 "CHARGE_PROVED",
                 "QUASHED",
-                "CORRUPTED"
+                "INVALID_OUTCOME",
+                "INVALID_SUSPENDED",
+                "INVALID_ADA"
               ]
             }
           }
@@ -5185,6 +5085,7 @@
               "type": "array",
               "items": {
                 "type": "string",
+                "description": "reported adjudication status codes",
                 "enum": [
                   "ACCEPTED",
                   "REJECTED",
@@ -5201,7 +5102,9 @@
                   "ADJOURNED",
                   "CHARGE_PROVED",
                   "QUASHED",
-                  "CORRUPTED"
+                  "INVALID_OUTCOME",
+                  "INVALID_SUSPENDED",
+                  "INVALID_ADA"
                 ]
               }
             }
@@ -5627,6 +5530,200 @@
         }
       ]
     },
+    "/reported-adjudications/punishments/{offenderBookingId}/active": {
+      "get": {
+        "tags": [
+          "30. Punishments"
+        ],
+        "summary": "get a list of active punishments by offenderBookingId",
+        "operationId": "getActivePunishments",
+        "parameters": [
+          {
+            "name": "offenderBookingId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActivePunishmentDto"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not able to process the request because the header “Accept” does not match with any of the content types this endpoint can handle",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "Active-Caseload",
+          "in": "header",
+          "description": "Current Caseload for request",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "example": "MDI"
+        }
+      ]
+    },
+    "/reported-adjudications/prisoner/{prisonerNumber}": {
+      "get": {
+        "tags": [
+          "40. Reports"
+        ],
+        "summary": "Get all adjudications for a prisoner",
+        "operationId": "getAdjudicationsForPrisoner",
+        "parameters": [
+          {
+            "name": "prisonerNumber",
+            "in": "path",
+            "description": "prisoner number",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReportedAdjudicationDto"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not able to process the request because the header “Accept” does not match with any of the content types this endpoint can handle",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "Active-Caseload",
+          "in": "header",
+          "description": "Current Caseload for request",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "example": "MDI"
+        }
+      ]
+    },
     "/reported-adjudications/my-reports": {
       "get": {
         "tags": [
@@ -5664,6 +5761,7 @@
               "type": "array",
               "items": {
                 "type": "string",
+                "description": "reported adjudication status codes",
                 "enum": [
                   "ACCEPTED",
                   "REJECTED",
@@ -5680,7 +5778,9 @@
                   "ADJOURNED",
                   "CHARGE_PROVED",
                   "QUASHED",
-                  "CORRUPTED"
+                  "INVALID_OUTCOME",
+                  "INVALID_SUSPENDED",
+                  "INVALID_ADA"
                 ]
               }
             }
@@ -6153,6 +6253,7 @@
               "type": "array",
               "items": {
                 "type": "string",
+                "description": "reported adjudication status codes",
                 "enum": [
                   "ACCEPTED",
                   "REJECTED",
@@ -6169,7 +6270,9 @@
                   "ADJOURNED",
                   "CHARGE_PROVED",
                   "QUASHED",
-                  "CORRUPTED"
+                  "INVALID_OUTCOME",
+                  "INVALID_SUSPENDED",
+                  "INVALID_ADA"
                 ]
               }
             }
@@ -8287,7 +8390,7 @@
           },
           "status": {
             "type": "string",
-            "description": "The status of the reported adjudication",
+            "description": "reported adjudication status codes",
             "enum": [
               "ACCEPTED",
               "REJECTED",
@@ -8304,7 +8407,9 @@
               "ADJOURNED",
               "CHARGE_PROVED",
               "QUASHED",
-              "CORRUPTED"
+              "INVALID_OUTCOME",
+              "INVALID_SUSPENDED",
+              "INVALID_ADA"
             ]
           },
           "reviewedByUserId": {
@@ -8555,7 +8660,7 @@
         "properties": {
           "status": {
             "type": "string",
-            "description": "The status to set the reported adjudication to",
+            "description": "reported adjudication status codes",
             "enum": [
               "ACCEPTED",
               "REJECTED",
@@ -8572,7 +8677,9 @@
               "ADJOURNED",
               "CHARGE_PROVED",
               "QUASHED",
-              "CORRUPTED"
+              "INVALID_OUTCOME",
+              "INVALID_SUSPENDED",
+              "INVALID_ADA"
             ]
           },
           "statusReason": {
@@ -8590,47 +8697,6 @@
         },
         "additionalProperties": false,
         "description": "Request to set the state for an a reported adjudication"
-      },
-      "RepairRequest": {
-        "required": [
-          "correctOutcomeCode",
-          "incorrectOutcomeCode"
-        ],
-        "type": "object",
-        "properties": {
-          "correctOutcomeCode": {
-            "type": "string",
-            "description": "the outcome that takes precedence",
-            "enum": [
-              "REFER_POLICE",
-              "REFER_INAD",
-              "REFER_GOV",
-              "NOT_PROCEED",
-              "DISMISSED",
-              "PROSECUTION",
-              "SCHEDULE_HEARING",
-              "CHARGE_PROVED",
-              "QUASHED"
-            ]
-          },
-          "incorrectOutcomeCode": {
-            "type": "string",
-            "description": "the outcome that is wrong",
-            "enum": [
-              "REFER_POLICE",
-              "REFER_INAD",
-              "REFER_GOV",
-              "NOT_PROCEED",
-              "DISMISSED",
-              "PROSECUTION",
-              "SCHEDULE_HEARING",
-              "CHARGE_PROVED",
-              "QUASHED"
-            ]
-          }
-        },
-        "additionalProperties": false,
-        "description": "repair a broken adjudication"
       },
       "PunishmentRequest": {
         "required": [
@@ -9848,6 +9914,7 @@
           "hearings",
           "incidentDateTime",
           "locationId",
+          "nomisSplitRecord",
           "offence",
           "offenceSequence",
           "oicIncidentId",
@@ -9959,6 +10026,10 @@
             "items": {
               "$ref": "#/components/schemas/DisIssued"
             }
+          },
+          "nomisSplitRecord": {
+            "type": "boolean",
+            "description": "the nomis record has been split into multiple adjudications"
           }
         },
         "additionalProperties": false,
@@ -10523,11 +10594,11 @@
           "sort": {
             "$ref": "#/components/schemas/SortObject"
           },
-          "last": {
-            "type": "boolean"
-          },
           "pageable": {
             "$ref": "#/components/schemas/PageableObject"
+          },
+          "last": {
+            "type": "boolean"
           },
           "first": {
             "type": "boolean"
@@ -10552,10 +10623,10 @@
           "sort": {
             "$ref": "#/components/schemas/SortObject"
           },
-          "paged": {
+          "unpaged": {
             "type": "boolean"
           },
-          "unpaged": {
+          "paged": {
             "type": "boolean"
           },
           "pageNumber": {
@@ -10608,6 +10679,7 @@
       "SuspendedPunishmentDto": {
         "required": [
           "chargeNumber",
+          "corrupted",
           "punishment"
         ],
         "type": "object",
@@ -10615,6 +10687,10 @@
           "chargeNumber": {
             "type": "string",
             "description": "charge number punishment from"
+          },
+          "corrupted": {
+            "type": "boolean",
+            "description": "indicates there is something wrong with this suspended punishment, and its within the last 6 months"
           },
           "punishment": {
             "$ref": "#/components/schemas/PunishmentDto"
@@ -10646,6 +10722,84 @@
         },
         "additionalProperties": false,
         "description": "additional days to activate dto"
+      },
+      "ActivePunishmentDto": {
+        "required": [
+          "chargeNumber",
+          "punishmentType"
+        ],
+        "type": "object",
+        "properties": {
+          "chargeNumber": {
+            "type": "string",
+            "description": "charge number"
+          },
+          "punishmentType": {
+            "type": "string",
+            "description": "punishment type",
+            "enum": [
+              "PRIVILEGE",
+              "EARNINGS",
+              "CONFINEMENT",
+              "REMOVAL_ACTIVITY",
+              "EXCLUSION_WORK",
+              "EXTRA_WORK",
+              "REMOVAL_WING",
+              "ADDITIONAL_DAYS",
+              "PROSPECTIVE_DAYS",
+              "CAUTION",
+              "DAMAGES_OWED"
+            ]
+          },
+          "privilegeType": {
+            "type": "string",
+            "description": "privilege type",
+            "enum": [
+              "CANTEEN",
+              "FACILITIES",
+              "MONEY",
+              "TV",
+              "ASSOCIATION",
+              "GYM",
+              "OTHER"
+            ]
+          },
+          "otherPrivilege": {
+            "type": "string",
+            "description": "other privilege description"
+          },
+          "days": {
+            "type": "integer",
+            "description": "days applied",
+            "format": "int32"
+          },
+          "startDate": {
+            "type": "string",
+            "description": "start date",
+            "format": "date"
+          },
+          "lastDay": {
+            "type": "string",
+            "description": "last day",
+            "format": "date"
+          },
+          "amount": {
+            "type": "number",
+            "description": "amount",
+            "format": "double"
+          },
+          "stoppagePercentage": {
+            "type": "integer",
+            "description": "stoppage percentage",
+            "format": "int32"
+          },
+          "activatedFrom": {
+            "type": "string",
+            "description": "activated from report"
+          }
+        },
+        "additionalProperties": false,
+        "description": "active punishment dto"
       },
       "HearingSummaryDto": {
         "required": [
@@ -10697,7 +10851,7 @@
           },
           "status": {
             "type": "string",
-            "description": "reported adjudication status",
+            "description": "reported adjudication status codes",
             "enum": [
               "ACCEPTED",
               "REJECTED",
@@ -10714,7 +10868,9 @@
               "ADJOURNED",
               "CHARGE_PROVED",
               "QUASHED",
-              "CORRUPTED"
+              "INVALID_OUTCOME",
+              "INVALID_SUSPENDED",
+              "INVALID_ADA"
             ]
           }
         },
@@ -10808,11 +10964,11 @@
           "sort": {
             "$ref": "#/components/schemas/SortObject"
           },
-          "last": {
-            "type": "boolean"
-          },
           "pageable": {
             "$ref": "#/components/schemas/PageableObject"
+          },
+          "last": {
+            "type": "boolean"
           },
           "first": {
             "type": "boolean"
@@ -11215,11 +11371,11 @@
           "sort": {
             "$ref": "#/components/schemas/SortObject"
           },
-          "last": {
-            "type": "boolean"
-          },
           "pageable": {
             "$ref": "#/components/schemas/PageableObject"
+          },
+          "last": {
+            "type": "boolean"
           },
           "first": {
             "type": "boolean"

--- a/openapi-specs/nomis-sync-api-docs.json
+++ b/openapi-specs/nomis-sync-api-docs.json
@@ -7,7 +7,7 @@
       "name": "HMPPS Digital Studio",
       "email": "feedback@digital.justice.gov.uk"
     },
-    "version": "2024-01-05.6038.79cdfc0"
+    "version": "2024-01-17.6165.474dc9b"
   },
   "servers": [
     {
@@ -3070,6 +3070,104 @@
         }
       }
     },
+    "/prisoners/{offenderNo}/sentencing/court-cases/{caseId}/court-appearances": {
+      "post": {
+        "tags": [
+          "sentencing-resource"
+        ],
+        "summary": "Creates a new Court Appearance",
+        "description": "Required role NOMIS_SENTENCING Creates a new Court Appearance for the offender,latest booking and given Court Case",
+        "operationId": "createCourtAppearance",
+        "parameters": [
+          {
+            "name": "offenderNo",
+            "in": "path",
+            "description": "Offender no",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Offender no",
+              "example": "AB1234A"
+            },
+            "example": "AB1234A"
+          },
+          {
+            "name": "caseId",
+            "in": "path",
+            "description": "Case Id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Case Id",
+              "example": 34565
+            },
+            "example": 34565
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CourtAppearanceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created Court Appearance",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateCourtAppearanceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Supplied data is invalid, for instance missing required fields or invalid values. See schema for details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden to access this endpoint when role NOMIS_SENTENCING not present",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Court case does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/prisoners/{offenderNo}/adjudications": {
       "post": {
         "tags": [
@@ -4600,6 +4698,154 @@
           },
           "403": {
             "description": "Forbidden, requires role SYNCHRONISATION_REPORTING",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/questionnaires/{questionnaireId}": {
+      "get": {
+        "tags": [
+          "incident-questionnaire-resource"
+        ],
+        "summary": "Get incident questionnaire details",
+        "description": "Gets incident questionnaire details. Requires role NOMIS_INCIDENTS",
+        "operationId": "getQuestionnaire",
+        "parameters": [
+          {
+            "name": "questionnaireId",
+            "in": "path",
+            "description": "Incident Questionnaire id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Incident Questionnaire id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuestionnaireResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden, requires role NOMIS_INCIDENTS",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/questionnaires/ids": {
+      "get": {
+        "tags": [
+          "incident-questionnaire-resource"
+        ],
+        "summary": "get questionnaire IDs by filter",
+        "description": "Retrieves a paged list of incident questionnaire ids by filter. Requires ROLE_NOMIS_INCIDENTS.",
+        "operationId": "getIdsByFilter",
+        "parameters": [
+          {
+            "name": "pageRequest",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Pageable"
+            }
+          },
+          {
+            "name": "fromDate",
+            "in": "query",
+            "description": "Filter results by those that were created on or after the given date",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "example": "2021-11-03"
+          },
+          {
+            "name": "toDate",
+            "in": "query",
+            "description": "Filter results by those that were created on or before the given date",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "example": "2021-11-03"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pageable list of ids are returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageQuestionnaireIdResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden to access this endpoint when role NOMIS_INCIDENTS not present",
             "content": {
               "application/json": {
                 "schema": {
@@ -8405,8 +8651,6 @@
           "courtEventType",
           "courtId",
           "eventDate",
-          "eventStatus",
-          "nextCourtId",
           "startTime"
         ],
         "type": "object",
@@ -8423,17 +8667,11 @@
           "courtEventType": {
             "type": "string"
           },
-          "eventStatus": {
-            "type": "string"
-          },
           "courtId": {
             "type": "string"
           },
           "outcomeReasonCode": {
             "type": "string"
-          },
-          "nextEventRequestFlag": {
-            "type": "boolean"
           },
           "nextEventDate": {
             "type": "string",
@@ -8488,15 +8726,11 @@
       "OffenderChargeRequest": {
         "required": [
           "mostSeriousFlag",
-          "offenceCode",
-          "statuteCode"
+          "offenceCode"
         ],
         "type": "object",
         "properties": {
           "offenceCode": {
-            "type": "string"
-          },
-          "statuteCode": {
             "type": "string"
           },
           "offencesCount": {
@@ -10170,6 +10404,7 @@
           "adjustmentDays",
           "adjustmentType",
           "bookingId",
+          "hasBeenReleased",
           "hiddenFromUsers",
           "id",
           "offenderNo",
@@ -10186,6 +10421,10 @@
             "type": "integer",
             "description": "The booking id",
             "format": "int64"
+          },
+          "hasBeenReleased": {
+            "type": "boolean",
+            "description": "Indicates whether for this booking the prisoner has been released"
           },
           "offenderNo": {
             "type": "string",
@@ -10253,6 +10492,256 @@
           }
         },
         "description": "Adjustment type"
+      },
+      "AnswerResponse": {
+        "required": [
+          "active",
+          "answer",
+          "answerSequence",
+          "commentRequired",
+          "dateRequired",
+          "id",
+          "listSequence"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The answer id",
+            "format": "int64"
+          },
+          "answer": {
+            "type": "string",
+            "description": "The answer text"
+          },
+          "answerSequence": {
+            "type": "integer",
+            "description": "The answer id used to set the listSequence values",
+            "format": "int32",
+            "example": 1
+          },
+          "listSequence": {
+            "type": "integer",
+            "description": "The order of the answers",
+            "format": "int32",
+            "example": 1
+          },
+          "active": {
+            "type": "boolean",
+            "description": "If the answer is active",
+            "example": true
+          },
+          "expiryDate": {
+            "type": "string",
+            "description": "The date the answer is no longer used",
+            "format": "date"
+          },
+          "nextQuestion": {
+            "$ref": "#/components/schemas/QuestionResponse"
+          },
+          "dateRequired": {
+            "type": "boolean",
+            "description": "If the answer should include a date",
+            "example": true
+          },
+          "commentRequired": {
+            "type": "boolean",
+            "description": "If the answer should include a comment",
+            "example": true
+          }
+        },
+        "description": "List of Answers to this question"
+      },
+      "QuestionResponse": {
+        "required": [
+          "active",
+          "answers",
+          "id",
+          "listSequence",
+          "multipleAnswers",
+          "question",
+          "questionSequence"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The question id",
+            "format": "int64"
+          },
+          "question": {
+            "type": "string",
+            "description": "The question text"
+          },
+          "answers": {
+            "type": "array",
+            "description": "List of Answers to this question",
+            "items": {
+              "$ref": "#/components/schemas/AnswerResponse"
+            }
+          },
+          "active": {
+            "type": "boolean",
+            "description": "If the question is active",
+            "example": true
+          },
+          "expiryDate": {
+            "type": "string",
+            "description": "The date the question is no longer used",
+            "format": "date"
+          },
+          "multipleAnswers": {
+            "type": "boolean",
+            "description": "If the question has multiple answers",
+            "example": true
+          },
+          "questionSequence": {
+            "type": "integer",
+            "description": "The question id used to set the listSequence values",
+            "format": "int32",
+            "example": 1
+          },
+          "listSequence": {
+            "type": "integer",
+            "description": "The order of the questions",
+            "format": "int32",
+            "example": 1
+          }
+        },
+        "description": "List of Questions (and associated Answers) for this Questionnaire"
+      },
+      "QuestionnaireResponse": {
+        "required": [
+          "active",
+          "code",
+          "createdBy",
+          "createdDate",
+          "id",
+          "listSequence",
+          "questions"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The unique identifier of the questionnaire",
+            "format": "int64"
+          },
+          "description": {
+            "type": "string",
+            "description": "A description of the questionnaire",
+            "example": "Escape from Establishment"
+          },
+          "code": {
+            "type": "string",
+            "description": "Code to identify this questionnaire",
+            "example": "ESCAPE_EST"
+          },
+          "active": {
+            "type": "boolean",
+            "description": "If the questionnaire is active",
+            "example": true
+          },
+          "listSequence": {
+            "type": "integer",
+            "description": "Sequence value of the questionnaires",
+            "format": "int32",
+            "example": 1
+          },
+          "questions": {
+            "type": "array",
+            "description": "List of Questions (and associated Answers) for this Questionnaire",
+            "items": {
+              "$ref": "#/components/schemas/QuestionResponse"
+            }
+          },
+          "expiryDate": {
+            "type": "string",
+            "description": "The date the questionnaire is no longer used",
+            "format": "date"
+          },
+          "createdDate": {
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
+            "type": "string",
+            "description": "Questionnaire created date",
+            "example": "2021-07-05T10:35:17"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Questionnaire created by"
+          },
+          "modifiedDate": {
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
+            "type": "string",
+            "description": "Questionnaire modified date",
+            "example": "2021-07-05T10:35:17"
+          },
+          "modifiedBy": {
+            "type": "string",
+            "description": "Questionnaire modified by"
+          }
+        },
+        "description": "Questionnaire"
+      },
+      "PageQuestionnaireIdResponse": {
+        "type": "object",
+        "properties": {
+          "totalPages": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalElements": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuestionnaireIdResponse"
+            }
+          },
+          "number": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/SortObject"
+          },
+          "numberOfElements": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageable": {
+            "$ref": "#/components/schemas/PageableObject"
+          },
+          "empty": {
+            "type": "boolean"
+          }
+        }
+      },
+      "QuestionnaireIdResponse": {
+        "required": [
+          "questionnaireId"
+        ],
+        "type": "object",
+        "properties": {
+          "questionnaireId": {
+            "type": "integer",
+            "description": "The questionnaire id",
+            "format": "int64"
+          }
+        },
+        "description": "Questionnaire id"
       },
       "IncentiveLevel": {
         "required": [
@@ -11026,6 +11515,7 @@
           "adjustmentDays",
           "adjustmentType",
           "bookingId",
+          "hasBeenReleased",
           "id",
           "offenderNo"
         ],
@@ -11040,6 +11530,10 @@
             "type": "integer",
             "description": "The booking id",
             "format": "int64"
+          },
+          "hasBeenReleased": {
+            "type": "boolean",
+            "description": "Indicates whether for this booking the prisoner has been released"
           },
           "offenderNo": {
             "type": "string",
@@ -11980,6 +12474,7 @@
           "bookingId",
           "charge",
           "gender",
+          "hasMultipleCharges",
           "hearings",
           "incident",
           "investigations",
@@ -12041,6 +12536,10 @@
             "items": {
               "$ref": "#/components/schemas/Hearing"
             }
+          },
+          "hasMultipleCharges": {
+            "type": "boolean",
+            "description": "indicates if this charge was part of a larger multi-charge adjudication in NOMIS"
           }
         },
         "description": "The requested adjudication charge and associated adjudication details. Note: the adjudication may have other charges associated with it"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsMigrationService.kt
@@ -109,6 +109,7 @@ fun AdjudicationChargeResponse.toAdjudication(): AdjudicationMigrateDto =
     punishments = this.hearings.flatMap { it.toHearingResultAwards() },
     hearings = this.hearings.map { it.toHearing() },
     disIssued = this.hearings.flatMap { hearing -> hearing.notifications.map { it.toIssued() } },
+    nomisSplitRecord = this.hasMultipleCharges,
   )
 
 private fun AdjudicationCharge.toEvidence(incident: AdjudicationIncident): List<MigrateEvidence> =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationMappingCreatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationMappingCreatorTest.kt
@@ -524,6 +524,7 @@ class AdjudicationMappingCreatorTest {
       ),
       investigations = listOf(),
       hearings = hearings,
+      hasMultipleCharges = false,
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationTransformationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationTransformationTest.kt
@@ -46,6 +46,12 @@ class AdjudicationTransformationTest {
   }
 
   @Test
+  fun `will set NOMIS split record field for multiple charges`() {
+    assertThat(nomisAdjudicationCharge(hasMultipleCharges = true).toAdjudication().nomisSplitRecord).isTrue()
+    assertThat(nomisAdjudicationCharge(hasMultipleCharges = false).toAdjudication().nomisSplitRecord).isFalse()
+  }
+
+  @Test
   fun `will user who created and reported the incident`() {
     val nomisAdjudication =
       nomisAdjudicationCharge(reportingStaffUsername = "F.LAST", createdByStaffUsername = "A.BEANS")
@@ -1200,6 +1206,7 @@ private fun nomisAdjudicationCharge(
   hearings: List<Hearing> = emptyList(),
   chargeEvidence: String? = null,
   chargeReportDetail: String? = null,
+  hasMultipleCharges: Boolean = false,
 ): AdjudicationChargeResponse {
   return AdjudicationChargeResponse(
     adjudicationSequence = 10,
@@ -1251,5 +1258,6 @@ private fun nomisAdjudicationCharge(
     hearings = hearings,
     adjudicationNumber = adjudicationNumber,
     comment = "comment",
+    hasMultipleCharges = hasMultipleCharges,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsMigrationIntTest.kt
@@ -153,6 +153,7 @@ class AdjudicationsMigrationIntTest : SqsIntegrationTestBase() {
     "offenderNo": "$offenderNo",
     "bookingId": $bookingId,
     "adjudicationNumber": $adjudicationNumber,
+    "hasMultipleCharges": false,
     "gender": {
         "code": "M",
         "description": "Male"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsServiceTest.kt
@@ -63,6 +63,7 @@ internal class AdjudicationsServiceTest {
             punishments = emptyList(),
             hearings = emptyList(),
             disIssued = emptyList(),
+            nomisSplitRecord = false,
           ),
         )
       }
@@ -100,6 +101,7 @@ internal class AdjudicationsServiceTest {
           punishments = emptyList(),
           hearings = emptyList(),
           disIssued = emptyList(),
+          nomisSplitRecord = false,
         ),
       )
 
@@ -132,6 +134,7 @@ internal class AdjudicationsServiceTest {
             punishments = emptyList(),
             hearings = emptyList(),
             disIssued = emptyList(),
+            nomisSplitRecord = false,
           ),
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/NomisApiMockServer.kt
@@ -948,6 +948,7 @@ fun adjudicationResponse(
     "adjudicationSequence": 1,
     "offenderNo": "$offenderNo",
     "bookingId": 1201725,
+    "hasMultipleCharges": false,
     "adjudicationNumber": $adjudicationNumber,
     "gender": {
         "code": "M",


### PR DESCRIPTION
DPS requires the `nomisSplitRecord` flag to indicate that the original NOMIS record had multiple charges which are now multiple Adjudications in DPS.

DPS will apparently drive additional info copy in their UI from this flag