### PR TITLE
SDIT-1614 Use new prisoner centric mapping POST endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsByPrisonerMigrationMappingApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsByPrisonerMigrationMappingApiService.kt
@@ -13,18 +13,20 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.histo
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.DuplicateErrorResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.MigrationMapping
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AlertMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.PrisonerAlertMappingsDto
 
 @Service
 class AlertsByPrisonerMigrationMappingApiService(@Qualifier("mappingApiWebClient") webClient: WebClient) :
-  MigrationMapping<List<AlertMappingDto>>(domainUrl = "/mapping/alerts/all", webClient) {
+  MigrationMapping<AlertMigrationMapping>(domainUrl = "/mapping/alerts/all", webClient) {
   suspend fun createMapping(
-    mappings: List<AlertMappingDto>,
+    offenderNo: String,
+    prisonerMapping: PrisonerAlertMappingsDto,
     errorJavaClass: ParameterizedTypeReference<DuplicateErrorResponse<AlertMappingDto>>,
   ): CreateMappingResult<AlertMappingDto> {
     return webClient.post()
-      .uri(createMappingUrl())
+      .uri("/mapping/alerts/{offenderNo}/all", offenderNo)
       .bodyValue(
-        mappings,
+        prisonerMapping,
       )
       .retrieve()
       .bodyToMono(Unit::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsByPrisonerMigrationMessageListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsByPrisonerMigrationMessageListener.kt
@@ -9,7 +9,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.sqs.model.Message
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.MigrationMessageListener
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AlertMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.PrisonerId
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.ALERTS_QUEUE_ID
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationMessage
@@ -21,7 +20,7 @@ import java.util.concurrent.CompletableFuture
 class AlertsByPrisonerMigrationMessageListener(
   objectMapper: ObjectMapper,
   alertsMigrationService: AlertsByPrisonerMigrationService,
-) : MigrationMessageListener<AlertsMigrationFilter, PrisonerId, AlertsForPrisonerResponse, List<AlertMappingDto>>(
+) : MigrationMessageListener<AlertsMigrationFilter, PrisonerId, AlertsForPrisonerResponse, AlertMigrationMapping>(
   objectMapper,
   alertsMigrationService,
 ) {
@@ -44,7 +43,7 @@ class AlertsByPrisonerMigrationMessageListener(
     return objectMapper.readValue(json)
   }
 
-  override fun parseContextMapping(json: String): MigrationMessage<*, List<AlertMappingDto>> {
+  override fun parseContextMapping(json: String): MigrationMessage<*, AlertMigrationMapping> {
     return objectMapper.readValue(json)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsSynchronisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsSynchronisationService.kt
@@ -52,6 +52,7 @@ class AlertsSynchronisationService(
           createdByUsername = nomisAlert.audit.createUsername,
         ).run {
           tryToCreateMapping(
+            offenderNo = event.offenderIdDisplay,
             nomisAlert = nomisAlert,
             dpsAlert = this,
             telemetry = telemetry,
@@ -121,11 +122,13 @@ class AlertsSynchronisationService(
   }
 
   private suspend fun tryToCreateMapping(
+    offenderNo: String,
     nomisAlert: AlertResponse,
     dpsAlert: Alert,
     telemetry: Map<String, Any>,
   ): MappingResponse {
     val mapping = AlertMappingDto(
+      offenderNo = offenderNo,
       dpsAlertId = dpsAlert.alertUuid.toString(),
       nomisBookingId = nomisAlert.bookingId,
       nomisAlertSequence = nomisAlert.alertSequence,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsByPrisonerMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsByPrisonerMigrationIntTest.kt
@@ -121,7 +121,8 @@ class AlertsByPrisonerMigrationIntTest : SqsIntegrationTestBase() {
         alertsNomisApiMockServer.stubGetAlertsToMigrate(offenderNo = "A0002KT", currentAlertCount = 1, previousAlertCount = 0)
         dpsAlertsServer.stubMigrateAlerts(offenderNo = "A0001KT", response = listOf(migratedAlert().copy(alertUuid = UUID.fromString("00000000-0000-0000-0000-000000000001"), offenderBookId = 1234567, alertSeq = 1)))
         dpsAlertsServer.stubMigrateAlerts(offenderNo = "A0002KT", response = listOf(migratedAlert().copy(alertUuid = UUID.fromString("00000000-0000-0000-0000-000000000002"), offenderBookId = 1234567, alertSeq = 2)))
-        alertsMappingApiMockServer.stubPostMappings()
+        alertsMappingApiMockServer.stubPostMappings("A0001KT")
+        alertsMappingApiMockServer.stubPostMappings("A0002KT")
         alertsMappingApiMockServer.stubMigrationCount(recordsMigrated = 2)
         migrationResult = performMigration()
       }
@@ -157,7 +158,8 @@ class AlertsByPrisonerMigrationIntTest : SqsIntegrationTestBase() {
 
       @Test
       fun `will POST mappings for alerts created for each prisoner`() {
-        alertsMappingApiMockServer.verify(2, postRequestedFor(urlPathEqualTo("/mapping/alerts/all")))
+        alertsMappingApiMockServer.verify(postRequestedFor(urlPathEqualTo("/mapping/alerts/A0001KT/all")))
+        alertsMappingApiMockServer.verify(postRequestedFor(urlPathEqualTo("/mapping/alerts/A0002KT/all")))
       }
 
       @Test
@@ -202,7 +204,7 @@ class AlertsByPrisonerMigrationIntTest : SqsIntegrationTestBase() {
         alertsNomisApiMockServer.stubGetPrisonIds(totalElements = 1, pageSize = 10, bookingId = 1234567, offenderNo = "A0001KT")
         alertsNomisApiMockServer.stubGetAlertsToMigrate(offenderNo = "A0001KT", currentAlertCount = 1, previousAlertCount = 0)
         dpsAlertsServer.stubMigrateAlerts(offenderNo = "A0001KT", response = listOf(migratedAlert().copy(alertUuid = UUID.fromString("00000000-0000-0000-0000-000000000001"), offenderBookId = 1234567, alertSeq = 1)))
-        alertsMappingApiMockServer.stubPostMappingsFailureFollowedBySuccess()
+        alertsMappingApiMockServer.stubPostMappingsFailureFollowedBySuccess(offenderNo = "A0001KT")
         performMigration()
       }
 
@@ -213,7 +215,7 @@ class AlertsByPrisonerMigrationIntTest : SqsIntegrationTestBase() {
 
       @Test
       fun `will POST mappings for alerts twice due to the single error`() {
-        alertsMappingApiMockServer.verify(2, postRequestedFor(urlPathEqualTo("/mapping/alerts/all")))
+        alertsMappingApiMockServer.verify(2, postRequestedFor(urlPathEqualTo("/mapping/alerts/A0001KT/all")))
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsByPrisonerMigrationMappingApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsByPrisonerMigrationMappingApiServiceTest.kt
@@ -13,7 +13,9 @@ import org.springframework.core.ParameterizedTypeReference
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helper.SpringAPIServiceTest
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.DuplicateErrorResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AlertMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AlertMappingDto.MappingType.DPS_CREATED
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AlertMappingIdDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.PrisonerAlertMappingsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.PrisonerAlertMappingsDto.MappingType.DPS_CREATED
 import java.util.UUID
 
 @SpringAPIServiceTest
@@ -29,15 +31,18 @@ class AlertsByPrisonerMigrationMappingApiServiceTest {
   inner class PostMappings {
     @Test
     internal fun `will pass oath2 token to service`() = runTest {
-      alertsMappingApiMockServer.stubPostMappings()
+      alertsMappingApiMockServer.stubPostMappings("A1234KT")
 
       apiService.createMapping(
-        listOf(
-          AlertMappingDto(
-            nomisBookingId = 123456,
-            nomisAlertSequence = 1,
-            dpsAlertId = UUID.randomUUID().toString(),
-            mappingType = DPS_CREATED,
+        offenderNo = "A1234KT",
+        PrisonerAlertMappingsDto(
+          mappingType = DPS_CREATED,
+          mappings = listOf(
+            AlertMappingIdDto(
+              nomisBookingId = 123456,
+              nomisAlertSequence = 1,
+              dpsAlertId = UUID.randomUUID().toString(),
+            ),
           ),
         ),
         object : ParameterizedTypeReference<DuplicateErrorResponse<AlertMappingDto>>() {},
@@ -51,15 +56,18 @@ class AlertsByPrisonerMigrationMappingApiServiceTest {
     @Test
     internal fun `will pass ids to service`() = runTest {
       val dpsAlertId = "a04f7a8d-61aa-400c-9395-f4dc62f36ab0"
-      alertsMappingApiMockServer.stubPostMappings()
+      alertsMappingApiMockServer.stubPostMappings("A1234KT")
 
       apiService.createMapping(
-        listOf(
-          AlertMappingDto(
-            nomisBookingId = 123456,
-            nomisAlertSequence = 1,
-            dpsAlertId = dpsAlertId,
-            mappingType = DPS_CREATED,
+        offenderNo = "A1234KT",
+        PrisonerAlertMappingsDto(
+          mappingType = DPS_CREATED,
+          mappings = listOf(
+            AlertMappingIdDto(
+              nomisBookingId = 123456,
+              nomisAlertSequence = 1,
+              dpsAlertId = dpsAlertId,
+            ),
           ),
         ),
         object : ParameterizedTypeReference<DuplicateErrorResponse<AlertMappingDto>>() {},
@@ -67,10 +75,10 @@ class AlertsByPrisonerMigrationMappingApiServiceTest {
 
       alertsMappingApiMockServer.verify(
         postRequestedFor(anyUrl())
-          .withRequestBody(matchingJsonPath("$[0].nomisBookingId", equalTo("123456")))
-          .withRequestBody(matchingJsonPath("$[0].nomisAlertSequence", equalTo("1")))
-          .withRequestBody(matchingJsonPath("$[0].dpsAlertId", equalTo(dpsAlertId)))
-          .withRequestBody(matchingJsonPath("$[0].mappingType", equalTo("DPS_CREATED"))),
+          .withRequestBody(matchingJsonPath("mappings[0].nomisBookingId", equalTo("123456")))
+          .withRequestBody(matchingJsonPath("mappings[0].nomisAlertSequence", equalTo("1")))
+          .withRequestBody(matchingJsonPath("mappings[0].dpsAlertId", equalTo(dpsAlertId)))
+          .withRequestBody(matchingJsonPath("mappingType", equalTo("DPS_CREATED"))),
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiMockServer.kt
@@ -77,15 +77,16 @@ class AlertsMappingApiMockServer(private val objectMapper: ObjectMapper) {
     mappingApi.stubMappingCreateFailureFollowedBySuccess(url = "/mapping/alerts")
   }
 
-  fun stubPostMappings() {
+  fun stubPostMappings(offenderNo: String) {
     mappingApi.stubFor(
-      post("/mapping/alerts/all").willReturn(
+      post("/mapping/alerts/$offenderNo/all").willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(201),
       ),
     )
   }
+
   fun stubMigrationCount(recordsMigrated: Long) {
     mappingApi.stubFor(
       get(urlPathMatching("/mapping/alerts/migration-id/.*/grouped-by-prisoner")).willReturn(
@@ -108,7 +109,7 @@ class AlertsMappingApiMockServer(private val objectMapper: ObjectMapper) {
     )
   }
 
-  fun stubPostMappingsFailureFollowedBySuccess() = mappingApi.stubMappingCreateFailureFollowedBySuccess(url = "/mapping/alerts/all")
+  fun stubPostMappingsFailureFollowedBySuccess(offenderNo: String) = mappingApi.stubMappingCreateFailureFollowedBySuccess(url = "/mapping/alerts/$offenderNo/all")
 
   fun stubDeleteMapping() {
     mappingApi.stubFor(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsSynchronisationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsSynchronisationIntTest.kt
@@ -171,6 +171,7 @@ class AlertsSynchronisationIntTest : SqsIntegrationTestBase() {
               postRequestedFor(urlPathEqualTo("/mapping/alerts"))
                 .withRequestBody(matchingJsonPath("dpsAlertId", equalTo(dpsAlertId)))
                 .withRequestBody(matchingJsonPath("nomisBookingId", equalTo(bookingId.toString())))
+                .withRequestBody(matchingJsonPath("offenderNo", equalTo(offenderNo)))
                 .withRequestBody(matchingJsonPath("nomisAlertSequence", equalTo(alertSequence.toString())))
                 .withRequestBody(matchingJsonPath("mappingType", equalTo("DPS_CREATED"))),
             )


### PR DESCRIPTION
Mapping now has offenderNo on table so that mappings can be deleted by prisoner. This requires a new POST endpoint and also added offenderNo to the single version of the POST