### PR TITLE
SDIT-1859 Resynchronising alerts on receive to old bookings  

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDataRepairResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDataRepairResource.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts
+
+import com.microsoft.applicationinsights.TelemetryClient
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class AlertsDataRepairResource(
+  private val alertsSynchronisationService: AlertsSynchronisationService,
+  private val telemetryClient: TelemetryClient,
+) {
+  @PostMapping("/prisoners/{offenderNo}/alerts/resynchronise")
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_MIGRATE_ALERTS')")
+  @Operation(
+    summary = "Resynchronises current alerts for the given prisoner from NOMIS back to DPS",
+    description = "Used when unexpected event has happened in NOMIS that as resulted in the DPS data drifting from NOMIS, so emergency use only. Requires ROLE_MIGRATE_ALERTS",
+  )
+  suspend fun repairAlerts(
+    @PathVariable offenderNo: String,
+  ) {
+    alertsSynchronisationService.resynchronisePrisonerAlerts(offenderNo)
+    telemetryClient.trackEvent(
+      "from-nomis-synch-alerts-resynchronisation-repair",
+      mapOf(
+        "offenderNo" to offenderNo,
+      ),
+      null,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDpsApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDpsApiService.kt
@@ -53,6 +53,14 @@ class AlertsDpsApiService(@Qualifier("alertsApiWebClient") private val webClient
     .retrieve()
     .awaitBody()
 
+  // TODO - switch to new API when available
+  suspend fun resynchroniseAlerts(offenderNo: String, alerts: List<MigrateAlert>): List<MigratedAlert> = webClient
+    .post()
+    .uri("/migrate/{offenderNo}/alerts", offenderNo)
+    .bodyValue(alerts)
+    .retrieve()
+    .awaitBody()
+
   suspend fun mergePrisonerAlerts(offenderNo: String, removedOffenderNo: String, alerts: List<MergeAlert>, retainedAlertIds: List<String>): MergedAlerts = webClient
     .post()
     .uri("/merge-alerts")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsEventListener.kt
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.EventFeatureSwitch
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.SQSMessage
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.SynchronisationMessageType.RETRY_RESYNCHRONISATION_MAPPING_BATCH
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.SynchronisationMessageType.RETRY_SYNCHRONISATION_MAPPING
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.SynchronisationMessageType.RETRY_SYNCHRONISATION_MAPPING_BATCH
 import java.util.concurrent.CompletableFuture
@@ -43,6 +44,7 @@ class AlertsEventListener(
               "ALERT-INSERTED" -> alertsSynchronisationService.nomisAlertInserted(sqsMessage.Message.fromJson())
               "ALERT-DELETED" -> alertsSynchronisationService.nomisAlertDeleted(sqsMessage.Message.fromJson())
               "prison-offender-events.prisoner.merged" -> alertsSynchronisationService.synchronisePrisonerMerge(sqsMessage.Message.fromJson())
+              "prisoner-offender-search.prisoner.received" -> alertsSynchronisationService.resynchronisePrisonerAlertsForAdmission(sqsMessage.Message.fromJson())
 
               else -> log.info("Received a message I wasn't expecting {}", eventType)
             }
@@ -56,6 +58,9 @@ class AlertsEventListener(
         )
 
         RETRY_SYNCHRONISATION_MAPPING_BATCH.name -> alertsSynchronisationService.retryCreateMappingsBatch(
+          sqsMessage.Message.fromJson(),
+        )
+        RETRY_RESYNCHRONISATION_MAPPING_BATCH.name -> alertsSynchronisationService.retryReplaceMappingsBatch(
           sqsMessage.Message.fromJson(),
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiService.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.histo
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.MigrationMapping
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AlertMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.NomisMappingIdUpdate
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.PrisonerAlertMappingsDto
 
 @Service
 class AlertsMappingApiService(@Qualifier("mappingApiWebClient") webClient: WebClient) :
@@ -64,4 +65,17 @@ class AlertsMappingApiService(@Qualifier("mappingApiWebClient") webClient: WebCl
       .bodyValue(NomisMappingIdUpdate(bookingId = newBookingId))
       .retrieve()
       .awaitBodyOrNullWhenNotFound()
+
+  suspend fun replaceMappings(
+    offenderNo: String,
+    prisonerMapping: PrisonerAlertMappingsDto,
+  ) {
+    webClient.put()
+      .uri("/mapping/alerts/{offenderNo}/all", offenderNo)
+      .bodyValue(
+        prisonerMapping,
+      )
+      .retrieve()
+      .awaitBodilessEntity()
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsNomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsNomisApiService.kt
@@ -41,6 +41,14 @@ class AlertsNomisApiService(@Qualifier("nomisApiWebClient") private val webClien
     .retrieve()
     .awaitBodyOrNullWhenNotFound()
 
+  suspend fun getAlertsToResynchronise(offenderNo: String): PrisonerAlertsResponse? = webClient.get()
+    .uri(
+      "/prisoners/{offenderNo}/alerts/to-migrate",
+      offenderNo,
+    )
+    .retrieve()
+    .awaitBodyOrNullWhenNotFound()
+
   suspend fun getAlertsByBookingId(bookingId: Long): BookingAlertsResponse = webClient.get()
     .uri(
       "/prisoners/booking-id/{bookingId}/alerts",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/data/NomisPrisonerMergeEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/data/NomisPrisonerMergeEvent.kt
@@ -13,3 +13,12 @@ data class MergeAdditionalInformationEvent(
   val removedNomsNumber: String,
   val bookingId: Long,
 )
+
+data class PrisonerReceiveDomainEvent(
+  val additionalInformation: ReceivePrisonerAdditionalInformationEvent,
+)
+
+data class ReceivePrisonerAdditionalInformationEvent(
+  val nomsNumber: String,
+  val reason: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/listeners/MigrationMessageType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/listeners/MigrationMessageType.kt
@@ -12,4 +12,5 @@ enum class MigrationMessageType {
 enum class SynchronisationMessageType {
   RETRY_SYNCHRONISATION_MAPPING,
   RETRY_SYNCHRONISATION_MAPPING_BATCH,
+  RETRY_RESYNCHRONISATION_MAPPING_BATCH,
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDataRepairResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDataRepairResourceIntTest.kt
@@ -1,0 +1,141 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts
+
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.eq
+import org.mockito.kotlin.check
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts.AlertsDpsApiExtension.Companion.dpsAlertsServer
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts.AlertsDpsApiMockServer.Companion.migratedAlert
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.SqsIntegrationTestBase
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.withRequestBodyJsonPath
+import java.util.*
+
+class AlertsDataRepairResourceIntTest : SqsIntegrationTestBase() {
+  @Autowired
+  private lateinit var alertsNomisApiMockServer: AlertsNomisApiMockServer
+
+  @Autowired
+  private lateinit var alertsMappingApiMockServer: AlertsMappingApiMockServer
+
+  @DisplayName("POST /prisoners/{offenderNo}/alerts/resynchronise")
+  @Nested
+  inner class RepairAdlerts {
+    val offenderNo = "A1234KT"
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.post().uri("/prisoners/$offenderNo/alerts/resynchronise")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.post().uri("/prisoners/$offenderNo/alerts/resynchronise")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access unauthorised with no auth token`() {
+        webTestClient.post().uri("/prisoners/$offenderNo/alerts/resynchronise")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+      val offenderNo = "A1234KT"
+      val bookingId = 1234L
+      private val dpsAlertId1 = UUID.fromString("956d4326-b0c3-47ac-ab12-f0165109a6c5")
+      private val dpsAlertId2 = UUID.fromString("f612a10f-4827-4022-be96-d882193dfabd")
+
+      @BeforeEach
+      fun setUp() {
+        alertsNomisApiMockServer.stubGetAlertsToResynchronise(offenderNo, bookingId = bookingId, currentAlertCount = 2)
+        dpsAlertsServer.stubResynchroniseAlerts(
+          offenderNo = offenderNo,
+          response = listOf(
+            migratedAlert().copy(offenderBookId = bookingId, alertSeq = 1, alertUuid = dpsAlertId1),
+            migratedAlert().copy(offenderBookId = bookingId, alertSeq = 2, alertUuid = dpsAlertId2),
+          ),
+        )
+        alertsMappingApiMockServer.stubReplaceMappings(offenderNo)
+
+        webTestClient.post().uri("/prisoners/$offenderNo/alerts/resynchronise")
+          .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_ALERTS")))
+          .exchange()
+          .expectStatus().isOk
+      }
+
+      @Test
+      fun `will retrieve current alerts for the prisoner`() {
+        alertsNomisApiMockServer.verify(getRequestedFor(urlPathEqualTo("/prisoners/$offenderNo/alerts/to-migrate")))
+      }
+
+      @Test
+      fun `will send all alerts to DPS`() {
+        dpsAlertsServer.verify(
+          postRequestedFor(urlPathEqualTo("/migrate/$offenderNo/alerts"))
+            .withRequestBodyJsonPath("[0].offenderBookId", "$bookingId")
+            .withRequestBodyJsonPath("[0].alertSeq", "1")
+            .withRequestBodyJsonPath("[1].offenderBookId", "$bookingId")
+            .withRequestBodyJsonPath("[1].alertSeq", "2"),
+        )
+      }
+
+      @Test
+      fun `will replaces mapping between the DPS and NOMIS alerts`() {
+        alertsMappingApiMockServer.verify(
+          putRequestedFor(urlPathEqualTo("/mapping/alerts/$offenderNo/all"))
+            .withRequestBodyJsonPath("mappingType", "NOMIS_CREATED")
+            .withRequestBodyJsonPath("mappings[0].nomisBookingId", "$bookingId")
+            .withRequestBodyJsonPath("mappings[0].nomisAlertSequence", "1")
+            .withRequestBodyJsonPath("mappings[0].dpsAlertId", "$dpsAlertId1")
+            .withRequestBodyJsonPath("mappings[1].nomisBookingId", "$bookingId")
+            .withRequestBodyJsonPath("mappings[1].nomisAlertSequence", "2")
+            .withRequestBodyJsonPath("mappings[1].dpsAlertId", "$dpsAlertId2"),
+        )
+      }
+
+      @Test
+      fun `will track telemetry for the resynchronise`() {
+        verify(telemetryClient).trackEvent(
+          eq("from-nomis-synch-alerts-resynchronise"),
+          check {
+            assertThat(it["offenderNo"]).isEqualTo(offenderNo)
+            assertThat(it["alertsCount"]).isEqualTo("2")
+            assertThat(it["alerts"]).isEqualTo("1, 2")
+          },
+          isNull(),
+        )
+      }
+
+      @Test
+      fun `will track telemetry for the repair`() {
+        verify(telemetryClient).trackEvent(
+          eq("from-nomis-synch-alerts-resynchronisation-repair"),
+          check {
+            assertThat(it["offenderNo"]).isEqualTo(offenderNo)
+          },
+          isNull(),
+        )
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDpsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDpsApiMockServer.kt
@@ -12,14 +12,12 @@ import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
-import org.springframework.http.HttpStatus
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts.model.Alert
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts.model.AlertCodeSummary
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts.model.MergedAlert
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts.model.MergedAlerts
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.alerts.model.MigratedAlert
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ErrorResponse
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -99,20 +97,6 @@ class AlertsDpsApiMockServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
-  fun stubMigrateAlert(
-    response: Alert = dpsAlert(),
-  ) {
-    stubFor(
-      post("/migrate/alerts")
-        .willReturn(
-          aResponse()
-            .withStatus(201)
-            .withHeader("Content-Type", "application/json")
-            .withBody(AlertsDpsApiExtension.objectMapper.writeValueAsString(response)),
-        ),
-    )
-  }
-
   fun stubMigrateAlerts(
     offenderNo: String,
     response: List<MigratedAlert> = listOf(migratedAlert()),
@@ -127,18 +111,18 @@ class AlertsDpsApiMockServer : WireMockServer(WIREMOCK_PORT) {
         ),
     )
   }
-
-  fun stubMigrateAlert(
-    status: HttpStatus,
-    error: ErrorResponse = ErrorResponse(status = status.value()),
+  fun stubResynchroniseAlerts(
+    offenderNo: String,
+    response: List<MigratedAlert> = listOf(migratedAlert()),
   ) {
     stubFor(
-      post("/migrate/alerts")
+      // TODO - switch to new API when available
+      post("/migrate/$offenderNo/alerts")
         .willReturn(
           aResponse()
-            .withStatus(status.value())
+            .withStatus(201)
             .withHeader("Content-Type", "application/json")
-            .withBody(AlertsDpsApiExtension.objectMapper.writeValueAsString(error)),
+            .withBody(AlertsDpsApiExtension.objectMapper.writeValueAsString(response)),
         ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDpsApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsDpsApiServiceTest.kt
@@ -337,6 +337,91 @@ class AlertsDpsApiServiceTest {
   }
 
   @Nested
+  inner class ResynchroniseAlerts {
+    @Test
+    internal fun `will pass oath2 token to service`() = runTest {
+      dpsAlertsServer.stubResynchroniseAlerts(offenderNo = "A1234KL")
+
+      apiService.resynchroniseAlerts(
+        offenderNo = "A1234KL",
+        alerts = listOf(
+          MigrateAlert(
+            offenderBookId = 1234567,
+            bookingSeq = 1,
+            alertSeq = 2,
+            activeFrom = LocalDate.now(),
+            alertCode = "XA",
+            authorisedBy = null,
+            description = null,
+            createdBy = "B.MORRIS",
+            createdByDisplayName = "B. Morris",
+            createdAt = LocalDateTime.now(),
+          ),
+        ),
+      )
+
+      dpsAlertsServer.verify(
+        postRequestedFor(anyUrl())
+          .withHeader("Authorization", equalTo("Bearer ABCDE")),
+      )
+    }
+
+    @Test
+    internal fun `will pass alerts to service`() = runTest {
+      dpsAlertsServer.stubResynchroniseAlerts(offenderNo = "A1234KL")
+
+      apiService.resynchroniseAlerts(
+        offenderNo = "A1234KL",
+        alerts = listOf(
+          MigrateAlert(
+            offenderBookId = 1234567,
+            bookingSeq = 1,
+            alertSeq = 2,
+            activeFrom = LocalDate.now(),
+            alertCode = "XA",
+            authorisedBy = null,
+            description = null,
+            createdBy = "B.MORRIS",
+            createdByDisplayName = "B. Morris",
+            createdAt = LocalDateTime.now(),
+          ),
+        ),
+      )
+
+      // TODO - switch to new endpoint when available
+      dpsAlertsServer.verify(
+        postRequestedFor(urlMatching("/migrate/A1234KL/alerts"))
+          .withRequestBody(matchingJsonPath("$[0].alertCode", equalTo("XA"))),
+      )
+    }
+
+    @Test
+    fun `will return dpsAlertIds`() = runTest {
+      dpsAlertsServer.stubResynchroniseAlerts(offenderNo = "A1234KL", response = listOf(migratedAlert().copy(alertUuid = UUID.fromString("f3f31737-6ee3-4ec5-8a79-0ac110fe50e2"))))
+
+      val dpsAlerts = apiService.resynchroniseAlerts(
+        offenderNo = "A1234KL",
+        alerts = listOf(
+          MigrateAlert(
+            offenderBookId = 1234567,
+            bookingSeq = 1,
+            alertSeq = 2,
+            activeFrom = LocalDate.now(),
+            alertCode = "XA",
+            authorisedBy = null,
+            description = null,
+            createdBy = "B.MORRIS",
+            createdByDisplayName = "B. Morris",
+            createdAt = LocalDateTime.now(),
+          ),
+        ),
+      )
+
+      assertThat(dpsAlerts[0].alertUuid.toString()).isEqualTo("f3f31737-6ee3-4ec5-8a79-0ac110fe50e2")
+    }
+  }
+
+  @Nested
   inner class MergeAlerts {
     @Test
     internal fun `will pass oath2 token to service`() = runTest {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiMockServer.kt
@@ -130,6 +130,18 @@ class AlertsMappingApiMockServer(private val objectMapper: ObjectMapper) {
       ),
     )
   }
+  fun stubReplaceMappings(offenderNo: String) {
+    mappingApi.stubFor(
+      put("/mapping/alerts/$offenderNo/all").willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(200),
+      ),
+    )
+  }
+  fun stubReplaceMappingsFailureFollowedBySuccess(offenderNo: String) {
+    mappingApi.stubMappingUpdateFailureFollowedBySuccess(url = "/mapping/alerts/$offenderNo/all")
+  }
 
   fun stubMigrationCount(recordsMigrated: Long) {
     mappingApi.stubFor(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/helper/Messages.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/helper/Messages.kt
@@ -50,3 +50,21 @@ fun mergeDomainEvent(
     }
 }
   """.trimIndent()
+fun prisonerReceivedDomainEvent(
+  eventType: String = "prisoner-offender-search.prisoner.received",
+  offenderNo: String = "A1234KT",
+  reason: String = "READMISSION",
+) =
+  //language=JSON
+  """{
+    "MessageId": "ae06c49e-1f41-4b9f-b2f2-dcca610d02cd", "Type": "Notification", "Timestamp": "2019-10-21T14:01:18.500Z", 
+    "Message": "{\"eventType\":\"$eventType\", \"description\": \"some desc\", \"additionalInformation\": {\"nomsNumber\":\"$offenderNo\", \"reason\":\"$reason\"}}",
+    "TopicArn": "arn:aws:sns:eu-west-1:000000000000:offender_events", 
+    "MessageAttributes": {
+      "eventType": {"Type": "String", "Value": "$eventType"}, 
+      "id": {"Type": "String", "Value": "8b07cbd9-0820-0a0f-c32f-a9429b618e0b"}, 
+      "contentType": {"Type": "String", "Value": "text/plain;charset=UTF-8"}, 
+      "timestamp": {"Type": "Number.java.lang.Long", "Value": "1571666478344"}
+    }
+}
+  """.trimIndent()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/MappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/MappingApiMockServer.kt
@@ -11,6 +11,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath
 import com.github.tomakehurst.wiremock.client.WireMock.okJson
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.put
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
@@ -700,6 +701,27 @@ class MappingApiMockServer : WireMockServer(WIREMOCK_PORT) {
 
     stubFor(
       post(urlPathEqualTo(url))
+        .inScenario("Retry create Scenario")
+        .whenScenarioStateIs("Cause create Success")
+        .willReturn(created())
+        .willSetStateTo(STARTED),
+    )
+  }
+  fun stubMappingUpdateFailureFollowedBySuccess(url: String) {
+    stubFor(
+      put(urlPathEqualTo(url))
+        .inScenario("Retry create Scenario")
+        .whenScenarioStateIs(STARTED)
+        .willReturn(
+          aResponse()
+            .withStatus(500) // request unsuccessful with status code 500
+            .withHeader("Content-Type", "application/json"),
+        )
+        .willSetStateTo("Cause create Success"),
+    )
+
+    stubFor(
+      put(urlPathEqualTo(url))
         .inScenario("Retry create Scenario")
         .whenScenarioStateIs("Cause create Success")
         .willReturn(created())


### PR DESCRIPTION
SDIT-1859 Resynchronising alerts on receive to old bookings  


When a prisoner is received on a old booking the alerts in DPS need resetting to match alerts in NOMIS therefore we need to 
* Get all current alerts as if this is a migration
* Replace alerts in DPS
* Replace mappings


TODO
* Call new DPS resynchronisation endpoint when available
* Narrow down scenario for old bookings that requires a search change