### PR TITLE
SDIT-1503 Add prison alert event handling for alerts

### DIFF
--- a/helm_deploy/hmpps-prisoner-from-nomis-migration/values.yaml
+++ b/helm_deploy/hmpps-prisoner-from-nomis-migration/values.yaml
@@ -101,6 +101,10 @@ generic-service:
       HMPPS_SQS_QUEUES_EVENTINCIDENTS_QUEUE_NAME: "sqs_name"
     prisoner-from-nomis-incidents-dl-queue:
       HMPPS_SQS_QUEUES_EVENTINCIDENTS_DLQ_NAME: "sqs_name"
+    prison-events-alerts-queue:
+      HMPPS_SQS_QUEUES_EVENTALERTS_QUEUE_NAME: "sqs_name"
+    prison-events-alerts-dl-queue:
+      HMPPS_SQS_QUEUES_EVENTALERTS_DLQ_NAME: "sqs_name"
     rds-database:
       SPRING_FLYWAY_USER: "database_username"
       SPRING_FLYWAY_PASSWORD: "database_password"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -28,6 +28,8 @@ generic-prometheus-alerts:
     - "syscon-devs-dev-prisoner_from_nomis_visits_dl_queue"
     - "syscon-devs-dev-prisoner_from_nomis_sentencing_queue"
     - "syscon-devs-dev-prisoner_from_nomis_sentencing_dl_queue"
+    - "syscon-devs-dev-prisoner_from_nomis_alerts_queue"
+    - "syscon-devs-dev-prisoner_from_nomis_alerts_dl_queue"
     - "syscon-devs-dev-prisoner_from_nomis_incidents_queue"
     - "syscon-devs-dev-prisoner_from_nomis_incidents_dl_queue"
     - "syscon-devs-dev-migration_sentencing_queue"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -38,6 +38,8 @@ generic-prometheus-alerts:
     - "syscon-devs-preprod-prisoner_from_nomis_sentencing_dl_queue"
     - "syscon-devs-preprod-prisoner_from_nomis_incidents_queue"
     - "syscon-devs-preprod-prisoner_from_nomis_incidents_dl_queue"
+    - "syscon-devs-preprod-prisoner_from_nomis_alerts_queue"
+    - "syscon-devs-preprod-prisoner_from_nomis_alerts_dl_queue"
     - "syscon-devs-preprod-migration_sentencing_queue"
     - "syscon-devs-preprod-migration_sentencing_dlq"
     - "syscon-devs-preprod-migration_visits_queue"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -30,6 +30,8 @@ generic-service:
     FEATURE_EVENT_INCIDENT-DELETED-PARTIES: false
     FEATURE_EVENT_INCIDENT-DELETED-RESPONSES: false
     FEATURE_EVENT_INCIDENT-DELETED-REQUIREMENTS: false
+    FEATURE_EVENT_ALERT-UPDATED: false
+    FEATURE_EVENT_ALERT-INSERTED: false
 
 generic-prometheus-alerts:
   rdsAlertsDatabases:
@@ -41,6 +43,8 @@ generic-prometheus-alerts:
     - "syscon-devs-prod-prisoner_from_nomis_sentencing_dl_queue"
     - "syscon-devs-prod-prisoner_from_nomis_incidents_queue"
     - "syscon-devs-prod-prisoner_from_nomis_incidents_dl_queue"
+    - "syscon-devs-prod-prisoner_from_nomis_alerts_queue"
+    - "syscon-devs-prod-prisoner_from_nomis_alerts_dl_queue"
     - "syscon-devs-prod-migration_sentencing_queue"
     - "syscon-devs-prod-migration_sentencing_dlq"
     - "syscon-devs-prod-migration_visits_queue"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsPrisonOffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsPrisonOffenderEventListener.kt
