### PR TITLE
SDIT-1436 Reduce Adjudication listener threads to 8

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsMigrationMessageListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/adjudications/AdjudicationsMigrationMessageListener.kt
@@ -26,7 +26,12 @@ class AdjudicationsMigrationMessageListener(
     adjudicationsMigrationService,
   ) {
 
-  @SqsListener(ADJUDICATIONS_QUEUE_ID, factory = "hmppsQueueContainerFactoryProxy")
+  @SqsListener(
+    ADJUDICATIONS_QUEUE_ID,
+    factory = "hmppsQueueContainerFactoryProxy",
+    maxConcurrentMessages = "8",
+    maxMessagesPerPoll = "8",
+  )
   @WithSpan(value = "dps-syscon-migration_adjudications_queue", kind = SpanKind.SERVER)
   fun onAdjudicationMessage(message: String, rawMessage: Message): CompletableFuture<Void>? {
     return onMessage(message, rawMessage)


### PR DESCRIPTION
Connection pool size is 10 and default thread listener is 10 - when any other endpoint is called that requires a connection (e.g. healthcheck), it can use more connections than in the pool - hence 500 errors. This is a particular issue during early stages of Adjudication migration due to the get IDs endpoint being so CPU intensive.