### PR TITLE
SDIT-1835 Ignore updates to adjustments deleted

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsMigrationService.kt
@@ -77,8 +77,9 @@ class SentencingAdjustmentsMigrationService(
             nomisApiService.getKeyDateAdjustment(nomisAdjustmentId)
           }
 
+        // this service needs deleting now migration is done
         val migratedSentenceAdjustment =
-          sentencingService.migrateSentencingAdjustment(nomisAdjustment.toSentencingAdjustment())
+          sentencingService.migrateSentencingAdjustment(nomisAdjustment!!.toSentencingAdjustment())
             .also {
               createAdjustmentMapping(
                 nomisAdjustmentId = nomisAdjustmentId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/NomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/NomisApiService.kt
@@ -17,6 +17,7 @@ import org.springframework.web.reactive.function.client.awaitBody
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.activities.model.AppointmentMigrateRequest
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.config.BadRequestException
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.awaitBodyOrNullWhenNotFound
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AdjudicationChargeIdResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AdjudicationChargeResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.EndActivitiesRequest
@@ -109,21 +110,19 @@ class NomisApiService(@Qualifier("nomisApiWebClient") private val webClient: Web
 
   suspend fun getSentenceAdjustment(
     nomisSentenceAdjustmentId: Long,
-  ): NomisAdjustment =
+  ): NomisAdjustment? =
     webClient.get()
       .uri("/sentence-adjustments/{nomisSentenceAdjustmentId}", nomisSentenceAdjustmentId)
       .retrieve()
-      .bodyToMono(NomisAdjustment::class.java)
-      .awaitSingle()
+      .awaitBodyOrNullWhenNotFound()
 
   suspend fun getKeyDateAdjustment(
     nomisKeyDateAdjustmentId: Long,
-  ): NomisAdjustment =
+  ): NomisAdjustment? =
     webClient.get()
       .uri("/key-date-adjustments/{nomisKeyDateAdjustmentId}", nomisKeyDateAdjustmentId)
       .retrieve()
-      .bodyToMono(NomisAdjustment::class.java)
-      .awaitSingle()
+      .awaitBodyOrNullWhenNotFound()
 
   suspend fun getAppointment(nomisEventId: Long): AppointmentResponse =
     webClient.get()


### PR DESCRIPTION
It is possible to process an UPSERT event from NOMIS after an adjustment is deleted - this can happen if events are delayed. In this scenario just ignore the update rather than sending to DLQ