### PR TITLE
SDIT-1375 Reduce Incidents Listener threads to 8

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/incidents/IncidentsMigrationMessageListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/incidents/IncidentsMigrationMessageListener.kt
@@ -25,7 +25,7 @@ class IncidentsMigrationMessageListener(
   incidentsMigrationService,
 ) {
 
-  @SqsListener(INCIDENTS_QUEUE_ID, factory = "hmppsQueueContainerFactoryProxy")
+  @SqsListener(INCIDENTS_QUEUE_ID, factory = "hmppsQueueContainerFactoryProxy", maxConcurrentMessages = "8", maxMessagesPerPoll = "8")
   @WithSpan(value = "dps-syscon-migration_incidents_queue", kind = SpanKind.SERVER)
   fun onIncidentMessage(message: String, rawMessage: Message): CompletableFuture<Void>? {
     return onMessage(message, rawMessage)


### PR DESCRIPTION
Connection pool size is 10 and default thread listener is 10 - when any other endpoint is called that requires a connection (e.g. healthcheck), it can use more connections than in the pool - hence 500 errors. This is a particular issue during early stages of incidents migration due to the get IDs endpoint being so CPU intensive.
This is the same change made to the AdjudicationsMigrationMessageListener.