### PR TITLE
SDIT-1591 Add prisoner merge event handling for Sentencing Adjustment

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -30,6 +30,7 @@ generic-service:
     FEATURE_EVENT_INCIDENT-DELETED-REQUIREMENTS: false
     FEATURE_EVENT_ALERT-UPDATED: false
     FEATURE_EVENT_ALERT-INSERTED: false
+    FEATURE_EVENT_BOOKING_NUMBER-CHANGED: false
 
 generic-prometheus-alerts:
   rdsAlertsDatabases:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsNomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsNomisApiService.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitBody
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.SentencingAdjustmentsResponse
+
+@Service
+class SentencingAdjustmentsNomisApiService(@Qualifier("nomisApiWebClient") private val webClient: WebClient) {
+  suspend fun getAllByBookingId(bookingId: Long): SentencingAdjustmentsResponse = webClient.get()
+    .uri(
+      "/prisoners/booking-id/{bookingId}/sentencing-adjustments?active-only=false",
+      bookingId,
+    )
+    .retrieve()
+    .awaitBody()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingPrisonOffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingPrisonOffenderEventListener.kt
@@ -54,6 +54,10 @@ class SentencingPrisonOffenderEventListener(
                 (sqsMessage.Message.fromJson()),
               )
 
+              "BOOKING_NUMBER-CHANGED" -> sentencingAdjustmentsSynchronisationService.synchronisePrisonerMerge(
+                (sqsMessage.Message.fromJson()),
+              )
+
               else -> log.info("Received a message I wasn't expecting {}", eventType)
             }
           } else {
@@ -87,6 +91,9 @@ data class KeyDateAdjustmentOffenderEvent(
   val auditModuleName: String?,
 )
 
+data class PrisonerMergeEvent(
+  val bookingId: Long,
+)
 private fun asCompletableFuture(
   process: suspend () -> Unit,
 ): CompletableFuture<Void> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/SqsIntegrationTestBase.kt
@@ -4,10 +4,14 @@ import com.microsoft.applicationinsights.TelemetryClient
 import org.awaitility.Awaitility
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilAsserted
 import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.SpyBean
@@ -153,6 +157,10 @@ class SqsIntegrationTestBase : TestBase() {
     roles: List<String> = listOf(),
     scopes: List<String> = listOf(),
   ): (HttpHeaders) -> Unit = jwtAuthHelper.setAuthorisation(user, roles, scopes)
+
+  internal fun waitForAnyProcessingToComplete() {
+    await untilAsserted { verify(telemetryClient).trackEvent(any(), any(), isNull()) }
+  }
 
   companion object {
     private val localStackContainer = LocalStackContainer.instance

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsNomisApiMockServer.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.KeyDateAdjustmentResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.SentenceAdjustmentResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.SentencingAdjustmentsResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.NomisApiExtension.Companion.nomisApi
+
+@Component
+class SentencingAdjustmentsNomisApiMockServer(private val objectMapper: ObjectMapper) {
+  fun stubGetAllByBookingId(
+    bookingId: Long = 123456,
+    sentenceAdjustments: List<SentenceAdjustmentResponse> = emptyList(),
+    keyDateAdjustments: List<KeyDateAdjustmentResponse> = emptyList(),
+  ) {
+    nomisApi.stubFor(
+      get(urlEqualTo("/prisoners/booking-id/$bookingId/sentencing-adjustments?active-only=false")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(HttpStatus.OK.value())
+          .withBody(objectMapper.writeValueAsString(SentencingAdjustmentsResponse(keyDateAdjustments, sentenceAdjustments))),
+      ),
+    )
+  }
+
+  fun verify(pattern: RequestPatternBuilder) = nomisApi.verify(pattern)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsNomisApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsNomisApiServiceTest.kt
@@ -1,0 +1,58 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing
+
+import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Import
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helper.SpringAPIServiceTest
+
+@SpringAPIServiceTest
+@Import(SentencingAdjustmentsNomisApiService::class, SentencingConfiguration::class, SentencingAdjustmentsNomisApiMockServer::class)
+class SentencingAdjustmentsNomisApiServiceTest {
+  @Autowired
+  private lateinit var apiService: SentencingAdjustmentsNomisApiService
+
+  @Autowired
+  private lateinit var sentencingAdjustmentsNomisApi: SentencingAdjustmentsNomisApiMockServer
+
+  @Nested
+  inner class GetAllByBookingId {
+    @Test
+    internal fun `will pass oath2 token to service`() = runTest {
+      sentencingAdjustmentsNomisApi.stubGetAllByBookingId(1234567)
+
+      apiService.getAllByBookingId(bookingId = 1234567)
+
+      sentencingAdjustmentsNomisApi.verify(
+        getRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
+      )
+    }
+
+    @Test
+    internal fun `will pass booking id to service`() = runTest {
+      sentencingAdjustmentsNomisApi.stubGetAllByBookingId(1234567)
+
+      apiService.getAllByBookingId(bookingId = 1234567)
+
+      sentencingAdjustmentsNomisApi.verify(
+        getRequestedFor(urlPathEqualTo("/prisoners/booking-id/1234567/sentencing-adjustments")),
+      )
+    }
+
+    @Test
+    internal fun `will request all adjustments, not just active ones`() = runTest {
+      sentencingAdjustmentsNomisApi.stubGetAllByBookingId(1234567)
+
+      apiService.getAllByBookingId(bookingId = 1234567)
+
+      sentencingAdjustmentsNomisApi.verify(
+        getRequestedFor(anyUrl()).withQueryParam("active-only", equalTo("false")),
+      )
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/MappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/MappingApiMockServer.kt
@@ -269,6 +269,23 @@ class MappingApiMockServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
+  fun stubGetNomisSentencingAdjustment(
+    adjustmentCategory: String = "SENTENCE",
+    nomisAdjustmentId: Long = 987L,
+    status: HttpStatus,
+  ) {
+    stubFor(
+      get(
+        urlPathMatching("/mapping/sentencing/adjustments/nomis-adjustment-category/$adjustmentCategory/nomis-adjustment-id/$nomisAdjustmentId"),
+      ).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(status.value())
+          .withBody("""{"message":"Not found"}"""),
+      ),
+    )
+  }
+
   fun stubSentenceAdjustmentMappingDelete(adjustmentId: String = "567S") {
     stubFor(
       delete(urlEqualTo("/mapping/sentencing/adjustments/adjustment-id/$adjustmentId")).willReturn(


### PR DESCRIPTION

This update includes essential changes in the SentencingAdjustmentsSynchronisationService to handle prisoner merge events so it can synchronize sentence and key date adjustments. Moreover, these modifications follow the introduction of SentencingAdjustmentsNomisApiService to interact with the NOMIS API. The update also involves new test cases ensuring that the prisoner merge handling works correctly.