### PR TITLE
SDIT-2248 Revised case notes merge strategy

### DIFF
--- a/openapi-specs/nomis-sync-api-docs.json
+++ b/openapi-specs/nomis-sync-api-docs.json
@@ -7,7 +7,7 @@
       "name": "HMPPS Digital Studio",
       "email": "feedback@digital.justice.gov.uk"
     },
-    "version": "2024-11-19.9951.ae8549a"
+    "version": "2024-11-20.9974.f0be93a"
   },
   "servers": [
     {
@@ -17918,12 +17918,12 @@
             "type": "integer",
             "format": "int32"
           },
+          "paged": {
+            "type": "boolean"
+          },
           "pageNumber": {
             "type": "integer",
             "format": "int32"
-          },
-          "paged": {
-            "type": "boolean"
           },
           "unpaged": {
             "type": "boolean"
@@ -20083,7 +20083,13 @@
           "occurrenceDateTime": {
             "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
             "type": "string",
-            "description": "Date case note occurred",
+            "description": "Datetime case note occurred",
+            "example": "2021-07-05T10:35:17"
+          },
+          "creationDateTime": {
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
+            "type": "string",
+            "description": "Datetime case note was created by user",
             "example": "2021-07-05T10:35:17"
           },
           "authorStaffId": {
@@ -20121,12 +20127,12 @@
           "createdDatetime": {
             "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$",
             "type": "string",
-            "description": "Created timestamp",
+            "description": "Created DB timestamp",
             "example": "2021-07-05T10:35:17"
           },
           "createdUsername": {
             "type": "string",
-            "description": "Created username"
+            "description": "Created DB username"
           },
           "auditModuleName": {
             "type": "string",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/casenotes/CaseNotesMappingApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/casenotes/CaseNotesMappingApiService.kt
@@ -1,38 +1,17 @@
 package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.casenotes
 
-import kotlinx.coroutines.reactive.awaitFirstOrDefault
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.reactive.function.client.awaitBodilessEntity
 import org.springframework.web.reactive.function.client.awaitBody
-import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.awaitBodyOrNullWhenNotFound
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.CreateMappingResult
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.DuplicateErrorResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.MigrationMapping
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CaseNoteMappingDto
 
 @Service
 class CaseNotesMappingApiService(@Qualifier("mappingApiWebClient") webClient: WebClient) :
   MigrationMapping<CaseNoteMappingDto>(domainUrl = "/mapping/casenotes", webClient) {
-  suspend fun createMappings(
-    mappings: List<CaseNoteMappingDto>,
-    errorJavaClass: ParameterizedTypeReference<DuplicateErrorResponse<CaseNoteMappingDto>>,
-  ): CreateMappingResult<CaseNoteMappingDto> =
-    webClient.post()
-      .uri("/mapping/casenotes/batch")
-      .bodyValue(mappings)
-      .retrieve()
-      .bodyToMono(Unit::class.java)
-      .map { CreateMappingResult<CaseNoteMappingDto>() }
-      .onErrorResume(WebClientResponseException.Conflict::class.java) {
-        Mono.just(CreateMappingResult(it.getResponseBodyAs(errorJavaClass)))
-      }
-      .awaitFirstOrDefault(CreateMappingResult())
-
   suspend fun deleteMappingGivenDpsId(dpsCaseNoteId: String) {
     webClient.delete()
       .uri("/mapping/casenotes/dps-casenote-id/{dpsCaseNoteId}", dpsCaseNoteId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/casenotes/CaseNotesNomisApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/casenotes/CaseNotesNomisApiServiceTest.kt
@@ -81,7 +81,7 @@ class CaseNotesNomisApiServiceTest {
       assertThat(response.caseNotes).hasSize(2)
       assertThat(response.caseNotes[0].bookingId).isEqualTo(1L)
       assertThat(response.caseNotes[0].caseNoteId).isEqualTo(1L)
-      assertThat(response.caseNotes[1].bookingId).isEqualTo(2L)
+      assertThat(response.caseNotes[1].bookingId).isEqualTo(1L)
       assertThat(response.caseNotes[1].caseNoteId).isEqualTo(2L)
     }
   }


### PR DESCRIPTION
New logic in the case notes merge which avoids migrating duplicate case notes created by merges, but including mappings for them pointing to the same DPS id as the original case notes