### PR TITLE
SDIT-1546 Handle alerts created due to a new booking

### DIFF
--- a/openapi-specs/nomis-mapping-service-api-docs.json
+++ b/openapi-specs/nomis-mapping-service-api-docs.json
@@ -7,7 +7,7 @@
       "name": "HMPPS Digital Studio",
       "email": "feedback@digital.justice.gov.uk"
     },
-    "version": "2024-04-22.4140.b54cf1a"
+    "version": "2024-04-23.4151.cdb1e57"
   },
   "servers": [
     {
@@ -201,6 +201,150 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DuplicateMappingErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mapping/alerts/nomis-booking-id/{bookingId}/nomis-alert-sequence/{alertSequence}": {
+      "get": {
+        "tags": [
+          "alerts-mapping-resource"
+        ],
+        "summary": "get mapping",
+        "description": "Retrieves a mapping by NOMIS id. Requires role NOMIS_ALERTS",
+        "operationId": "getMappingByNomisId_1",
+        "parameters": [
+          {
+            "name": "bookingId",
+            "in": "path",
+            "description": "NOMIS booking id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "NOMIS booking id",
+              "example": 12345
+            },
+            "example": 12345
+          },
+          {
+            "name": "alertSequence",
+            "in": "path",
+            "description": "NOMIS booking id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "NOMIS booking id",
+              "example": 2
+            },
+            "example": 2
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Mapping Information Returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertMappingDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Id does not exist in mapping table",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "alerts-mapping-resource"
+        ],
+        "summary": "updates mapping",
+        "description": "Updates a mapping by NOMIS id setting a new NOMIS booking Id. Requires role NOMIS_ALERTS",
+        "operationId": "updateMappingBookingIdByNomisId",
+        "parameters": [
+          {
+            "name": "bookingId",
+            "in": "path",
+            "description": "NOMIS booking id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "NOMIS booking id",
+              "example": 12345
+            },
+            "example": 12345
+          },
+          {
+            "name": "alertSequence",
+            "in": "path",
+            "description": "NOMIS booking id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "NOMIS booking id",
+              "example": 2
+            },
+            "example": 2
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NomisMappingIdUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Mapping Information Returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertMappingDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Id does not exist in mapping table",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -4224,74 +4368,6 @@
         }
       }
     },
