### PR TITLE
SDIT-1886 Resynchronise alerts after a booking has moved.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsEventListener.kt
@@ -45,6 +45,7 @@ class AlertsEventListener(
               "ALERT-INSERTED" -> alertsSynchronisationService.nomisAlertInserted(sqsMessage.Message.fromJson())
               "ALERT-DELETED" -> alertsSynchronisationService.nomisAlertDeleted(sqsMessage.Message.fromJson())
               "prison-offender-events.prisoner.merged" -> alertsSynchronisationService.synchronisePrisonerMerge(sqsMessage.Message.fromJson())
+              "prison-offender-events.prisoner.booking.moved" -> alertsSynchronisationService.synchronisePrisonerBookingMoved(sqsMessage.Message.fromJson())
               "prisoner-offender-search.prisoner.received" -> alertsSynchronisationService.resynchronisePrisonerAlertsForAdmission(sqsMessage.Message.fromJson())
 
               else -> log.info("Received a message I wasn't expecting {}", eventType)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/data/NomisPrisonerMergeEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/data/NomisPrisonerMergeEvent.kt
@@ -22,3 +22,13 @@ data class ReceivePrisonerAdditionalInformationEvent(
   val nomsNumber: String,
   val reason: String,
 )
+
+data class PrisonerBookingMovedDomainEvent(
+  val additionalInformation: BookingMovedAdditionalInformationEvent,
+)
+
+data class BookingMovedAdditionalInformationEvent(
+  val movedToNomsNumber: String,
+  val movedFromNomsNumber: String,
+  val bookingId: Long,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/helper/Messages.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/helper/Messages.kt
@@ -50,6 +50,26 @@ fun mergeDomainEvent(
     }
 }
   """.trimIndent()
+
+fun bookingMovedDomainEvent(
+  eventType: String = "prison-offender-events.prisoner.booking.moved",
+  bookingId: Long = 1234567,
+  movedToNomsNumber: String = "A1234KT",
+  movedFromNomsNumber: String = "A1000KT",
+) =
+  //language=JSON
+  """{
+    "MessageId": "ae06c49e-1f41-4b9f-b2f2-dcca610d02cd", "Type": "Notification", "Timestamp": "2019-10-21T14:01:18.500Z", 
+    "Message": "{\"eventType\":\"$eventType\", \"description\": \"some desc\", \"additionalInformation\": {\"movedToNomsNumber\":\"$movedToNomsNumber\", \"movedFromNomsNumber\":\"$movedFromNomsNumber\", \"bookingId\":\"$bookingId\"}}",
+    "TopicArn": "arn:aws:sns:eu-west-1:000000000000:offender_events", 
+    "MessageAttributes": {
+      "eventType": {"Type": "String", "Value": "$eventType"}, 
+      "id": {"Type": "String", "Value": "8b07cbd9-0820-0a0f-c32f-a9429b618e0b"}, 
+      "contentType": {"Type": "String", "Value": "text/plain;charset=UTF-8"}, 
+      "timestamp": {"Type": "Number.java.lang.Long", "Value": "1571666478344"}
+    }
+}
+  """.trimIndent()
 fun prisonerReceivedDomainEvent(
   eventType: String = "prisoner-offender-search.prisoner.received",
   offenderNo: String = "A1234KT",


### PR DESCRIPTION
When a booking is moved from Prisoner A to Prisoner B, Prisoner B would have already resynchronised, but the source prisoner (Prisoner A) need to be resynchronised as well