### PR TITLE
SDIT-1859 Resynchronising alerts to DPS API in new admission

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiService.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.histo
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.DuplicateErrorResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.MigrationMapping
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.AlertMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.NomisMappingIdUpdate
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.PrisonerAlertMappingsDto
 
 @Service
@@ -54,17 +53,6 @@ class AlertsMappingApiService(@Qualifier("mappingApiWebClient") webClient: WebCl
       .retrieve()
       .awaitBodilessEntity()
   }
-
-  suspend fun updateNomisMappingId(previousBookingId: Long, alertSequence: Long, newBookingId: Long): AlertMappingDto? =
-    webClient.put()
-      .uri(
-        "/mapping/alerts/nomis-booking-id/{bookingId}/nomis-alert-sequence/{alertSequence}",
-        previousBookingId,
-        alertSequence,
-      )
-      .bodyValue(NomisMappingIdUpdate(bookingId = newBookingId))
-      .retrieve()
-      .awaitBodyOrNullWhenNotFound()
 
   suspend fun replaceMappings(
     offenderNo: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsMappingApiServiceTest.kt
@@ -298,32 +298,6 @@ class AlertsMappingApiServiceTest {
   }
 
   @Nested
-  inner class UpdateNomisMappingId {
-    @Test
-    internal fun `will pass oath2 token to service`() = runTest {
-      alertsMappingApiMockServer.stubUpdateByNomisId(previousBookingId = 5000, alertSequence = 3)
-
-      apiService.updateNomisMappingId(previousBookingId = 5000, alertSequence = 3, newBookingId = 123456)
-
-      alertsMappingApiMockServer.verify(
-        putRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
-      )
-    }
-
-    @Test
-    internal fun `will pass ids to service`() = runTest {
-      alertsMappingApiMockServer.stubUpdateByNomisId(previousBookingId = 5000, alertSequence = 3)
-
-      apiService.updateNomisMappingId(previousBookingId = 5000, alertSequence = 3, newBookingId = 123456)
-
-      alertsMappingApiMockServer.verify(
-        putRequestedFor(urlPathEqualTo("/mapping/alerts/nomis-booking-id/5000/nomis-alert-sequence/3"))
-          .withRequestBody(matchingJsonPath("bookingId", equalTo("123456"))),
-      )
-    }
-  }
-
-  @Nested
   inner class ReplaceMappings {
     @Test
     internal fun `will pass oath2 token to service`() = runTest {


### PR DESCRIPTION
Since there are edge cases where we can't work out what the previous booking is - this change uses the resync endpoint to simply replace all alerts in DPS on a new booking