### PR TITLE
SDIT-2270 Handle PHONES_PERSON-INSERTED

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/contactperson/ContactPersonEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/contactperson/ContactPersonEventListener.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.contactperson.Con
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.contactperson.ContactPersonSynchronisationMessageType.RETRY_SYNCHRONISATION_CONTACT_MAPPING
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.contactperson.ContactPersonSynchronisationMessageType.RETRY_SYNCHRONISATION_EMAIL_MAPPING
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.contactperson.ContactPersonSynchronisationMessageType.RETRY_SYNCHRONISATION_PERSON_MAPPING
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.contactperson.ContactPersonSynchronisationMessageType.RETRY_SYNCHRONISATION_PHONE_MAPPING
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.EventFeatureSwitch
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.SQSMessage
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.asCompletableFuture
@@ -80,6 +81,7 @@ class ContactPersonEventListener(
       RETRY_SYNCHRONISATION_CONTACT_MAPPING -> service.retryCreateContactMapping(message.fromJson())
       RETRY_SYNCHRONISATION_ADDRESS_MAPPING -> service.retryCreateAddressMapping(message.fromJson())
       RETRY_SYNCHRONISATION_EMAIL_MAPPING -> service.retryCreateEmailMapping(message.fromJson())
+      RETRY_SYNCHRONISATION_PHONE_MAPPING -> service.retryCreatePhoneMapping(message.fromJson())
     }
   }
 }
@@ -124,6 +126,7 @@ data class PersonAddressEvent(
 data class PersonPhoneEvent(
   val personId: Long,
   val phoneId: Long,
+  val addressId: Long?,
   override val auditModuleName: String,
   val isAddress: Boolean,
 ) : EventAudited
@@ -151,4 +154,5 @@ enum class ContactPersonSynchronisationMessageType {
   RETRY_SYNCHRONISATION_CONTACT_MAPPING,
   RETRY_SYNCHRONISATION_ADDRESS_MAPPING,
   RETRY_SYNCHRONISATION_EMAIL_MAPPING,
+  RETRY_SYNCHRONISATION_PHONE_MAPPING,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/contactperson/ContactPersonMappingApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/contactperson/ContactPersonMappingApiService.kt
@@ -7,6 +7,7 @@ import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.reactive.function.client.awaitBody
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.awaitBodyOrNullWhenNotFound
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.CreateMappingResult
@@ -43,6 +44,14 @@ class ContactPersonMappingApiService(@Qualifier("mappingApiWebClient") webClient
     )
     .retrieve()
     .awaitBodyOrNullWhenNotFound()
+
+  suspend fun getByNomisAddressId(nomisAddressId: Long): PersonAddressMappingDto = webClient.get()
+    .uri(
+      "/mapping/contact-person/address/nomis-address-id/{nomisAddressId}",
+      nomisAddressId,
+    )
+    .retrieve()
+    .awaitBody()
 
   suspend fun getByNomisEmailIdOrNull(nomisInternetAddressId: Long): PersonEmailMappingDto? = webClient.get()
     .uri(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/contactperson/ContactPersonMappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/contactperson/ContactPersonMappingApiMockServer.kt
@@ -231,6 +231,26 @@ class ContactPersonMappingApiMockServer(private val objectMapper: ObjectMapper) 
     }
   }
 
+  fun stubGetByNomisAddressId(
+    nomisAddressId: Long = 123456,
+    mapping: PersonAddressMappingDto = PersonAddressMappingDto(
+      nomisId = 123456,
+      dpsId = "654321",
+      mappingType = PersonAddressMappingDto.MappingType.MIGRATED,
+    ),
+  ) {
+    mapping.apply {
+      mappingApi.stubFor(
+        get(urlEqualTo("/mapping/contact-person/address/nomis-address-id/$nomisAddressId")).willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(HttpStatus.OK.value())
+            .withBody(objectMapper.writeValueAsString(mapping)),
+        ),
+      )
+    }
+  }
+
   fun stubCreateAddressMapping() {
     mappingApi.stubFor(
       post("/mapping/contact-person/address").willReturn(


### PR DESCRIPTION
A bit more complicated than other sync events since:
* NOMIS has single event for person phones and phones associated with an address
* DPS has different endpoints for the address and the global phone numbers
* For an address related phone we therefore have to look up the DPS address Id as well