-    "/mapping/alerts/nomis-booking-id/{bookingId}/nomis-alert-sequence/{alertSequence}": {
-      "get": {
-        "tags": [
-          "alerts-mapping-resource"
-        ],
-        "summary": "get mapping",
-        "description": "Retrieves a mapping by NOMIS id. Requires role NOMIS_ALERTS",
-        "operationId": "getMappingByNomisId_1",
-        "parameters": [
-          {
-            "name": "bookingId",
-            "in": "path",
-            "description": "NOMIS booking id",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "NOMIS booking id",
-              "example": 12345
-            },
-            "example": 12345
-          },
-          {
-            "name": "alertSequence",
-            "in": "path",
-            "description": "NOMIS booking id",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "NOMIS booking id",
-              "example": 2
-            },
-            "example": 2
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Mapping Information Returned",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AlertMappingDto"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized to access this endpoint",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Id does not exist in mapping table",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/mapping/alerts/migration-id/{migrationId}/grouped-by-prisoner": {
       "get": {
         "tags": [
@@ -5712,6 +5788,70 @@
         },
         "description": "ID of mapping identified by the NOMIS id for a Court Charge mapping"
       },
+      "AlertMappingDto": {
+        "required": [
+          "dpsAlertId",
+          "mappingType",
+          "nomisAlertSequence",
+          "nomisBookingId",
+          "offenderNo"
+        ],
+        "type": "object",
+        "properties": {
+          "dpsAlertId": {
+            "type": "string",
+            "description": "DPS alert id"
+          },
+          "nomisBookingId": {
+            "type": "integer",
+            "description": "NOMIS booking id",
+            "format": "int64"
+          },
+          "nomisAlertSequence": {
+            "type": "integer",
+            "description": "NOMIS alert sequence",
+            "format": "int64"
+          },
+          "offenderNo": {
+            "type": "string",
+            "description": "Prisoner number"
+          },
+          "label": {
+            "type": "string",
+            "description": "Label (a timestamp for migrated ids)"
+          },
+          "mappingType": {
+            "type": "string",
+            "description": "Mapping type",
+            "enum": [
+              "MIGRATED",
+              "DPS_CREATED",
+              "NOMIS_CREATED"
+            ]
+          },
+          "whenCreated": {
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
+            "type": "string",
+            "description": "Date time the mapping was created",
+            "example": "2021-07-05T10:35:17"
+          }
+        },
+        "description": "NOMIS to Alert mapping"
+      },
+      "NomisMappingIdUpdate": {
+        "required": [
+          "bookingId"
+        ],
+        "type": "object",
+        "properties": {
+          "bookingId": {
+            "type": "integer",
+            "description": "NOMIS booking id",
+            "format": "int64"
+          }
+        },
+        "description": "Update mapping NOMIS Ids"
+      },
       "ActivityMappingDto": {
         "required": [
           "activityScheduleId",
@@ -6737,56 +6877,6 @@
         },
         "description": "Mappings for a prisoner created during migration"
       },
-      "AlertMappingDto": {
-        "required": [
-          "dpsAlertId",
-          "mappingType",
-          "nomisAlertSequence",
-          "nomisBookingId",
-          "offenderNo"
-        ],
-        "type": "object",
-        "properties": {
-          "dpsAlertId": {
-            "type": "string",
-            "description": "DPS alert id"
-          },
-          "nomisBookingId": {
-            "type": "integer",
-            "description": "NOMIS booking id",
-            "format": "int64"
-          },
-          "nomisAlertSequence": {
-            "type": "integer",
-            "description": "NOMIS alert sequence",
-            "format": "int64"
-          },
-          "offenderNo": {
-            "type": "string",
-            "description": "Prisoner number"
-          },
-          "label": {
-            "type": "string",
-            "description": "Label (a timestamp for migrated ids)"
-          },
-          "mappingType": {
-            "type": "string",
-            "description": "Mapping type",
-            "enum": [
-              "MIGRATED",
-              "DPS_CREATED",
-              "NOMIS_CREATED"
-            ]
-          },
-          "whenCreated": {
-            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
-            "type": "string",
-            "description": "Date time the mapping was created",
-            "example": "2021-07-05T10:35:17"
-          }
-        },
-        "description": "NOMIS to Alert mapping"
-      },
       "AdjudicationAllMappingDto": {
         "required": [
           "adjudicationId",
@@ -7018,12 +7108,6 @@
             "type": "integer",
             "format": "int64"
           },
-          "first": {
-            "type": "boolean"
-          },
-          "last": {
-            "type": "boolean"
-          },
           "size": {
             "type": "integer",
             "format": "int32"
@@ -7043,6 +7127,12 @@
             "items": {
               "$ref": "#/components/schemas/SortObject"
             }
+          },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
           },
           "numberOfElements": {
             "type": "integer",
@@ -7141,12 +7231,6 @@
             "type": "integer",
             "format": "int64"
           },
-          "first": {
-            "type": "boolean"
-          },
-          "last": {
-            "type": "boolean"
-          },
           "size": {
             "type": "integer",
             "format": "int32"
@@ -7166,6 +7250,12 @@
             "items": {
               "$ref": "#/components/schemas/SortObject"
             }
+          },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
           },
           "numberOfElements": {
             "type": "integer",

--- a/openapi-specs/nomis-sync-api-docs.json
+++ b/openapi-specs/nomis-sync-api-docs.json
@@ -7,7 +7,7 @@
       "name": "HMPPS Digital Studio",
       "email": "feedback@digital.justice.gov.uk"
     },
-    "version": "2024-04-18.7325.5fbd49e"
+    "version": "2024-04-23.7395.570b9dd"
   },
   "servers": [
     {
@@ -6072,6 +6072,85 @@
           },
           "403": {
             "description": "Forbidden to access this endpoint when role SYNCHRONISATION_REPORTING not present",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prisoners/{offenderNo}/bookings/{bookingId}/previous": {
+      "get": {
+        "tags": [
+          "prisoners-resource"
+        ],
+        "summary": "Gets a prisoner's previous booking relative to the supplied booking id",
+        "description": "Requires role NOMIS_ALERTS.",
+        "operationId": "getPreviousBooking",
+        "parameters": [
+          {
+            "name": "offenderNo",
+            "in": "path",
+            "description": "Offender Noms Id",
+            "required": true,
+            "schema": {
+              "pattern": "[A-Z]\\d{4}[A-Z]{2}",
+              "type": "string",
+              "description": "Offender Noms Id",
+              "example": "A1234ZZ"
+            },
+            "example": "A1234ZZ"
+          },
+          {
+            "name": "bookingId",
+            "in": "path",
+            "description": "Booking Id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Booking Id",
+              "example": 123
+            },
+            "example": 123
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ids of booking",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PreviousBookingId"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized to access this endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden to access this endpoint when role NOMIS_ALERTS not present",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Booking or prisoner does not exist or has no previous booking",
             "content": {
               "application/json": {
                 "schema": {
@@ -14184,6 +14263,28 @@
         },
         "description": "Details of a prisoner merge"
       },
+      "PreviousBookingId": {
+        "required": [
+          "bookingId",
+          "bookingSequence"
+        ],
+        "type": "object",
+        "properties": {
+          "bookingId": {
+            "type": "integer",
+            "description": "The NOMIS booking ID",
+            "format": "int64",
+            "example": 1234567
+          },
+          "bookingSequence": {
+            "type": "integer",
+            "description": "The NOMIS booking sequence",
+            "format": "int64",
+            "example": 3
+          }
+        },
+        "description": "ID of previous booking"
+      },
       "PrisonerAlertsResponse": {
         "required": [
           "latestBookingAlerts",
@@ -15696,6 +15797,42 @@
         },
         "description": "Incentive information"
       },
+      "Actions": {
+        "required": [
+          "csraOrRsraReview",
+          "nonAssociationsUpdated",
+          "observationBook",
+          "openCSIPAlert",
+          "serviceReferral",
+          "simReferral",
+          "unitOrCellMove"
+        ],
+        "type": "object",
+        "properties": {
+          "openCSIPAlert": {
+            "type": "boolean"
+          },
+          "nonAssociationsUpdated": {
+            "type": "boolean"
+          },
+          "observationBook": {
+            "type": "boolean"
+          },
+          "unitOrCellMove": {
+            "type": "boolean"
+          },
+          "csraOrRsraReview": {
+            "type": "boolean"
+          },
+          "serviceReferral": {
+            "type": "boolean"
+          },
+          "simReferral": {
+            "type": "boolean"
+          }
+        },
+        "description": "Action list"
+      },
       "Attendee": {
         "required": [
           "If attended (otherwise contributor)",
@@ -15727,10 +15864,13 @@
       "CSIPResponse": {
         "required": [
           "areaOfWork",
+          "decision",
+          "documents",
           "id",
           "investigation",
           "location",
           "offender",
+          "originalAgencyLocation",
           "plans",
           "proActiveReferral",
           "reportDetails",
@@ -15754,6 +15894,10 @@
             "type": "integer",
             "description": "The booking id associated with the CSIP",
             "format": "int64"
+          },
+          "originalAgencyLocation": {
+            "type": "string",
+            "description": "The original location when the CSIP was created"
           },
           "logNumber": {
             "type": "string",
@@ -15804,6 +15948,9 @@
           "investigation": {
             "$ref": "#/components/schemas/Investigation"
           },
+          "decision": {
+            "$ref": "#/components/schemas/Decision"
+          },
           "caseManager": {
             "type": "string",
             "description": "Case Manager involved"
@@ -15830,9 +15977,78 @@
             "items": {
               "$ref": "#/components/schemas/Review"
             }
+          },
+          "documents": {
+            "type": "array",
+            "description": "CSIP Documents",
+            "items": {
+              "$ref": "#/components/schemas/Document"
+            }
           }
         },
         "description": "CSIP Details"
+      },
+      "Decision": {
+        "required": [
+          "actions"
+        ],
+        "type": "object",
+        "properties": {
+          "conclusion": {
+            "type": "string",
+            "description": "Conclusion & Reason for decision"
+          },
+          "decisionOutcome": {
+            "$ref": "#/components/schemas/CodeDescription"
+          },
+          "signedOffRole": {
+            "$ref": "#/components/schemas/CodeDescription"
+          },
+          "recordedBy": {
+            "type": "string",
+            "description": "Recorded By"
+          },
+          "recordedDate": {
+            "type": "string",
+            "description": "Recorded Date",
+            "format": "date"
+          },
+          "nextSteps": {
+            "type": "string",
+            "description": "What to do next"
+          },
+          "otherDetails": {
+            "type": "string",
+            "description": "Other information to take into consideration"
+          },
+          "actions": {
+            "$ref": "#/components/schemas/Actions"
+          }
+        },
+        "description": "DecisionAndActions"
+      },
+      "Document": {
+        "required": [
+          "fileName",
+          "id",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Document Id",
+            "format": "int64"
+          },
+          "fileName": {
+            "type": "string",
+            "description": "Name of the document"
+          },
+          "status": {
+            "$ref": "#/components/schemas/CodeDescription"
+          }
+        },
+        "description": "CSIP Documents"
       },
       "FactorResponse": {
         "required": [

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiService.kt
@@ -7,6 +7,7 @@ import org.springframework.web.reactive.function.client.awaitBodilessEntity
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.awaitBodyOrNullWhenNotFound
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.MigrationMapping
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AlertMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.NomisMappingIdUpdate
 
 @Service
 class AlertsMappingApiService(@Qualifier("mappingApiWebClient") webClient: WebClient) :
@@ -46,6 +47,3 @@ class AlertsMappingApiService(@Qualifier("mappingApiWebClient") webClient: WebCl
       .retrieve()
       .awaitBodyOrNullWhenNotFound()
 }
-
-// TODO replace with OpenAPI generated version
-data class NomisMappingIdUpdate(val bookingId: Long)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiService.kt
@@ -34,4 +34,18 @@ class AlertsMappingApiService(@Qualifier("mappingApiWebClient") webClient: WebCl
       .retrieve()
       .awaitBodilessEntity()
   }
+
+  suspend fun updateNomisMappingId(previousBookingId: Long, alertSequence: Long, newBookingId: Long): AlertMappingDto? =
+    webClient.put()
+      .uri(
+        "/mapping/alerts/nomis-booking-id/{bookingId}/nomis-alert-sequence/{alertSequence}",
+        previousBookingId,
+        alertSequence,
+      )
+      .bodyValue(NomisMappingIdUpdate(bookingId = newBookingId))
+      .retrieve()
+      .awaitBodyOrNullWhenNotFound()
 }
+
+// TODO replace with OpenAPI generated version
+data class NomisMappingIdUpdate(val bookingId: Long)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsNomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsNomisApiService.kt
@@ -6,6 +6,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBody
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AlertIdResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AlertResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.PreviousBookingId
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.PrisonerAlertsResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.PrisonerId
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RestResponsePage
@@ -53,7 +54,7 @@ class AlertsNomisApiService(@Qualifier("nomisApiWebClient") private val webClien
     .retrieve()
     .awaitBody()
 
-  suspend fun getBookingPreviousTo(offenderNo: String, bookingId: Long): PreviousBookingIId = webClient.get()
+  suspend fun getBookingPreviousTo(offenderNo: String, bookingId: Long): PreviousBookingId = webClient.get()
     .uri(
       "/prisoners/{offenderNo}/bookings/{bookingId}/previous",
       offenderNo,
@@ -62,6 +63,3 @@ class AlertsNomisApiService(@Qualifier("nomisApiWebClient") private val webClien
     .retrieve()
     .awaitBody()
 }
-
-// TODO replace with OpenAPI generated version
-data class PreviousBookingIId(val bookingId: Long, val bookingSequence: Long)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsNomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsNomisApiService.kt
@@ -15,7 +15,7 @@ import java.time.LocalDate
 class AlertsNomisApiService(@Qualifier("nomisApiWebClient") private val webClient: WebClient) {
   suspend fun getAlert(bookingId: Long, alertSequence: Long): AlertResponse = webClient.get()
     .uri(
-      "/prisoner/booking-id/{bookingId}/alerts/{alertSequence}",
+      "/prisoners/booking-id/{bookingId}/alerts/{alertSequence}",
       bookingId,
       alertSequence,
     )
@@ -52,4 +52,16 @@ class AlertsNomisApiService(@Qualifier("nomisApiWebClient") private val webClien
     )
     .retrieve()
     .awaitBody()
+
+  suspend fun getBookingPreviousTo(offenderNo: String, bookingId: Long): PreviousBookingIId = webClient.get()
+    .uri(
+      "/prisoners/{offenderNo}/bookings/{bookingId}/previous",
+      offenderNo,
+      bookingId,
+    )
+    .retrieve()
+    .awaitBody()
 }
+
+// TODO replace with OpenAPI generated version
+data class PreviousBookingIId(val bookingId: Long, val bookingSequence: Long)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiMockServer.kt
@@ -6,6 +6,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.delete
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.put
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
@@ -158,6 +159,46 @@ class AlertsMappingApiMockServer(private val objectMapper: ObjectMapper) {
               size = 1,
             ),
           ),
+      ),
+    )
+  }
+
+  fun stubUpdateByNomisId(
+    previousBookingId: Long = 123456,
+    alertSequence: Long = 1,
+    newBookingId: Long = 5000,
+    dpsAlertId: String = UUID.randomUUID().toString(),
+  ) {
+    mappingApi.stubFor(
+      put("/mapping/alerts/nomis-booking-id/$previousBookingId/nomis-alert-sequence/$alertSequence").willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(200)
+          .withBody(
+            objectMapper.writeValueAsString(
+              AlertMappingDto(
+                dpsAlertId = dpsAlertId,
+                nomisBookingId = newBookingId,
+                nomisAlertSequence = alertSequence,
+                mappingType = MIGRATED,
+                offenderNo = "A1234KT",
+              ),
+            ),
+          ),
+      ),
+    )
+  }
+
+  fun stubUpdateByNomisId(
+    status: HttpStatus,
+    error: ErrorResponse = ErrorResponse(status = status.value()),
+  ) {
+    mappingApi.stubFor(
+      put(urlPathMatching("/mapping/alerts/nomis-booking-id/\\d+/nomis-alert-sequence/\\d+")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(status.value())
+          .withBody(objectMapper.writeValueAsString(error)),
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiServiceTest.kt
@@ -6,6 +6,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -162,6 +163,32 @@ class AlertsMappingApiServiceTest {
           .withRequestBody(matchingJsonPath("nomisAlertSequence", equalTo("1")))
           .withRequestBody(matchingJsonPath("dpsAlertId", equalTo(dpsAlertId)))
           .withRequestBody(matchingJsonPath("mappingType", equalTo("DPS_CREATED"))),
+      )
+    }
+  }
+
+  @Nested
+  inner class UpdateNomisMappingId {
+    @Test
+    internal fun `will pass oath2 token to service`() = runTest {
+      alertsMappingApiMockServer.stubUpdateByNomisId(previousBookingId = 5000, alertSequence = 3)
+
+      apiService.updateNomisMappingId(previousBookingId = 5000, alertSequence = 3, newBookingId = 123456)
+
+      alertsMappingApiMockServer.verify(
+        putRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
+      )
+    }
+
+    @Test
+    internal fun `will pass ids to service`() = runTest {
+      alertsMappingApiMockServer.stubUpdateByNomisId(previousBookingId = 5000, alertSequence = 3)
+
+      apiService.updateNomisMappingId(previousBookingId = 5000, alertSequence = 3, newBookingId = 123456)
+
+      alertsMappingApiMockServer.verify(
+        putRequestedFor(urlPathEqualTo("/mapping/alerts/nomis-booking-id/5000/nomis-alert-sequence/3"))
+          .withRequestBody(matchingJsonPath("bookingId", equalTo("123456"))),
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsNomisApiMockServer.kt
@@ -170,4 +170,5 @@ class AlertsNomisApiMockServer(private val objectMapper: ObjectMapper) {
   }
 
   fun verify(pattern: RequestPatternBuilder) = nomisApi.verify(pattern)
+  fun verify(count: Int, pattern: RequestPatternBuilder) = nomisApi.verify(count, pattern)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsNomisApiMockServer.kt
@@ -44,7 +44,7 @@ class AlertsNomisApiMockServer(private val objectMapper: ObjectMapper) {
     ),
   ) {
     nomisApi.stubFor(
-      get(urlEqualTo("/prisoner/booking-id/$bookingId/alerts/$alertSequence")).willReturn(
+      get(urlEqualTo("/prisoners/booking-id/$bookingId/alerts/$alertSequence")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(HttpStatus.OK.value())
@@ -55,7 +55,7 @@ class AlertsNomisApiMockServer(private val objectMapper: ObjectMapper) {
 
   fun stubGetAlert(status: HttpStatus, error: ErrorResponse = ErrorResponse(status = status.value())) {
     nomisApi.stubFor(
-      get(urlPathMatching("/prisoner/booking-id/\\d+/alerts/\\d+")).willReturn(
+      get(urlPathMatching("/prisoners/booking-id/\\d+/alerts/\\d+")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(status.value())
@@ -146,6 +146,24 @@ class AlertsNomisApiMockServer(private val objectMapper: ObjectMapper) {
               totalElements = totalElements,
               size = pageSize.toInt(),
             ),
+          ),
+      ),
+    )
+  }
+
+  fun stubGetPreviousBooking(offenderNo: String, bookingId: Long, oldBookingId: Long = 12345, oldBookingSequence: Long = 2) {
+    nomisApi.stubFor(
+      get(urlEqualTo("/prisoners/$offenderNo/bookings/$bookingId/previous")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(HttpStatus.OK.value())
+          .withBody(
+            """
+              {
+                "bookingId": $oldBookingId,
+                "bookingSequence": $oldBookingSequence
+              }
+            """.trimIndent(),
           ),
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsSynchronisationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsSynchronisationIntTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.atLeastOnce
 import org.mockito.Mockito.eq
+import org.mockito.Mockito.times
 import org.mockito.kotlin.any
 import org.mockito.kotlin.check
 import org.mockito.kotlin.isNull
@@ -501,6 +502,7 @@ class AlertsSynchronisationIntTest : SqsIntegrationTestBase() {
         fun `will retrieve the alert from NOMIS`() {
           await untilAsserted {
             alertsNomisApiMockServer.verify(
+              2,
               getRequestedFor(urlPathEqualTo("/prisoners/booking-id/$bookingId/alerts/$alertSequence")),
             )
           }
@@ -510,6 +512,7 @@ class AlertsSynchronisationIntTest : SqsIntegrationTestBase() {
         fun `will retrieve the previous booking id`() {
           await untilAsserted {
             alertsNomisApiMockServer.verify(
+              2,
               getRequestedFor(urlPathEqualTo("/prisoners/$offenderNo/bookings/$bookingId/previous")),
             )
           }
@@ -519,6 +522,7 @@ class AlertsSynchronisationIntTest : SqsIntegrationTestBase() {
         fun `will attempt update the mapping`() {
           await untilAsserted {
             alertsMappingApiMockServer.verify(
+              2,
               putRequestedFor(urlPathEqualTo("/mapping/alerts/nomis-booking-id/$previousBookingId/nomis-alert-sequence/$alertSequence"))
                 .withRequestBody(matchingJsonPath("bookingId", equalTo("$bookingId"))),
             )
@@ -528,7 +532,7 @@ class AlertsSynchronisationIntTest : SqsIntegrationTestBase() {
         @Test
         fun `will track a telemetry event for failure`() {
           await untilAsserted {
-            verify(telemetryClient).trackEvent(
+            verify(telemetryClient, times(2)).trackEvent(
               eq("alert-synchronisation-booking-transfer-failed"),
               check {
                 assertThat(it["offenderNo"]).isEqualTo(offenderNo)


### PR DESCRIPTION
These are identified with the NOMIS standard copy table audit text. When this happens the alert mapping needs updating to point to the new booking. There are no changes required in DPS