### PR TITLE
SDIT-1606 Handle ALERT-DELETED prisoner event

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -34,6 +34,7 @@ generic-service:
     FEATURE_EVENT_INT_LOC_USAGE_LOCATIONS-UPDATED: false
     FEATURE_EVENT_ALERT-UPDATED: false
     FEATURE_EVENT_ALERT-INSERTED: false
+    FEATURE_EVENT_ALERT-DELETED: false
 
 generic-prometheus-alerts:
   rdsAlertsDatabases:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDpsApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDpsApiService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitBodilessEntity
 import org.springframework.web.reactive.function.client.awaitBody
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts.model.Alert
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts.model.CreateAlert
@@ -29,4 +30,13 @@ class AlertsDpsApiService(@Qualifier("alertsApiWebClient") private val webClient
       .header("Username", updatedByUsername)
       .retrieve()
       .awaitBody()
+
+  suspend fun deleteAlert(alertId: String) {
+    webClient
+      .delete()
+      .uri("/alerts/{alertId}", alertId)
+      .header("Source", "NOMIS")
+      .retrieve()
+      .awaitBodilessEntity()
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiService.kt
@@ -25,4 +25,11 @@ class AlertsMappingApiService(@Qualifier("mappingApiWebClient") private val webC
       .retrieve()
       .awaitBodilessEntity()
   }
+
+  suspend fun deleteMappingByDpsId(dpsAlertId: String) {
+    webClient.delete()
+      .uri("/mapping/alerts/dps-alert-id/$dpsAlertId")
+      .retrieve()
+      .awaitBodilessEntity()
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsPrisonOffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsPrisonOffenderEventListener.kt
@@ -38,8 +38,9 @@ class AlertsPrisonOffenderEventListener(
           val eventType = sqsMessage.MessageAttributes!!.eventType.Value
           if (eventFeatureSwitch.isEnabled(eventType)) {
             when (eventType) {
-              "ALERT-UPDATED" -> alertsSynchronisationService.nomisAlertUpdated((sqsMessage.Message.fromJson()))
-              "ALERT-INSERTED" -> alertsSynchronisationService.nomisAlertInserted((sqsMessage.Message.fromJson()))
+              "ALERT-UPDATED" -> alertsSynchronisationService.nomisAlertUpdated(sqsMessage.Message.fromJson())
+              "ALERT-INSERTED" -> alertsSynchronisationService.nomisAlertInserted(sqsMessage.Message.fromJson())
+              "ALERT-DELETED" -> alertsSynchronisationService.nomisAlertDeleted(sqsMessage.Message.fromJson())
 
               else -> log.info("Received a message I wasn't expecting {}", eventType)
             }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDpsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDpsApiMockServer.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.delete
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.put
@@ -91,6 +92,17 @@ class AlertsDpsApiMockServer : WireMockServer(WIREMOCK_PORT) {
             .withStatus(200)
             .withHeader("Content-Type", "application/json")
             .withBody(AlertsDpsApiExtension.objectMapper.writeValueAsString(response)),
+        ),
+    )
+  }
+
+  fun stubDeleteAlert() {
+    stubFor(
+      delete(urlPathMatching("/alerts/.*"))
+        .willReturn(
+          aResponse()
+            .withStatus(204)
+            .withHeader("Content-Type", "application/json"),
         ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDpsApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDpsApiServiceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts
 
 import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
+import com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
@@ -197,6 +198,50 @@ class AlertsDpsApiServiceTest {
 
       dpsAlertsServer.verify(
         putRequestedFor(anyUrl())
+          .withHeader("Source", equalTo("NOMIS")),
+      )
+    }
+  }
+
+  @Nested
+  inner class DeleteAlert {
+    @Test
+    internal fun `will pass oath2 token to service`() = runTest {
+      dpsAlertsServer.stubDeleteAlert()
+
+      apiService.deleteAlert(
+        alertId = "f3f31737-6ee3-4ec5-8a79-0ac110fe50e2",
+      )
+
+      dpsAlertsServer.verify(
+        deleteRequestedFor(anyUrl())
+          .withHeader("Authorization", equalTo("Bearer ABCDE")),
+      )
+    }
+
+    @Test
+    internal fun `will pass alert id to service`() = runTest {
+      dpsAlertsServer.stubDeleteAlert()
+
+      apiService.deleteAlert(
+        alertId = "f3f31737-6ee3-4ec5-8a79-0ac110fe50e2",
+      )
+
+      dpsAlertsServer.verify(
+        deleteRequestedFor(urlEqualTo("/alerts/f3f31737-6ee3-4ec5-8a79-0ac110fe50e2")),
+      )
+    }
+
+    @Test
+    internal fun `will pass source as NOMIS to service via header`() = runTest {
+      dpsAlertsServer.stubDeleteAlert()
+
+      apiService.deleteAlert(
+        alertId = "f3f31737-6ee3-4ec5-8a79-0ac110fe50e2",
+      )
+
+      dpsAlertsServer.verify(
+        deleteRequestedFor(anyUrl())
           .withHeader("Source", equalTo("NOMIS")),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiMockServer.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.client.CountMatchingStrategy
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.delete
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
@@ -72,6 +73,27 @@ class AlertsMappingApiMockServer(private val objectMapper: ObjectMapper) {
 
   fun stubPostMappingFailureFollowedBySuccess() {
     mappingApi.stubMappingCreateFailureFollowedBySuccess(url = "/mapping/alerts")
+  }
+
+  fun stubDeleteMapping() {
+    mappingApi.stubFor(
+      delete(urlPathMatching("/mapping/alerts/dps-alert-id/.*")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(HttpStatus.NO_CONTENT.value()),
+      ),
+    )
+  }
+
+  fun stubDeleteMapping(status: HttpStatus, error: ErrorResponse = ErrorResponse(status = status.value())) {
+    mappingApi.stubFor(
+      delete(urlPathMatching("/mapping/alerts/dps-alert-id/.*")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(status.value())
+          .withBody(objectMapper.writeValueAsString(error)),
+      ),
+    )
   }
 
   fun verify(pattern: RequestPatternBuilder) = mappingApi.verify(pattern)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiServiceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts
 
 import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
+import com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath
@@ -87,6 +88,34 @@ class AlertsMappingApiServiceTest {
       assertThrows<WebClientResponseException.InternalServerError> {
         apiService.getOrNullByNomisId(bookingId = 1234567, alertSequence = 4)
       }
+    }
+  }
+
+  @Nested
+  inner class DeleteMapping {
+    private val dpsAlertId = UUID.randomUUID().toString()
+
+    @Test
+    internal fun `will pass oath2 token to service`() = runTest {
+      alertsMappingApiMockServer.stubDeleteMapping()
+
+      apiService.deleteMappingByDpsId(dpsAlertId)
+
+      alertsMappingApiMockServer.verify(
+        deleteRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
+      )
+    }
+
+    @Test
+    internal fun `will pass ids to service`() = runTest {
+      val dpsAlertId = "a04f7a8d-61aa-400c-9395-f4dc62f36ab0"
+      alertsMappingApiMockServer.stubDeleteMapping()
+
+      apiService.deleteMappingByDpsId(dpsAlertId)
+
+      alertsMappingApiMockServer.verify(
+        deleteRequestedFor(urlPathEqualTo("/mapping/alerts/dps-alert-id/$dpsAlertId")),
+      )
     }
   }
 


### PR DESCRIPTION
Will delete alert in DPS if mapping still exists and try to delete the mapping