### PR TITLE
SDIT-1568 - Handle duplicates for batch alerts

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiMockServer.kt
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AlertMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AlertMappingDto.MappingType.MIGRATED
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.DuplicateMappingErrorResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.MappingApiExtension.Companion.mappingApi
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.pageContent
@@ -101,6 +102,17 @@ class AlertsMappingApiMockServer(private val objectMapper: ObjectMapper) {
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(201),
+      ),
+    )
+  }
+
+  fun stubPostBatchMappings(error: DuplicateMappingErrorResponse) {
+    mappingApi.stubFor(
+      post("/mapping/alerts/batch").willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(409)
+          .withBody(objectMapper.writeValueAsString(error)),
       ),
     )
   }


### PR DESCRIPTION
For a merge duplicates can happen since they will not be rejected by DPS, therefore a network issue can result in this scenario 