### PR TITLE
SDIT-2089 Correct slow complete migration logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/activities/ActivitiesMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/activities/ActivitiesMigrationService.kt
@@ -33,12 +33,14 @@ class ActivitiesMigrationService(
   @Value("\${activities.page.size:20}") pageSize: Long,
   @Value("\${activities.complete-check.delay-seconds}") completeCheckDelaySeconds: Int,
   @Value("\${activities.complete-check.count}") completeCheckCount: Int,
+  @Value("\${complete-check.scheduled-retry-seconds}") completeCheckScheduledRetrySeconds: Int,
 ) : MigrationService<ActivitiesMigrationFilter, FindActiveActivityIdsResponse, ActivityMigrationMappingDto>(
   mappingService = activitiesMappingService,
   migrationType = ACTIVITIES,
   pageSize = pageSize,
   completeCheckDelaySeconds = completeCheckDelaySeconds,
   completeCheckCount = completeCheckCount,
+  completeCheckScheduledRetrySeconds = completeCheckScheduledRetrySeconds,
 ) {
 
   private val log = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/activities/AllocationsMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/activities/AllocationsMigrationService.kt
@@ -39,12 +39,14 @@ class AllocationsMigrationService(
   @Value("\${allocations.page.size:50}") pageSize: Long,
   @Value("\${allocations.complete-check.delay-seconds}") completeCheckDelaySeconds: Int,
   @Value("\${allocations.complete-check.count}") completeCheckCount: Int,
+  @Value("\${complete-check.scheduled-retry-seconds}") completeCheckScheduledRetrySeconds: Int,
 ) : MigrationService<AllocationsMigrationFilter, FindActiveAllocationIdsResponse, AllocationMigrationMappingDto>(
   mappingService = allocationsMappingService,
   migrationType = MigrationType.ALLOCATIONS,
   pageSize = pageSize,
   completeCheckDelaySeconds = completeCheckDelaySeconds,
   completeCheckCount = completeCheckCount,
+  completeCheckScheduledRetrySeconds = completeCheckScheduledRetrySeconds,
 ) {
 
   private val log = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/contactperson/ContactPersonMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/contactperson/ContactPersonMigrationService.kt
@@ -25,6 +25,7 @@ class ContactPersonMigrationService(
   @Value("\${contactperson.complete-check.delay-seconds}") completeCheckDelaySeconds: Int,
   @Value("\${contactperson.complete-check.retry-seconds:1}") completeCheckRetrySeconds: Int,
   @Value("\${contactperson.complete-check.count}") completeCheckCount: Int,
+  @Value("\${complete-check.scheduled-retry-seconds}") completeCheckScheduledRetrySeconds: Int,
 ) : MigrationService<ContactPersonMigrationFilter, PersonIdResponse, ContactPersonMappingsDto>(
   mappingService = contactPersonMappingService,
   migrationType = MigrationType.CONTACTPERSON,
@@ -32,6 +33,7 @@ class ContactPersonMigrationService(
   completeCheckDelaySeconds = completeCheckDelaySeconds,
   completeCheckCount = completeCheckCount,
   completeCheckRetrySeconds = completeCheckRetrySeconds,
+  completeCheckScheduledRetrySeconds = completeCheckScheduledRetrySeconds,
 ) {
   private companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/MigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/MigrationService.kt
@@ -19,6 +19,7 @@ abstract class MigrationService<FILTER : Any, NOMIS_ID : Any, MAPPING : Any>(
   private val completeCheckDelaySeconds: Int,
   private val completeCheckCount: Int,
   private val completeCheckRetrySeconds: Int = 1,
+  private val completeCheckScheduledRetrySeconds: Int = completeCheckDelaySeconds,
 ) {
 
   @Autowired
@@ -123,7 +124,7 @@ abstract class MigrationService<FILTER : Any, NOMIS_ID : Any, MAPPING : Any>(
           context = context,
           body = MigrationStatusCheck(),
         ),
-        delaySeconds = completeCheckDelaySeconds,
+        delaySeconds = completeCheckScheduledRetrySeconds,
       )
     } else {
       if (context.body.hasCheckedAReasonableNumberOfTimes(completeCheckCount)) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -152,6 +152,7 @@ cancel:
 
 complete-check:
   delay-seconds: 10
+  scheduled-retry-seconds: 10
   count: 9
 
 activities:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/activities/ActivitiesMigrationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/activities/ActivitiesMigrationServiceTest.kt
@@ -67,6 +67,7 @@ class ActivitiesMigrationServiceTest {
     pageSize = 3L,
     completeCheckDelaySeconds = 10,
     completeCheckCount = 9,
+    completeCheckScheduledRetrySeconds = 10,
   ) {
     init {
       queueService = this@ActivitiesMigrationServiceTest.queueService
@@ -91,6 +92,7 @@ class ActivitiesMigrationServiceTest {
       pageSize = 3L,
       completeCheckDelaySeconds = 10,
       completeCheckCount = 9,
+      completeCheckScheduledRetrySeconds = 0,
     ) {
       init {
         queueService = this@ActivitiesMigrationServiceTest.queueService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/activities/AllocationsMigrationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/activities/AllocationsMigrationServiceTest.kt
@@ -82,6 +82,7 @@ class AllocationsMigrationServiceTest {
     pageSize = 3L,
     completeCheckDelaySeconds = 10,
     completeCheckCount = 9,
+    completeCheckScheduledRetrySeconds = 10,
   ) {
     init {
       queueService = this@AllocationsMigrationServiceTest.queueService
@@ -107,6 +108,7 @@ class AllocationsMigrationServiceTest {
       pageSize = 3L,
       completeCheckDelaySeconds = 10,
       completeCheckCount = 9,
+      completeCheckScheduledRetrySeconds = 0,
     ) {
       init {
         queueService = this@AllocationsMigrationServiceTest.queueService

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -105,6 +105,7 @@ cancel:
 
 complete-check:
   delay-seconds: 1
+  scheduled-retry-seconds: 1
   count: 1
 
 hmpps.sqs:


### PR DESCRIPTION
Previously migrations would incorrectly wait for the same amount time it would wait at the beginning of a migration for the initial slow "get ids" query compared to  the end of the migration.

This is now a separate config.

For contacts,allocations,activities this is set to 10 seconds all others are whatever the value is now to not break anything