### PR TITLE
SDIT-1858 Added the ability for domain switch for generic events.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsEventListener.kt
@@ -39,7 +39,7 @@ class AlertsEventListener(
       when (sqsMessage.Type) {
         "Notification" -> {
           val eventType = sqsMessage.MessageAttributes!!.eventType.Value
-          if (eventFeatureSwitch.isEnabled(eventType)) {
+          if (eventFeatureSwitch.isEnabled(eventType, "alerts")) {
             when (eventType) {
               "ALERT-UPDATED" -> alertsSynchronisationService.nomisAlertUpdated(sqsMessage.Message.fromJson())
               "ALERT-INSERTED" -> alertsSynchronisationService.nomisAlertInserted(sqsMessage.Message.fromJson())
@@ -89,8 +89,6 @@ data class AlertUpdatedEvent(
 
 private fun asCompletableFuture(
   process: suspend () -> Unit,
-): CompletableFuture<Void> {
-  return CoroutineScope(Dispatchers.Default).future {
-    process()
-  }.thenAccept { }
-}
+): CompletableFuture<Void> = CoroutineScope(Dispatchers.Default).future {
+  process()
+}.thenAccept { }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/casenotes/CaseNotesPrisonOffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/casenotes/CaseNotesPrisonOffenderEventListener.kt
@@ -37,7 +37,7 @@ class CaseNotesPrisonOffenderEventListener(
       when (sqsMessage.Type) {
         "Notification" -> {
           val eventType = sqsMessage.MessageAttributes!!.eventType.Value
-          if (eventFeatureSwitch.isEnabled(eventType)) {
+          if (eventFeatureSwitch.isEnabled(eventType, "casenotes")) {
             when (eventType) {
               "OFFENDER_CASE_NOTES-INSERTED" -> caseNotesSynchronisationService.caseNoteInserted(sqsMessage.Message.fromJson())
               "OFFENDER_CASE_NOTES-UPDATED" -> caseNotesSynchronisationService.caseNoteUpdated(sqsMessage.Message.fromJson())
@@ -72,8 +72,6 @@ data class CaseNotesEvent(
 
 private fun asCompletableFuture(
   process: suspend () -> Unit,
-): CompletableFuture<Void> {
-  return CoroutineScope(Dispatchers.Default).future {
-    process()
-  }.thenAccept { }
-}
+): CompletableFuture<Void> = CoroutineScope(Dispatchers.Default).future {
+  process()
+}.thenAccept { }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingEventListener.kt
@@ -39,7 +39,7 @@ class CourtSentencingEventListener(
       when (sqsMessage.Type) {
         "Notification" -> {
           val eventType = sqsMessage.MessageAttributes!!.eventType.Value
-          if (eventFeatureSwitch.isEnabled(eventType)) {
+          if (eventFeatureSwitch.isEnabled(eventType, "courtsentencing")) {
             when (eventType) {
               "OFFENDER_CASES-INSERTED" -> courtSentencingSynchronisationService.nomisCourtCaseInserted(sqsMessage.Message.fromJson())
               "OFFENDER_CASES-UPDATED" -> courtSentencingSynchronisationService.nomisCourtCaseUpdated(sqsMessage.Message.fromJson())
@@ -126,8 +126,6 @@ data class OffenderSentenceEvent(
 
 private fun asCompletableFuture(
   process: suspend () -> Unit,
-): CompletableFuture<Void> {
-  return CoroutineScope(Dispatchers.Default).future {
-    process()
-  }.thenAccept { }
-}
+): CompletableFuture<Void> = CoroutineScope(Dispatchers.Default).future {
+  process()
+}.thenAccept { }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/csip/CSIPPrisonOffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/csip/CSIPPrisonOffenderEventListener.kt
@@ -39,7 +39,7 @@ class CSIPPrisonOffenderEventListener(
       when (sqsMessage.Type) {
         "Notification" -> {
           val eventType = sqsMessage.MessageAttributes!!.eventType.Value
-          if (eventFeatureSwitch.isEnabled(eventType)) {
+          if (eventFeatureSwitch.isEnabled(eventType, "csip")) {
             when (eventType) {
               "CSIP_REPORTS-INSERTED" -> csipSynchronisationService.csipReportInserted(sqsMessage.Message.fromJson())
               "CSIP_REPORTS-UPDATED" -> csipReportUpdated(sqsMessage.Message.fromJson())
@@ -112,8 +112,6 @@ data class CSIPFactorEvent(
 
 private fun asCompletableFuture(
   process: suspend () -> Unit,
-): CompletableFuture<Void> {
-  return CoroutineScope(Dispatchers.Default).future {
-    process()
-  }.thenAccept { }
-}
+): CompletableFuture<Void> = CoroutineScope(Dispatchers.Default).future {
+  process()
+}.thenAccept { }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/incidents/IncidentsPrisonOffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/incidents/IncidentsPrisonOffenderEventListener.kt
@@ -37,7 +37,7 @@ class IncidentsPrisonOffenderEventListener(
       when (sqsMessage.Type) {
         "Notification" -> {
           val eventType = sqsMessage.MessageAttributes!!.eventType.Value
-          if (eventFeatureSwitch.isEnabled(eventType)) {
+          if (eventFeatureSwitch.isEnabled(eventType, "incidents")) {
             when (eventType) {
               "INCIDENT-INSERTED" -> incidentsSynchronisationService.synchroniseIncidentInsert(sqsMessage.Message.fromJson())
 
@@ -82,8 +82,6 @@ data class IncidentsOffenderEvent(
 
 private fun asCompletableFuture(
   process: suspend () -> Unit,
-): CompletableFuture<Void> {
-  return CoroutineScope(Dispatchers.Default).future {
-    process()
-  }.thenAccept { }
-}
+): CompletableFuture<Void> = CoroutineScope(Dispatchers.Default).future {
+  process()
+}.thenAccept { }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/listeners/EventFeatureSwitch.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/listeners/EventFeatureSwitch.kt
@@ -5,7 +5,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class EventFeatureSwitch(private val environment: Environment) {
-  fun isEnabled(eventType: String): Boolean {
-    return environment.getProperty("feature.event.$eventType", Boolean::class.java, true)
-  }
+  fun isEnabled(eventType: String, domain: String? = null): Boolean =
+    isEnabled("feature.event.$eventType") &&
+      (domain == null || isEnabled("feature.event.$domain.$eventType"))
+
+  private fun isEnabled(property: String): Boolean = environment.getProperty(property, Boolean::class.java, true)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/prisonperson/PrisonPersonEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/prisonperson/PrisonPersonEventListener.kt
@@ -35,7 +35,7 @@ class PrisonPersonEventListener(
       when (sqsMessage.Type) {
         "Notification" -> {
           val eventType = sqsMessage.MessageAttributes!!.eventType.Value
-          if (eventFeatureSwitch.isEnabled(eventType)) {
+          if (eventFeatureSwitch.isEnabled(eventType, "prisonperson")) {
             when (eventType) {
               "OFFENDER_PHYSICAL_ATTRIBUTES-CHANGED" -> prisonPersonService.physicalAttributesChanged(sqsMessage.Message.fromJson())
               else -> log.info("Received a message I wasn't expecting {}", eventType)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/listeners/EventFeatureSwitchTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/listeners/EventFeatureSwitchTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.TestPropertySource
@@ -10,6 +11,7 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.SqsIn
   properties = [
     "feature.event.IEP_UPSERTED=true",
     "feature.event.OTHER_EVENT=false",
+    "feature.event.casenote.GENERIC_EVENT=false",
   ],
 )
 internal class EventFeatureSwitchTest : SqsIntegrationTestBase() {
@@ -30,5 +32,23 @@ internal class EventFeatureSwitchTest : SqsIntegrationTestBase() {
   @Test
   fun `should return true when feature switch is not present`() {
     assertThat(featureSwitch.isEnabled("NO_SWITCH_EVENT")).isTrue
+  }
+
+  @Nested
+  inner class DomainSwitch {
+    @Test
+    fun `should return true when feature switch is not present `() {
+      assertThat(featureSwitch.isEnabled("GENERIC_EVENT")).isTrue
+    }
+
+    @Test
+    fun `should return true when feature switch is not present for domain `() {
+      assertThat(featureSwitch.isEnabled("GENERIC_EVENT", domain = "alert")).isTrue
+    }
+
+    @Test
+    fun `should return false when feature switch is present for domain `() {
+      assertThat(featureSwitch.isEnabled("GENERIC_EVENT", domain = "casenote")).isFalse()
+    }
   }
 }


### PR DESCRIPTION
This allows to switch off generic events e.g. prison-offender-events.prisoner.merged for a domain.

FEATURE_EVENT_PRISON-OFFENDER-EVENTS_PRISONER_MERGED would become FEATURE_EVENT_ALERTS_PRISON-OFFENDER-EVENTS_PRISONER_MERGED to turn-off just for alerts. No domains require this so far but added the domain parameter for ones in progress