### PR TITLE
SDIT-2290 offenderIdDisplay can be null

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/contactperson/ContactPersonEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/contactperson/ContactPersonEventListener.kt
@@ -112,7 +112,7 @@ data class ContactEvent(
 
 data class ContactRestrictionEvent(
   val offenderPersonRestrictionId: Long,
-  val offenderIdDisplay: String,
+  val offenderIdDisplay: String?,
   val personId: Long,
   val contactPersonId: Long,
   override val auditModuleName: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/contactperson/ContactPersonSynchronisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/contactperson/ContactPersonSynchronisationService.kt
@@ -218,7 +218,7 @@ class ContactPersonSynchronisationService(
 
   suspend fun contactRestrictionUpserted(event: ContactRestrictionEvent) {
     val telemetry =
-      telemetryOf("offenderNo" to event.offenderIdDisplay, "nomisPersonId" to event.personId, "dpsContactId" to event.personId, "nomisContactId" to event.contactPersonId, "nomisContactRestrictionId" to event.offenderPersonRestrictionId)
+      telemetryOf("offenderNo" to (event.offenderIdDisplay ?: "unknown"), "nomisPersonId" to event.personId, "dpsContactId" to event.personId, "nomisContactId" to event.contactPersonId, "nomisContactRestrictionId" to event.offenderPersonRestrictionId)
 
     if (event.doesOriginateInDps()) {
       telemetryClient.trackEvent(
@@ -256,7 +256,7 @@ class ContactPersonSynchronisationService(
 
   suspend fun contactRestrictionDeleted(event: ContactRestrictionEvent) {
     val telemetry =
-      telemetryOf("offenderNo" to event.offenderIdDisplay, "nomisPersonId" to event.personId, "dpsContactId" to event.personId, "nomisContactId" to event.contactPersonId, "nomisContactRestrictionId" to event.offenderPersonRestrictionId)
+      telemetryOf("offenderNo" to (event.offenderIdDisplay ?: "unknown"), "nomisPersonId" to event.personId, "dpsContactId" to event.personId, "nomisContactId" to event.contactPersonId, "nomisContactRestrictionId" to event.offenderPersonRestrictionId)
 
     mappingApiService.getByNomisContactRestrictionIdOrNull(nomisContactRestrictionId = event.offenderPersonRestrictionId)?.also {
       track("contactperson-contact-restriction-synchronisation-deleted", telemetry) {


### PR DESCRIPTION
It can be null during a cascading delete where the contact has already been deleted