### PR TITLE
SDIT-1886 Resynchronise alerts after a booking has moved.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsSynchronisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsSynchronisationService.kt
@@ -263,7 +263,7 @@ class AlertsSynchronisationService(
         },
       )
 
-      tryToReplaceMergedMappings(movedFromNomsNumber, MergedPrisonerAlertMappingsDto(movedFromNomsNumber, prisonerMappings), telemetry)
+      tryToReplaceMappings(offenderNo = movedFromNomsNumber, prisonerMappings = prisonerMappings, telemetry)
       telemetryClient.trackEvent(
         "from-nomis-synch-alerts-booking-moved",
         telemetry,
@@ -327,23 +327,6 @@ class AlertsSynchronisationService(
     }
   }
 
-  private suspend fun tryToCreateMappings(
-    mappings: List<AlertMappingDto>,
-    telemetry: Map<String, Any>,
-  ): MappingResponse {
-    try {
-      return createMappingsBatch(mappings, telemetry)
-    } catch (e: Exception) {
-      log.error("Failed to create mappings for alert id $mappings", e)
-      queueService.sendMessage(
-        messageType = SynchronisationMessageType.RETRY_SYNCHRONISATION_MAPPING_BATCH.name,
-        synchronisationType = SynchronisationType.ALERTS,
-        message = mappings,
-        telemetryAttributes = telemetry.valuesAsStrings(),
-      )
-      return MAPPING_FAILED
-    }
-  }
   private suspend fun tryToReplaceMappings(
     offenderNo: String,
     prisonerMappings: PrisonerAlertMappingsDto,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsSynchronisationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/alerts/AlertsSynchronisationIntTest.kt
@@ -1161,7 +1161,7 @@ class AlertsSynchronisationIntTest : SqsIntegrationTestBase() {
             resyncedAlert().copy(offenderBookId = bookingId, alertSeq = 2, alertUuid = dpsAlertId2),
           ),
         )
-        alertsMappingApiMockServer.stubReplaceMappingsForMerge(movedFromNomsNumber)
+        alertsMappingApiMockServer.stubReplaceMappings(movedFromNomsNumber)
         awsSqsSentencingOffenderEventsClient.sendMessage(
           alertsQueueOffenderEventsUrl,
           bookingMovedDomainEvent(
@@ -1192,15 +1192,14 @@ class AlertsSynchronisationIntTest : SqsIntegrationTestBase() {
       @Test
       fun `will create a mapping between the DPS and NOMIS alerts`() {
         alertsMappingApiMockServer.verify(
-          putRequestedFor(urlPathEqualTo("/mapping/alerts/$movedFromNomsNumber/merge"))
-            .withRequestBodyJsonPath("prisonerMapping.mappings[0].nomisBookingId", "$bookingId")
-            .withRequestBodyJsonPath("prisonerMapping.mappings[0].nomisAlertSequence", "1")
-            .withRequestBodyJsonPath("prisonerMapping.mappings[0].dpsAlertId", "$dpsAlertId1")
-            .withRequestBodyJsonPath("prisonerMapping.mappings[1].nomisBookingId", "$bookingId")
-            .withRequestBodyJsonPath("prisonerMapping.mappings[1].nomisAlertSequence", "2")
-            .withRequestBodyJsonPath("prisonerMapping.mappings[1].dpsAlertId", "$dpsAlertId2")
-            .withRequestBodyJsonPath("prisonerMapping.mappingType", "NOMIS_CREATED")
-            .withRequestBodyJsonPath("removedOffenderNo", "A1000KT"),
+          putRequestedFor(urlPathEqualTo("/mapping/alerts/$movedFromNomsNumber/all"))
+            .withRequestBodyJsonPath("mappings[0].nomisBookingId", "$bookingId")
+            .withRequestBodyJsonPath("mappings[0].nomisAlertSequence", "1")
+            .withRequestBodyJsonPath("mappings[0].dpsAlertId", "$dpsAlertId1")
+            .withRequestBodyJsonPath("mappings[1].nomisBookingId", "$bookingId")
+            .withRequestBodyJsonPath("mappings[1].nomisAlertSequence", "2")
+            .withRequestBodyJsonPath("mappings[1].dpsAlertId", "$dpsAlertId2")
+            .withRequestBodyJsonPath("mappingType", "NOMIS_CREATED"),
         )
       }
 
@@ -1238,7 +1237,7 @@ class AlertsSynchronisationIntTest : SqsIntegrationTestBase() {
             resyncedAlert().copy(offenderBookId = bookingId, alertSeq = 2, alertUuid = dpsAlertId2),
           ),
         )
-        alertsMappingApiMockServer.stubReplaceMappingsForMergeFollowedBySuccess(movedFromNomsNumber)
+        alertsMappingApiMockServer.stubReplaceMappingsFailureFollowedBySuccess(movedFromNomsNumber)
         awsSqsSentencingOffenderEventsClient.sendMessage(
           alertsQueueOffenderEventsUrl,
           bookingMovedDomainEvent(
@@ -1271,15 +1270,14 @@ class AlertsSynchronisationIntTest : SqsIntegrationTestBase() {
       fun `will try to create a mapping between the DPS and NOMIS alerts until it succeeds`() {
         alertsMappingApiMockServer.verify(
           2,
-          putRequestedFor(urlPathEqualTo("/mapping/alerts/$movedFromNomsNumber/merge"))
-            .withRequestBodyJsonPath("prisonerMapping.mappings[0].nomisBookingId", "$bookingId")
-            .withRequestBodyJsonPath("prisonerMapping.mappings[0].nomisAlertSequence", "1")
-            .withRequestBodyJsonPath("prisonerMapping.mappings[0].dpsAlertId", "$dpsAlertId1")
-            .withRequestBodyJsonPath("prisonerMapping.mappings[1].nomisBookingId", "$bookingId")
-            .withRequestBodyJsonPath("prisonerMapping.mappings[1].nomisAlertSequence", "2")
-            .withRequestBodyJsonPath("prisonerMapping.mappings[1].dpsAlertId", "$dpsAlertId2")
-            .withRequestBodyJsonPath("prisonerMapping.mappingType", "NOMIS_CREATED")
-            .withRequestBodyJsonPath("removedOffenderNo", "A1000KT"),
+          putRequestedFor(urlPathEqualTo("/mapping/alerts/$movedFromNomsNumber/all"))
+            .withRequestBodyJsonPath("mappings[0].nomisBookingId", "$bookingId")
+            .withRequestBodyJsonPath("mappings[0].nomisAlertSequence", "1")
+            .withRequestBodyJsonPath("mappings[0].dpsAlertId", "$dpsAlertId1")
+            .withRequestBodyJsonPath("mappings[1].nomisBookingId", "$bookingId")
+            .withRequestBodyJsonPath("mappings[1].nomisAlertSequence", "2")
+            .withRequestBodyJsonPath("mappings[1].dpsAlertId", "$dpsAlertId2")
+            .withRequestBodyJsonPath("mappingType", "NOMIS_CREATED"),
         )
       }
 


### PR DESCRIPTION
Switched to using /mapping/alerts/{offenderNo}/all rather than the merge equivalent - the merge version would have simply removed mappings twice though did work