@@ -1,0 +1,73 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.awspring.cloud.sqs.annotation.SqsListener
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.annotations.WithSpan
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.future.future
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.EventFeatureSwitch
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.SQSMessage
+import java.util.concurrent.CompletableFuture
+
+@Service
+class AlertsPrisonOffenderEventListener(
+  private val objectMapper: ObjectMapper,
+  private val eventFeatureSwitch: EventFeatureSwitch,
+  private val alertsSynchronisationService: AlertsSynchronisationService,
+) {
+
+  private companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @SqsListener("eventalerts", factory = "hmppsQueueContainerFactoryProxy")
+  @WithSpan(value = "syscon-devs-prisoner_from_nomis_alerts_queue", kind = SpanKind.SERVER)
+  fun onMessage(message: String): CompletableFuture<Void> {
+    log.debug("Received offender event message {}", message)
+    val sqsMessage: SQSMessage = objectMapper.readValue(message)
+    return asCompletableFuture {
+      when (sqsMessage.Type) {
+        "Notification" -> {
+          val eventType = sqsMessage.MessageAttributes!!.eventType.Value
+          if (eventFeatureSwitch.isEnabled(eventType)) {
+            when (eventType) {
+              "ALERT-UPDATED" -> alertsSynchronisationService.nomisAlertUpdated((sqsMessage.Message.fromJson()))
+              "ALERT-INSERTED" -> alertsSynchronisationService.nomisAlertInserted((sqsMessage.Message.fromJson()))
+
+              else -> log.info("Received a message I wasn't expecting {}", eventType)
+            }
+          } else {
+            log.info("Feature switch is disabled for event {}", eventType)
+          }
+        }
+      }
+    }
+  }
+
+  private inline fun <reified T> String.fromJson(): T =
+    objectMapper.readValue(this)
+}
+
+data class AlertInsertedEvent(
+  val bookingId: Long,
+  val alertSeq: Long,
+)
+
+data class AlertUpdatedEvent(
+  val bookingId: Long,
+  val alertSeq: Long,
+)
+
+private fun asCompletableFuture(
+  process: suspend () -> Unit,
+): CompletableFuture<Void> {
+  return CoroutineScope(Dispatchers.Default).future {
+    process()
+  }.thenAccept { }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsSynchronisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsSynchronisationService.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class AlertsSynchronisationService {
+  private companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  suspend fun nomisAlertInserted(event: AlertInsertedEvent) {
+    log.debug("TODO: handle {}", event)
+  }
+
+  suspend fun nomisAlertUpdated(event: AlertUpdatedEvent) {
+    log.debug("TODO: handle {}", event)
+  }
+}

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -34,3 +34,6 @@ hmpps.sqs:
     eventincidents:
       queueName: ${random.uuid}
       dlqName: ${random.uuid}
+    eventalerts:
+      queueName: ${random.uuid}
+      dlqName: ${random.uuid}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsSynchronisationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsSynchronisationIntTest.kt
@@ -1,0 +1,89 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts
+
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.system.CapturedOutput
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.SqsIntegrationTestBase
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.sendMessage
+
+private const val BOOKING_ID = 1234L
+private const val ALERT_SEQUENCE = 1L
+
+class AlertsSynchronisationIntTest : SqsIntegrationTestBase() {
+
+  @Nested
+  @DisplayName("ALERT-INSERTED")
+  inner class AlertInserted {
+    @Nested
+    @DisplayName("Check queue config")
+    inner class QueueConfig {
+      @BeforeEach
+      fun setUp() {
+        awsSqsAlertOffenderEventsClient.sendMessage(
+          alertsQueueOffenderEventsUrl,
+          alertEvent(
+            eventType = "ALERT-INSERTED",
+          ),
+        )
+      }
+
+      @Test
+      fun `will read the message`(output: CapturedOutput) {
+        await untilAsserted {
+          await untilAsserted {
+            assertThat(output.out).contains("AlertInsertedEvent(bookingId=1234, alertSeq=1)")
+          }
+        }
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("ALERT-UPDATED")
+  inner class AlertUpdated {
+    @Nested
+    @DisplayName("Check queue config")
+    inner class QueueConfig {
+      @BeforeEach
+      fun setUp() {
+        awsSqsAlertOffenderEventsClient.sendMessage(
+          alertsQueueOffenderEventsUrl,
+          alertEvent(
+            eventType = "ALERT-UPDATED",
+          ),
+        )
+      }
+
+      @Test
+      fun `will read the message`(output: CapturedOutput) {
+        await untilAsserted {
+          await untilAsserted {
+            assertThat(output.out).contains("AlertUpdatedEvent(bookingId=1234, alertSeq=1)")
+          }
+        }
+      }
+    }
+  }
+}
+
+fun alertEvent(
+  eventType: String,
+  bookingId: Long = BOOKING_ID,
+  alertSeq: Long = ALERT_SEQUENCE,
+) = """{
+    "MessageId": "ae06c49e-1f41-4b9f-b2f2-dcca610d02cd", "Type": "Notification", "Timestamp": "2019-10-21T14:01:18.500Z", 
+    "Message": "{\"eventId\":\"5958295\",\"eventType\":\"$eventType\",\"eventDatetime\":\"2019-10-21T15:00:25.489964\",\"bookingId\": \"$bookingId\",\"alertSeq\": \"$alertSeq\",\"nomisEventType\":\"OFF_ALERT_UPDATE\",\"alertType\":\"L\",\"alertCode\":\"LCE\",\"alertDateTime\":\"2024-02-14T13:24:11\" }",
+    "TopicArn": "arn:aws:sns:eu-west-1:000000000000:offender_events", 
+    "MessageAttributes": {
+      "eventType": {"Type": "String", "Value": "$eventType"}, 
+      "id": {"Type": "String", "Value": "8b07cbd9-0820-0a0f-c32f-a9429b618e0b"}, 
+      "contentType": {"Type": "String", "Value": "text/plain;charset=UTF-8"}, 
+      "timestamp": {"Type": "Number.java.lang.Long", "Value": "1571666478344"}
+    }
+}
+""".trimIndent()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/SqsIntegrationTestBase.kt
@@ -110,6 +110,12 @@ class SqsIntegrationTestBase : TestBase() {
   internal val awsSqsIncidentsOffenderEventsClient by lazy { incidentsOffenderEventsQueue.sqsClient }
   internal val awsSqsIncidentsOffenderEventDlqClient by lazy { incidentsOffenderEventsQueue.sqsDlqClient as SqsAsyncClient }
 
+  internal val alertsOffenderEventsQueue by lazy { hmppsQueueService.findByQueueId("eventalerts") as HmppsQueue }
+  internal val alertsQueueOffenderEventsUrl by lazy { alertsOffenderEventsQueue.queueUrl }
+  internal val alertsQueueOffenderEventsDlqUrl by lazy { alertsOffenderEventsQueue.dlqUrl as String }
+  internal val awsSqsAlertOffenderEventsClient by lazy { alertsOffenderEventsQueue.sqsClient }
+  internal val awsSqsAlertsOffenderEventDlqClient by lazy { alertsOffenderEventsQueue.sqsDlqClient as SqsAsyncClient }
+
   private val allQueues by lazy {
     listOf(
       incidentsOffenderEventsQueue,
@@ -121,6 +127,7 @@ class SqsIntegrationTestBase : TestBase() {
       incidentsMigrationQueue,
       sentencingMigrationQueue,
       visitsMigrationQueue,
+      alertsOffenderEventsQueue,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/TestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/TestBase.kt
@@ -1,11 +1,14 @@
 package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration
 
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.system.OutputCaptureExtension
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.config.PostgresContainer
 
 @ActiveProfiles("test")
+@ExtendWith(OutputCaptureExtension::class)
 abstract class TestBase {
 
   companion object {


### PR DESCRIPTION
Introduced handling for "ALERT-UPDATED" and "ALERT-INSERTED" events in the HMPPS Prisoner from NOMIS migration service. Modified YAML values to add features for these events and updated queues to manage alerts. Added new classes for service and test of alert synchronization and updated existing classes to support these changes.