### PR TITLE
SDIT-1658 First pass at skeletion for migrating alerts by prisoner

### DIFF
--- a/openapi-specs/nomis-sync-api-docs.json
+++ b/openapi-specs/nomis-sync-api-docs.json
@@ -7,7 +7,7 @@
       "name": "HMPPS Digital Studio",
       "email": "feedback@digital.justice.gov.uk"
     },
-    "version": "2024-04-10.7260.212f7df"
+    "version": "2024-04-10.7270.32c3b17"
   },
   "servers": [
     {
@@ -6076,7 +6076,7 @@
         "tags": [
           "prisoners-resource"
         ],
-        "summary": "Gets the identifiers for all prisoners. Currently only active prisoners are supported",
+        "summary": "Gets the identifiers for all prisoners. By default only active prisoners will be return unless active=false",
         "description": "Requires role SYNCHRONISATION_REPORTING.",
         "operationId": "getPrisonerIdentifiers",
         "parameters": [
@@ -6091,7 +6091,7 @@
           {
             "name": "active",
             "in": "query",
-            "description": "Only return active prisoners currently in prison",
+            "description": "When true only return active prisoners currently in prison else all prisoners that at some point has been in prison are returned",
             "required": false,
             "schema": {
               "type": "boolean",
@@ -14174,18 +14174,29 @@
       "PrisonerId": {
         "required": [
           "bookingId",
-          "offenderNo"
+          "offenderNo",
+          "status"
         ],
         "type": "object",
         "properties": {
           "bookingId": {
             "type": "integer",
-            "format": "int64"
+            "description": "Latest booking id",
+            "format": "int64",
+            "example": 12345
           },
           "offenderNo": {
-            "type": "string"
+            "type": "string",
+            "description": "The NOMIS reference AKA prisoner number",
+            "example": "A1234AA"
+          },
+          "status": {
+            "type": "string",
+            "description": "The prisoner's current status",
+            "example": "ACTIVE IN"
           }
-        }
+        },
+        "description": "Prisoner identifier"
       },
       "SentenceResponse": {
         "required": [

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsByPrisonerMigrationMappingApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsByPrisonerMigrationMappingApiService.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.MigrationMapping
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AlertMappingDto
+
+@Service
+class AlertsByPrisonerMigrationMappingApiService(@Qualifier("mappingApiWebClient") webClient: WebClient) :
+  MigrationMapping<List<AlertMappingDto>>(domainUrl = "/mapping/alerts/all", webClient)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsByPrisonerMigrationMessageListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsByPrisonerMigrationMessageListener.kt
@@ -10,19 +10,18 @@ import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.sqs.model.Message
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.MigrationMessageListener
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AlertMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AlertIdResponse
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AlertResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.PrisonerId
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.ALERTS_QUEUE_ID
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationMessage
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationPage
 import java.util.concurrent.CompletableFuture
 
 @Service
-@ConditionalOnProperty(name = ["alerts.migration.type"], havingValue = "all")
-class AlertsMigrationMessageListener(
+@ConditionalOnProperty(name = ["alerts.migration.type"], havingValue = "by-prisoner")
+class AlertsByPrisonerMigrationMessageListener(
   objectMapper: ObjectMapper,
-  alertsMigrationService: AlertsMigrationService,
-) : MigrationMessageListener<AlertsMigrationFilter, AlertIdResponse, AlertResponse, AlertMappingDto>(
+  alertsMigrationService: AlertsByPrisonerMigrationService,
+) : MigrationMessageListener<AlertsMigrationFilter, PrisonerId, AlertsForPrisonerResponse, List<AlertMappingDto>>(
   objectMapper,
   alertsMigrationService,
 ) {
@@ -41,11 +40,11 @@ class AlertsMigrationMessageListener(
     return objectMapper.readValue(json)
   }
 
-  override fun parseContextNomisId(json: String): MigrationMessage<*, AlertIdResponse> {
+  override fun parseContextNomisId(json: String): MigrationMessage<*, PrisonerId> {
     return objectMapper.readValue(json)
   }
 
-  override fun parseContextMapping(json: String): MigrationMessage<*, AlertMappingDto> {
+  override fun parseContextMapping(json: String): MigrationMessage<*, List<AlertMappingDto>> {
     return objectMapper.readValue(json)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsByPrisonerMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsByPrisonerMigrationService.kt
@@ -1,0 +1,95 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.domain.PageImpl
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.data.MigrationContext
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.trackEvent
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AlertMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.PrisonerId
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.AuditService
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationHistoryService
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationQueueService
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationService
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationType
+
+@Service
+class AlertsByPrisonerMigrationService(
+  queueService: MigrationQueueService,
+  private val alertsNomisService: AlertsNomisApiService,
+  alertsMappingService: AlertsByPrisonerMigrationMappingApiService,
+  private val alertsDpsService: AlertsDpsApiService,
+  migrationHistoryService: MigrationHistoryService,
+  telemetryClient: TelemetryClient,
+  auditService: AuditService,
+  @Value("\${alerts.page.size:1000}") pageSize: Long,
+  @Value("\${alerts.complete-check.delay-seconds}") completeCheckDelaySeconds: Int,
+  @Value("\${alerts.complete-check.count}") completeCheckCount: Int,
+) : MigrationService<AlertsMigrationFilter, PrisonerId, AlertsForPrisonerResponse, List<AlertMappingDto>>(
+  queueService = queueService,
+  auditService = auditService,
+  migrationHistoryService = migrationHistoryService,
+  mappingService = alertsMappingService,
+  telemetryClient = telemetryClient,
+  migrationType = MigrationType.ALERTS,
+  pageSize = pageSize,
+  completeCheckDelaySeconds = completeCheckDelaySeconds,
+  completeCheckCount = completeCheckCount,
+) {
+  private companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  override suspend fun getIds(
+    migrationFilter: AlertsMigrationFilter,
+    pageSize: Long,
+    pageNumber: Long,
+  ): PageImpl<PrisonerId> {
+    return alertsNomisService.getPrisonerIds(
+      pageNumber = pageNumber,
+      pageSize = pageSize,
+    )
+  }
+
+  override suspend fun migrateNomisEntity(context: MigrationContext<PrisonerId>) {
+    log.info("attempting to migrate ${context.body}")
+    val latestNomisBookingId = context.body.bookingId
+    val offenderNo = context.body.offenderNo
+    val status = context.body.status
+
+    val nomisAlerts = alertsNomisService.getAlertsToMigrate(offenderNo)
+    val activeAlertsFromPreviousBookings = nomisAlerts.previousBookingsAlerts.filter { it.isActive }
+    alertsDpsService.migrateAlerts(nomisAlerts.latestBookingAlerts.map { it.toDPSMigratedAlert(context.body.offenderNo) })?.also {
+      // TODO create mappings here
+      telemetryClient.trackEvent(
+        "alerts-migration-entity-migrated",
+        mapOf(
+          "latestNomisBookingId" to latestNomisBookingId,
+          "offenderNo" to offenderNo,
+          "status" to status,
+          "migrationId" to context.migrationId,
+          "alertCount" to it.size.toString(),
+          "alertsFromCurrentBooking" to nomisAlerts.latestBookingAlerts.size.toString(),
+          "totalAlertsFromPreviousBookings" to nomisAlerts.previousBookingsAlerts.size.toString(),
+          "totalActiveAlertsFromPreviousBookings" to activeAlertsFromPreviousBookings.size.toString(),
+        ),
+      )
+
+      if (activeAlertsFromPreviousBookings.isNotEmpty()) {
+        log.debug("active previous alert codes are: ${activeAlertsFromPreviousBookings.joinToString { it.alertCode.code }}")
+      }
+    } ?: run {
+      telemetryClient.trackEvent(
+        "alerts-migration-entity-migration-rejected",
+        mapOf(
+          "latestNomisBookingId" to latestNomisBookingId,
+          "offenderNo" to offenderNo,
+          "migrationId" to context.migrationId,
+        ),
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDpsApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDpsApiService.kt
@@ -49,4 +49,11 @@ class AlertsDpsApiService(@Qualifier("alertsApiWebClient") private val webClient
       .bodyValue(alert)
       .retrieve()
       .awaitBodyOrNullWhenConflict()
+
+  // TODO - real DPS service which is not ready yet
+  suspend fun migrateAlerts(alerts: List<MigrateAlertRequest>): List<Alert>? = emptyList()
 }
+
+data class AlertsForPrisonerResponse(
+  val alerts: List<Alert>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMigrationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMigrationResource.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.validation.Valid
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
@@ -25,7 +26,9 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.Migration
 @RequestMapping("/migrate", produces = [MediaType.APPLICATION_JSON_VALUE])
 class AlertsMigrationResource(
   private val alertsMigrationService: AlertsMigrationService,
+  private val alertsByPrisonerMigrationService: AlertsByPrisonerMigrationService,
   private val migrationHistoryService: MigrationHistoryService,
+  @Value("\${alerts.migration.type}") private val migrationType: String,
 ) {
   @PreAuthorize("hasRole('ROLE_MIGRATE_ALERTS')")
   @PostMapping("/alerts")
@@ -62,7 +65,7 @@ class AlertsMigrationResource(
   suspend fun migrateAlerts(
     @RequestBody @Valid
     migrationFilter: AlertsMigrationFilter,
-  ) = alertsMigrationService.startMigration(migrationFilter)
+  ) = if (migrationType == "by-prisoner") alertsByPrisonerMigrationService.startMigration(migrationFilter) else alertsMigrationService.startMigration(migrationFilter)
 
   @PreAuthorize("hasRole('ROLE_MIGRATE_ALERTS')")
   @GetMapping("/alerts/history")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsNomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsNomisApiService.kt
@@ -6,6 +6,8 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBody
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AlertIdResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AlertResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.PrisonerAlertsResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.PrisonerId
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RestResponsePage
 import java.time.LocalDate
 
@@ -29,6 +31,25 @@ class AlertsNomisApiService(@Qualifier("nomisApiWebClient") private val webClien
         .queryParam("toDate", toDate)
         .build()
     }
+    .retrieve()
+    .awaitBody()
+
+  suspend fun getPrisonerIds(pageNumber: Long, pageSize: Long): RestResponsePage<PrisonerId> = webClient.get()
+    .uri {
+      it.path("/prisoners/ids")
+        .queryParam("page", pageNumber)
+        .queryParam("size", pageSize)
+        .queryParam("active", false)
+        .build()
+    }
+    .retrieve()
+    .awaitBody()
+
+  suspend fun getAlertsToMigrate(offenderNo: String): PrisonerAlertsResponse = webClient.get()
+    .uri(
+      "/prisoner/{offenderNo}/alerts/to-migrate",
+      offenderNo,
+    )
     .retrieve()
     .awaitBody()
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -135,6 +135,8 @@ complete-check:
   count: 9
 
 alerts:
+  migration:
+    type: "by-prisoner"
   complete-check:
     delay-seconds: 180
     count: 9

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsByPrisonerMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsByPrisonerMigrationIntTest.kt
@@ -1,0 +1,510 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.returnResult
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.SqsIntegrationTestBase
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.persistence.repository.MigrationHistory
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.persistence.repository.MigrationHistoryRepository
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing.MigrationResult
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationStatus
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationType
+import java.time.Duration
+import java.time.LocalDateTime
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = ["alerts.migration.type=by-prisoner"])
+class AlertsByPrisonerMigrationIntTest : SqsIntegrationTestBase() {
+  @Autowired
+  private lateinit var alertsNomisApiMockServer: AlertsNomisApiMockServer
+
+  @Autowired
+  private lateinit var alertsMappingApiMockServer: AlertsMappingApiMockServer
+
+  @Autowired
+  private lateinit var migrationHistoryRepository: MigrationHistoryRepository
+
+  @Nested
+  @DisplayName("POST /migrate/alerts")
+  inner class MigrateAlerts {
+    @Nested
+    inner class Security {
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.post().uri("/migrate/alerts")
+          .headers(setAuthorisation(roles = listOf()))
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(AlertsMigrationFilter())
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.post().uri("/migrate/alerts")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(AlertsMigrationFilter())
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access unauthorised with no auth token`() {
+        webTestClient.post().uri("/migrate/alerts")
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(AlertsMigrationFilter())
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+      private lateinit var migrationResult: MigrationResult
+
+      @BeforeEach
+      fun setUp() {
+        alertsNomisApiMockServer.stubGetPrisonIds(totalElements = 2, pageSize = 10, bookingId = 1234567, offenderNo = "A0001KT")
+        alertsNomisApiMockServer.stubGetAlertsToMigrate(offenderNo = "A0001KT", currentAlertCount = 1, previousAlertCount = 0)
+        alertsNomisApiMockServer.stubGetAlertsToMigrate(offenderNo = "A0002KT", currentAlertCount = 1, previousAlertCount = 0)
+        migrationResult = performMigration()
+      }
+
+      @Test
+      fun `will only migrate all prisoners of the alerts`() {
+        verify(telemetryClient, times(2)).trackEvent(
+          eq("alerts-migration-entity-migrated"),
+          any(),
+          isNull(),
+        )
+        verify(telemetryClient).trackEvent(
+          eq("alerts-migration-entity-migrated"),
+          check {
+            assertThat(it).containsEntry("offenderNo", "A0001KT")
+          },
+          isNull(),
+        )
+        verify(telemetryClient).trackEvent(
+          eq("alerts-migration-entity-migrated"),
+          check {
+            assertThat(it).containsEntry("offenderNo", "A0002KT")
+          },
+          isNull(),
+        )
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /migrate/alerts/history")
+  inner class GetAll {
+    @BeforeEach
+    internal fun createHistoryRecords() {
+      runBlocking {
+        migrationHistoryRepository.deleteAll()
+        migrationHistoryRepository.save(
+          MigrationHistory(
+            migrationId = "2020-01-01T00:00:00",
+            whenStarted = LocalDateTime.parse("2020-01-01T00:00:00"),
+            whenEnded = LocalDateTime.parse("2020-01-01T01:00:00"),
+            status = MigrationStatus.COMPLETED,
+            estimatedRecordCount = 123_567,
+            filter = "",
+            recordsMigrated = 123_560,
+            recordsFailed = 7,
+            migrationType = MigrationType.ALERTS,
+          ),
+        )
+        migrationHistoryRepository.save(
+          MigrationHistory(
+            migrationId = "2020-01-02T00:00:00",
+            whenStarted = LocalDateTime.parse("2020-01-02T00:00:00"),
+            whenEnded = LocalDateTime.parse("2020-01-02T01:00:00"),
+            status = MigrationStatus.COMPLETED,
+            estimatedRecordCount = 123_567,
+            filter = "",
+            recordsMigrated = 123_567,
+            recordsFailed = 0,
+            migrationType = MigrationType.ALERTS,
+          ),
+        )
+        migrationHistoryRepository.save(
+          MigrationHistory(
+            migrationId = "2020-01-02T02:00:00",
+            whenStarted = LocalDateTime.parse("2020-01-02T02:00:00"),
+            whenEnded = LocalDateTime.parse("2020-01-02T03:00:00"),
+            status = MigrationStatus.COMPLETED,
+            estimatedRecordCount = 123_567,
+            filter = "",
+            recordsMigrated = 123_567,
+            recordsFailed = 0,
+            migrationType = MigrationType.ALERTS,
+          ),
+        )
+        migrationHistoryRepository.save(
+          MigrationHistory(
+            migrationId = "2020-01-03T02:00:00",
+            whenStarted = LocalDateTime.parse("2020-01-03T02:00:00"),
+            whenEnded = LocalDateTime.parse("2020-01-03T03:00:00"),
+            status = MigrationStatus.COMPLETED,
+            estimatedRecordCount = 123_567,
+            filter = "",
+            recordsMigrated = 123_560,
+            recordsFailed = 7,
+            migrationType = MigrationType.ALERTS,
+          ),
+        )
+      }
+    }
+
+    @AfterEach
+    internal fun deleteHistoryRecords() {
+      runBlocking {
+        migrationHistoryRepository.deleteAll()
+      }
+    }
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.get().uri("/migrate/alerts/history")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.get().uri("/migrate/alerts/history")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access unauthorised with no auth token`() {
+        webTestClient.get().uri("/migrate/alerts/history")
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+    }
+
+    @Test
+    internal fun `can read all records`() {
+      webTestClient.get().uri("/migrate/alerts/history")
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_ALERTS")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.size()").isEqualTo(4)
+        .jsonPath("$[0].migrationId").isEqualTo("2020-01-03T02:00:00")
+        .jsonPath("$[1].migrationId").isEqualTo("2020-01-02T02:00:00")
+        .jsonPath("$[2].migrationId").isEqualTo("2020-01-02T00:00:00")
+        .jsonPath("$[3].migrationId").isEqualTo("2020-01-01T00:00:00")
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /migrate/alerts/history/{migrationId}")
+  inner class Get {
+    @BeforeEach
+    internal fun createHistoryRecords() {
+      runBlocking {
+        migrationHistoryRepository.deleteAll()
+        migrationHistoryRepository.save(
+          MigrationHistory(
+            migrationId = "2020-01-01T00:00:00",
+            whenStarted = LocalDateTime.parse("2020-01-01T00:00:00"),
+            whenEnded = LocalDateTime.parse("2020-01-01T01:00:00"),
+            status = MigrationStatus.COMPLETED,
+            estimatedRecordCount = 123_567,
+            filter = "",
+            recordsMigrated = 123_560,
+            recordsFailed = 7,
+            migrationType = MigrationType.ALERTS,
+          ),
+        )
+      }
+    }
+
+    @AfterEach
+    internal fun deleteHistoryRecords() {
+      runBlocking {
+        migrationHistoryRepository.deleteAll()
+      }
+    }
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.get().uri("/migrate/alerts/history/2020-01-01T00:00:00")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.get().uri("/migrate/alerts/history/2020-01-01T00:00:00")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access unauthorised with no auth token`() {
+        webTestClient.get().uri("/migrate/alerts/history/2020-01-01T00:00:00")
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+    }
+
+    @Test
+    internal fun `can read record`() {
+      webTestClient.get().uri("/migrate/alerts/history/2020-01-01T00:00:00")
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_ALERTS")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.migrationId").isEqualTo("2020-01-01T00:00:00")
+        .jsonPath("$.status").isEqualTo("COMPLETED")
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /migrate/alerts/active-migration")
+  inner class GetActiveMigration {
+    @BeforeEach
+    internal fun createHistoryRecords() {
+      runBlocking {
+        migrationHistoryRepository.deleteAll()
+        migrationHistoryRepository.save(
+          MigrationHistory(
+            migrationId = "2020-01-01T00:00:00",
+            whenStarted = LocalDateTime.parse("2020-01-01T00:00:00"),
+            whenEnded = LocalDateTime.parse("2020-01-01T01:00:00"),
+            status = MigrationStatus.STARTED,
+            estimatedRecordCount = 123_567,
+            filter = "",
+            recordsMigrated = 123_560,
+            recordsFailed = 7,
+            migrationType = MigrationType.ALERTS,
+          ),
+        )
+        migrationHistoryRepository.save(
+          MigrationHistory(
+            migrationId = "2019-01-01T00:00:00",
+            whenStarted = LocalDateTime.parse("2019-01-01T00:00:00"),
+            whenEnded = LocalDateTime.parse("2019-01-01T01:00:00"),
+            status = MigrationStatus.COMPLETED,
+            estimatedRecordCount = 123_567,
+            filter = "",
+            recordsMigrated = 123_567,
+            recordsFailed = 0,
+            migrationType = MigrationType.ALERTS,
+          ),
+        )
+      }
+    }
+
+    @AfterEach
+    internal fun deleteHistoryRecords() {
+      runBlocking {
+        migrationHistoryRepository.deleteAll()
+      }
+    }
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.get().uri("/migrate/alerts/active-migration")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.get().uri("/migrate/alerts/active-migration")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access unauthorised with no auth token`() {
+        webTestClient.get().uri("/migrate/alerts/active-migration")
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+    }
+
+    @Test
+    internal fun `will return dto with null contents if no migrations are found`() {
+      deleteHistoryRecords()
+      webTestClient.get().uri("/migrate/alerts/active-migration")
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_ALERTS")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.migrationId").doesNotExist()
+        .jsonPath("$.whenStarted").doesNotExist()
+        .jsonPath("$.recordsMigrated").doesNotExist()
+        .jsonPath("$.estimatedRecordCount").doesNotExist()
+        .jsonPath("$.status").doesNotExist()
+        .jsonPath("$.migrationType").doesNotExist()
+    }
+
+    @Test
+    internal fun `can read active migration data`() {
+      alertsMappingApiMockServer.stubSingleItemByMigrationId(migrationId = "2020-01-01T00:00:00", count = 123456)
+      webTestClient.get().uri("/migrate/alerts/active-migration")
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_ALERTS")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.migrationId").isEqualTo("2020-01-01T00:00:00")
+        .jsonPath("$.whenStarted").isEqualTo("2020-01-01T00:00:00")
+        .jsonPath("$.recordsMigrated").isEqualTo(123456)
+        .jsonPath("$.toBeProcessedCount").isEqualTo(0)
+        .jsonPath("$.beingProcessedCount").isEqualTo(0)
+        .jsonPath("$.recordsFailed").isEqualTo(0)
+        .jsonPath("$.estimatedRecordCount").isEqualTo(123567)
+        .jsonPath("$.status").isEqualTo("STARTED")
+        .jsonPath("$.migrationType").isEqualTo("ALERTS")
+    }
+  }
+
+  @Nested
+  @DisplayName("POST /migrate/alerts/{migrationId}/terminate/")
+  inner class TerminateMigrationAlerts {
+    @BeforeEach
+    internal fun setUp() {
+      webTestClient.delete().uri("/history")
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATION_ADMIN")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().is2xxSuccessful
+    }
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.post().uri("/migrate/alerts/{migrationId}/cancel", "some id")
+          .headers(setAuthorisation(roles = listOf()))
+          .contentType(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.post().uri("/migrate/alerts/{migrationId}/cancel", "some id")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access unauthorised with no auth token`() {
+        webTestClient.post().uri("/migrate/alerts/{migrationId}/cancel", "some id")
+          .contentType(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+    }
+
+    @Test
+    internal fun `will return a not found if no running migration found`() {
+      webTestClient.post().uri("/migrate/alerts/{migrationId}/cancel", "some id")
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_ALERTS")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isNotFound
+    }
+
+    @Test
+    internal fun `will terminate a running migration`() {
+      alertsNomisApiMockServer.stubGetPrisonIds(totalElements = 2, pageSize = 10, bookingId = 1234567, offenderNo = "A0001KT")
+      alertsNomisApiMockServer.stubGetAlertsToMigrate(offenderNo = "A0001KT", currentAlertCount = 1, previousAlertCount = 0)
+      alertsNomisApiMockServer.stubGetAlertsToMigrate(offenderNo = "A0002KT", currentAlertCount = 1, previousAlertCount = 0)
+
+      val migrationId = performMigration().migrationId
+
+      webTestClient.post().uri("/migrate/alerts/{mi grationId}/cancel", migrationId)
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_ALERTS")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isAccepted
+
+      webTestClient.get().uri("/migrate/alerts/history/{migrationId}", migrationId)
+        .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_ALERTS")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.migrationId").isEqualTo(migrationId)
+        .jsonPath("$.status").isEqualTo("CANCELLED_REQUESTED")
+
+      await atMost Duration.ofSeconds(60) untilAsserted {
+        webTestClient.get().uri("/migrate/alerts/history/{migrationId}", migrationId)
+          .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_ALERTS")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.migrationId").isEqualTo(migrationId)
+          .jsonPath("$.status").isEqualTo("CANCELLED")
+      }
+    }
+  }
+
+  private fun performMigration(body: AlertsMigrationFilter = AlertsMigrationFilter()): MigrationResult =
+    webTestClient.post().uri("/migrate/alerts")
+      .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_ALERTS")))
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(body)
+      .exchange()
+      .expectStatus().isAccepted.returnResult<MigrationResult>().responseBody.blockFirst()!!
+      .also {
+        waitUntilCompleted()
+      }
+
+  private fun waitUntilCompleted() =
+    await atMost Duration.ofSeconds(60) untilAsserted {
+      verify(telemetryClient).trackEvent(
+        eq("alerts-migration-completed"),
+        any(),
+        isNull(),
+      )
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsNomisApiMockServer.kt
@@ -14,6 +14,8 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.A
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AlertResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.CodeDescription
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.NomisAudit
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.PrisonerAlertsResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.PrisonerId
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.NomisApiExtension.Companion.nomisApi
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.pageContent
 import java.time.LocalDate
@@ -71,6 +73,65 @@ class AlertsNomisApiMockServer(private val objectMapper: ObjectMapper) {
     }
     nomisApi.stubFor(
       get(urlPathEqualTo("/alerts/ids")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(HttpStatus.OK.value())
+          .withBody(
+            pageContent(
+              objectMapper = objectMapper,
+              content = content,
+              pageSize = pageSize,
+              pageNumber = 0,
+              totalElements = totalElements,
+              size = pageSize.toInt(),
+            ),
+          ),
+      ),
+    )
+  }
+
+  fun stubGetAlertsToMigrate(
+    offenderNo: String,
+    currentAlertCount: Long = 1,
+    previousAlertCount: Long = 0,
+    alert: AlertResponse = AlertResponse(
+      bookingId = 1,
+      alertSequence = 1,
+      alertCode = CodeDescription("XA", "TACT"),
+      type = CodeDescription("X", "Security"),
+      date = LocalDate.now(),
+      isActive = true,
+      isVerified = false,
+      audit = NomisAudit(
+        createDatetime = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+        createUsername = "Q1251T",
+      ),
+    ),
+  ) {
+    val response = PrisonerAlertsResponse(
+      latestBookingAlerts = (1..currentAlertCount).map { alert.copy(bookingId = it, alertSequence = 1) },
+      previousBookingsAlerts = (1..previousAlertCount).map { alert.copy(bookingId = it + 1, alertSequence = 1) },
+    )
+    nomisApi.stubFor(
+      get(urlEqualTo("/prisoner/$offenderNo/alerts/to-migrate")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(HttpStatus.OK.value())
+          .withBody(objectMapper.writeValueAsString(response)),
+      ),
+    )
+  }
+
+  fun stubGetPrisonIds(totalElements: Long = 20, pageSize: Long = 20, bookingId: Long = 123456, offenderNo: String = "A0001KT") {
+    val content: List<PrisonerId> = (1..min(pageSize, totalElements)).map {
+      PrisonerId(
+        bookingId = bookingId + it,
+        offenderNo = offenderNo.replace("0001", "$it".padStart(4, '0')),
+        status = "ACTIVE IN",
+      )
+    }
+    nomisApi.stubFor(
+      get(urlPathEqualTo("/prisoners/ids")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(HttpStatus.OK.value())

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -44,6 +44,8 @@ locations:
   page:
     size: 10
 alerts:
+  migration:
+    type: "all"
   complete-check:
     delay-seconds: 1
     count: 1


### PR DESCRIPTION
This is feature switched via alerts.migration.type with test by default using old method and deployed service using skeleton of new.

This allows us to hedge our bets depending on what we find when only migrating some alerts from previous bookings. If we discover this is not acceptable we can easily revert back to old method.

This version only track telemetry event showing how many previous alerts will be made active by this approach.