### PR TITLE
SDIT-2385 Integration to adjustment get ids and current term patch

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsNomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsNomisApiService.kt
@@ -1,10 +1,20 @@
 package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing
 
+import kotlinx.coroutines.reactor.awaitSingle
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.domain.PageImpl
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBody
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.awaitBodyOrNullWhenNotFound
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AdjustmentIdResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.SentencingAdjustmentsResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing.adjustments.model.LegacyAdjustment
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing.adjustments.model.LegacyAdjustment.AdjustmentType
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.NomisCodeDescription
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RestResponsePage
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.typeReference
+import java.time.LocalDate
 
 @Service
 class SentencingAdjustmentsNomisApiService(@Qualifier("nomisApiWebClient") private val webClient: WebClient) {
@@ -15,4 +25,70 @@ class SentencingAdjustmentsNomisApiService(@Qualifier("nomisApiWebClient") priva
     )
     .retrieve()
     .awaitBody()
+
+  suspend fun getSentenceAdjustment(
+    nomisSentenceAdjustmentId: Long,
+  ): NomisAdjustment? = webClient.get()
+    .uri("/sentence-adjustments/{nomisSentenceAdjustmentId}", nomisSentenceAdjustmentId)
+    .retrieve()
+    .awaitBodyOrNullWhenNotFound()
+
+  suspend fun getKeyDateAdjustment(
+    nomisKeyDateAdjustmentId: Long,
+  ): NomisAdjustment? = webClient.get()
+    .uri("/key-date-adjustments/{nomisKeyDateAdjustmentId}", nomisKeyDateAdjustmentId)
+    .retrieve()
+    .awaitBodyOrNullWhenNotFound()
+
+  suspend fun getSentencingAdjustmentIds(
+    fromDate: LocalDate? = null,
+    toDate: LocalDate? = null,
+    pageNumber: Long = 0,
+    pageSize: Long = 20,
+  ): PageImpl<AdjustmentIdResponse> =
+    webClient.get()
+      .uri {
+        it.path("/adjustments/ids")
+          .queryParam("fromDate", fromDate)
+          .queryParam("toDate", toDate)
+          .queryParam("page", pageNumber)
+          .queryParam("size", pageSize)
+          .build()
+      }
+      .retrieve()
+      .bodyToMono(typeReference<RestResponsePage<AdjustmentIdResponse>>())
+      .awaitSingle()
+}
+
+data class NomisAdjustment(
+  val id: Long,
+  val bookingId: Long,
+  val bookingSequence: Int,
+  val offenderNo: String,
+  val sentenceSequence: Long? = null,
+  val adjustmentType: NomisCodeDescription,
+  val adjustmentDate: LocalDate?,
+  val adjustmentFromDate: LocalDate?,
+  val adjustmentToDate: LocalDate?,
+  val adjustmentDays: Long,
+  val comment: String?,
+  val active: Boolean,
+  val hiddenFromUsers: Boolean,
+  val hasBeenReleased: Boolean,
+  val prisonId: String,
+) {
+  fun toSentencingAdjustment(): LegacyAdjustment = LegacyAdjustment(
+    bookingId = bookingId,
+    sentenceSequence = sentenceSequence?.toInt(),
+    currentTerm = bookingSequence == 1,
+    adjustmentType = AdjustmentType.valueOf(adjustmentType.code),
+    adjustmentDate = adjustmentDate,
+    adjustmentFromDate = adjustmentFromDate,
+    adjustmentDays = adjustmentDays.toInt(),
+    comment = comment,
+    active = active,
+    offenderNo = offenderNo,
+    bookingReleased = hasBeenReleased,
+    agencyId = prisonId,
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsSynchronisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsSynchronisationService.kt
@@ -14,14 +14,12 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.S
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing.SentencingAdjustmentsSynchronisationService.MappingResponse.MAPPING_CREATED
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing.SentencingAdjustmentsSynchronisationService.MappingResponse.MAPPING_FAILED
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.InternalMessage
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.NomisApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.SynchronisationQueueService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.SynchronisationType
 
 @Service
 class SentencingAdjustmentsSynchronisationService(
   private val sentencingAdjustmentsMappingService: SentencingAdjustmentsMappingService,
-  private val nomisApiService: NomisApiService,
   private val sentencingAdjustmentsNomisApiService: SentencingAdjustmentsNomisApiService,
   private val sentencingService: SentencingService,
   private val telemetryClient: TelemetryClient,
@@ -39,7 +37,7 @@ class SentencingAdjustmentsSynchronisationService(
       )
       return
     }
-    nomisApiService.getSentenceAdjustment(event.adjustmentId)?.takeUnless { it.hiddenFromUsers }
+    sentencingAdjustmentsNomisApiService.getSentenceAdjustment(event.adjustmentId)?.takeUnless { it.hiddenFromUsers }
       ?.also { nomisAdjustment ->
         sentencingAdjustmentsMappingService.findNomisSentencingAdjustmentMapping(
           nomisAdjustmentId = event.adjustmentId,
@@ -95,7 +93,7 @@ class SentencingAdjustmentsSynchronisationService(
       )
       return
     }
-    nomisApiService.getKeyDateAdjustment(event.adjustmentId)?.also { nomisAdjustment ->
+    sentencingAdjustmentsNomisApiService.getKeyDateAdjustment(event.adjustmentId)?.also { nomisAdjustment ->
       sentencingAdjustmentsMappingService.findNomisSentencingAdjustmentMapping(
         nomisAdjustmentId = event.adjustmentId,
         nomisAdjustmentCategory = "KEY-DATE",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingService.kt
@@ -37,4 +37,12 @@ class SentencingService(@Qualifier("sentencingApiWebClient") private val webClie
       .retrieve()
       .awaitBodyOrNullWhenNotFound<Unit>()
   }
+
+  suspend fun patchSentencingAdjustmentCurrentTerm(adjustmentId: String, sentencingAdjustment: LegacyAdjustment): Unit =
+    webClient.patch()
+      .uri("/legacy/adjustments/{adjustmentId}/current-term", adjustmentId)
+      .header("Content-Type", LEGACY_CONTENT_TYPE)
+      .bodyValue(sentencingAdjustment)
+      .retrieve()
+      .awaitBody()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsDataRepairResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsDataRepairResourceIntTest.kt
@@ -17,12 +17,11 @@ import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.MappingApiExtension
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.MappingApiExtension.Companion.mappingApi
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.NomisApiExtension.Companion.nomisApi
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.SentencingApiExtension.Companion.sentencingApi
 
 class SentencingAdjustmentsDataRepairResourceIntTest : SqsIntegrationTestBase() {
   @Autowired
-  private lateinit var sentencingAdjustmentsNomisApi: SentencingAdjustmentsNomisApiMockServer
+  private lateinit var nomisApi: SentencingAdjustmentsNomisApiMockServer
 
   @DisplayName("POST /prisoners/booking-id/{bookingId}/merge/sentencing-adjustments/repair")
   @Nested
@@ -59,7 +58,7 @@ class SentencingAdjustmentsDataRepairResourceIntTest : SqsIntegrationTestBase() 
     inner class HappyPath {
       @BeforeEach
       fun setUp() {
-        sentencingAdjustmentsNomisApi.stubGetAllByBookingId(
+        nomisApi.stubGetAllByBookingId(
           bookingId = bookingId,
           sentenceAdjustments = listOf(
             sentenceAdjustmentResponse(bookingId = bookingId, sentenceAdjustmentId = 1001),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsNomisApiMockServer.kt
@@ -1,16 +1,22 @@
 package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.tomakehurst.wiremock.client.CountMatchingStrategy
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AdjustmentIdResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.KeyDateAdjustmentResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.SentenceAdjustmentResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.SentencingAdjustmentsResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.NomisApiExtension
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.NomisApiExtension.Companion.nomisApi
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.pageContent
 
 @Component
 class SentencingAdjustmentsNomisApiMockServer(private val objectMapper: ObjectMapper) {
@@ -29,5 +35,191 @@ class SentencingAdjustmentsNomisApiMockServer(private val objectMapper: ObjectMa
     )
   }
 
+  fun stubGetSentenceAdjustment(
+    adjustmentId: Long,
+    hiddenForUsers: Boolean = false,
+    prisonId: String = "MDI",
+    bookingId: Long = 2,
+    sentenceSequence: Long = 1,
+    offenderNo: String = "G4803UT",
+    bookingSequence: Int = 1,
+  ) {
+    nomisApi.stubFor(
+      get(
+        urlPathEqualTo("/sentence-adjustments/$adjustmentId"),
+      )
+        .willReturn(
+          aResponse().withHeader("Content-Type", "application/json")
+            .withStatus(HttpStatus.OK.value())
+            .withBody(
+              sentenceAdjustmentResponse(
+                sentenceAdjustmentId = adjustmentId,
+                hiddenForUsers = hiddenForUsers,
+                prisonId = prisonId,
+                bookingId = bookingId,
+                sentenceSequence = sentenceSequence,
+                offenderNo = offenderNo,
+                bookingSequence = bookingSequence,
+              ),
+            ),
+        ),
+    )
+  }
+
+  fun stubGetSentenceAdjustment(
+    adjustmentId: Long,
+    status: HttpStatus,
+    error: ErrorResponse = ErrorResponse(status = status.value()),
+  ) {
+    nomisApi.stubFor(
+      get(
+        urlPathEqualTo("/sentence-adjustments/$adjustmentId"),
+      )
+        .willReturn(
+          aResponse()
+            .withStatus(status.value())
+            .withHeader("Content-Type", "application/json")
+            .withBody(NomisApiExtension.objectMapper.writeValueAsString(error)),
+        ),
+    )
+  }
+
+  fun stubGetKeyDateAdjustment(
+    adjustmentId: Long,
+    prisonId: String = "MDI",
+    bookingId: Long = 2,
+    offenderNo: String = "G4803UT",
+    bookingSequence: Int = 1,
+  ) {
+    nomisApi.stubFor(
+      get(
+        urlPathEqualTo("/key-date-adjustments/$adjustmentId"),
+      )
+        .willReturn(
+          aResponse().withHeader("Content-Type", "application/json")
+            .withStatus(HttpStatus.OK.value())
+            .withBody(
+              keyDateAdjustmentResponse(
+                keyDateAdjustmentId = adjustmentId,
+                prisonId = prisonId,
+                bookingId = bookingId,
+                offenderNo = offenderNo,
+                bookingSequence = bookingSequence,
+              ),
+            ),
+        ),
+    )
+  }
+
+  fun stubGetKeyDateAdjustment(
+    adjustmentId: Long,
+    status: HttpStatus,
+    error: ErrorResponse = ErrorResponse(status = status.value()),
+  ) {
+    nomisApi.stubFor(
+      get(
+        urlPathEqualTo("/key-date-adjustments/$adjustmentId"),
+      )
+        .willReturn(
+          aResponse()
+            .withStatus(status.value())
+            .withHeader("Content-Type", "application/json")
+            .withBody(NomisApiExtension.objectMapper.writeValueAsString(error)),
+        ),
+    )
+  }
+
+  fun stubGetSentencingAdjustmentIds(
+    count: Long = 1,
+    content: List<AdjustmentIdResponse> = listOf(
+      AdjustmentIdResponse(123456, adjustmentCategory = "SENTENCE"),
+    ),
+  ) {
+    nomisApi.stubFor(
+      get(urlPathEqualTo("/adjustments/ids")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(HttpStatus.OK.value())
+          .withBody(pageAdjustmentIdResponse(count = count, content = content)),
+      ),
+    )
+  }
+
+  fun pageAdjustmentIdResponse(
+    count: Long,
+    content: List<AdjustmentIdResponse>,
+  ) = pageContent(
+    objectMapper = objectMapper,
+    content = content,
+    pageSize = 1L,
+    pageNumber = 0L,
+    totalElements = count,
+    size = 1,
+  )
+
+  fun verify(countMatchingStrategy: CountMatchingStrategy, pattern: RequestPatternBuilder) = nomisApi.verify(countMatchingStrategy, pattern)
   fun verify(pattern: RequestPatternBuilder) = nomisApi.verify(pattern)
+}
+private fun keyDateAdjustmentResponse(
+  bookingId: Long = 2,
+  keyDateAdjustmentId: Long = 3,
+  offenderNo: String = "G4803UT",
+  prisonId: String = "MDI",
+  bookingSequence: Int = 1,
+): String {
+  // language=JSON
+  return """
+{
+  "bookingId":$bookingId,
+  "bookingSequence":$bookingSequence,
+  "id":$keyDateAdjustmentId,
+  "offenderNo": "$offenderNo",
+  "commentText":"a comment",
+  "adjustmentDate":"2021-10-06",
+  "adjustmentFromDate":"2021-10-07",
+  "active":true,
+  "adjustmentDays":8,
+  "adjustmentType": {
+    "code": "ADA",
+    "description": "Additional days"
+  },
+  "hasBeenReleased": false,
+  "prisonId": "$prisonId"
+}
+   
+  """.trimIndent()
+}
+
+private fun sentenceAdjustmentResponse(
+  bookingId: Long = 2,
+  sentenceSequence: Long = 1,
+  offenderNo: String = "G4803UT",
+  sentenceAdjustmentId: Long = 3,
+  hiddenForUsers: Boolean = false,
+  prisonId: String = "MDI",
+  bookingSequence: Int = 1,
+): String {
+  // language=JSON
+  return """
+{
+  "bookingId":$bookingId,
+  "bookingSequence":$bookingSequence,
+  "id":$sentenceAdjustmentId,
+  "offenderNo": "$offenderNo",
+  "sentenceSequence": $sentenceSequence,
+  "commentText":"a comment",
+  "adjustmentDate":"2021-10-06",
+  "adjustmentFromDate":"2021-10-07",
+  "active":true,
+  "hiddenFromUsers":$hiddenForUsers,
+  "adjustmentDays":8,
+  "adjustmentType": {
+    "code": "RST",
+    "description": "RST Desc"
+  },
+  "hasBeenReleased": false,
+  "prisonId": "$prisonId"
+  }
+   
+  """.trimIndent()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsNomisApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsNomisApiServiceTest.kt
@@ -5,11 +5,14 @@ import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helper.SpringAPIServiceTest
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.AdjustmentIdResponse
+import java.time.LocalDate
 
 @SpringAPIServiceTest
 @Import(SentencingAdjustmentsNomisApiService::class, SentencingConfiguration::class, SentencingAdjustmentsNomisApiMockServer::class)
@@ -53,6 +56,116 @@ class SentencingAdjustmentsNomisApiServiceTest {
       sentencingAdjustmentsNomisApi.verify(
         getRequestedFor(anyUrl()).withQueryParam("active-only", equalTo("false")),
       )
+    }
+  }
+
+  @Nested
+  inner class GetSentenceAdjustment {
+    @Test
+    internal fun `will pass oath2 token to service`() = runTest {
+      sentencingAdjustmentsNomisApi.stubGetSentenceAdjustment(1234567)
+
+      apiService.getSentenceAdjustment(nomisSentenceAdjustmentId = 1234567)
+
+      sentencingAdjustmentsNomisApi.verify(
+        getRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
+      )
+    }
+
+    @Test
+    internal fun `will pass adjustment id to service`() = runTest {
+      sentencingAdjustmentsNomisApi.stubGetSentenceAdjustment(1234567)
+
+      apiService.getSentenceAdjustment(nomisSentenceAdjustmentId = 1234567)
+
+      sentencingAdjustmentsNomisApi.verify(
+        getRequestedFor(urlPathEqualTo("/sentence-adjustments/1234567")),
+      )
+    }
+  }
+
+  @Nested
+  inner class GetKeyDateAdjustment {
+    @Test
+    internal fun `will pass oath2 token to service`() = runTest {
+      sentencingAdjustmentsNomisApi.stubGetKeyDateAdjustment(1234567)
+
+      apiService.getKeyDateAdjustment(nomisKeyDateAdjustmentId = 1234567)
+
+      sentencingAdjustmentsNomisApi.verify(
+        getRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
+      )
+    }
+
+    @Test
+    internal fun `will pass adjustment id to service`() = runTest {
+      sentencingAdjustmentsNomisApi.stubGetKeyDateAdjustment(1234567)
+
+      apiService.getKeyDateAdjustment(nomisKeyDateAdjustmentId = 1234567)
+
+      sentencingAdjustmentsNomisApi.verify(
+        getRequestedFor(urlPathEqualTo("/key-date-adjustments/1234567")),
+      )
+    }
+  }
+
+  @Nested
+  inner class GetSentencingAdjustmentIds {
+    @Test
+    fun `will pass oath2 token to service`() = runTest {
+      sentencingAdjustmentsNomisApi.stubGetSentencingAdjustmentIds()
+
+      apiService.getSentencingAdjustmentIds()
+
+      sentencingAdjustmentsNomisApi.verify(
+        getRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
+      )
+    }
+
+    @Test
+    fun `will pass mandatory parameters to service`() = runTest {
+      sentencingAdjustmentsNomisApi.stubGetSentencingAdjustmentIds()
+
+      apiService.getSentencingAdjustmentIds(pageNumber = 12, pageSize = 20)
+
+      sentencingAdjustmentsNomisApi.verify(
+        getRequestedFor(anyUrl())
+          .withQueryParam("fromDate", equalTo(""))
+          .withQueryParam("toDate", equalTo(""))
+          .withQueryParam("page", equalTo("12"))
+          .withQueryParam("size", equalTo("20")),
+      )
+    }
+
+    @Test
+    fun `can pass optional parameters to service`() = runTest {
+      sentencingAdjustmentsNomisApi.stubGetSentencingAdjustmentIds()
+
+      apiService.getSentencingAdjustmentIds(
+        fromDate = LocalDate.parse("2020-01-01"),
+        toDate = LocalDate.parse("2020-01-02"),
+        pageNumber = 12,
+        pageSize = 20,
+      )
+
+      sentencingAdjustmentsNomisApi.verify(
+        getRequestedFor(anyUrl())
+          .withQueryParam("fromDate", equalTo("2020-01-01"))
+          .withQueryParam("toDate", equalTo("2020-01-02")),
+      )
+    }
+
+    @Test
+    fun `will return adjustment ids`() = runTest {
+      sentencingAdjustmentsNomisApi.stubGetSentencingAdjustmentIds(content = listOf(AdjustmentIdResponse(1234567, "SENTENCE"), AdjustmentIdResponse(6543, "KEY_DATE")))
+
+      val pages = apiService.getSentencingAdjustmentIds(pageNumber = 12, pageSize = 20)
+
+      assertThat(pages.content).hasSize(2)
+      assertThat(pages.content[0].adjustmentId).isEqualTo(1234567)
+      assertThat(pages.content[0].adjustmentCategory).isEqualTo("SENTENCE")
+      assertThat(pages.content[1].adjustmentId).isEqualTo(6543)
+      assertThat(pages.content[1].adjustmentCategory).isEqualTo("KEY_DATE")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingSynchronisationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingSynchronisationIntTest.kt
@@ -40,7 +40,6 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.MappingA
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.MappingApiExtension.Companion.KEYDATE_ADJUSTMENTS_GET_MAPPING_URL
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.MappingApiExtension.Companion.SENTENCE_ADJUSTMENTS_GET_MAPPING_URL
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.MappingApiExtension.Companion.mappingApi
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.NomisApiExtension.Companion.nomisApi
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.SentencingApiExtension.Companion.sentencingApi
 import uk.gov.justice.hmpps.sqs.countAllMessagesOnQueue
 import java.time.LocalDate
@@ -53,7 +52,7 @@ private const val SENTENCE_SEQUENCE = 1L
 
 class SentencingSynchronisationIntTest : SqsIntegrationTestBase() {
   @Autowired
-  private lateinit var sentencingAdjustmentsNomisApi: SentencingAdjustmentsNomisApiMockServer
+  private lateinit var nomisApi: SentencingAdjustmentsNomisApiMockServer
 
   @Nested
   @DisplayName("SENTENCE_ADJUSTMENT_UPSERTED")
@@ -1677,7 +1676,7 @@ class SentencingSynchronisationIntTest : SqsIntegrationTestBase() {
 
       @BeforeEach
       fun setUp() {
-        sentencingAdjustmentsNomisApi.stubGetAllByBookingId(
+        nomisApi.stubGetAllByBookingId(
           bookingId = bookingId,
           sentenceAdjustments = emptyList(),
           keyDateAdjustments = emptyList(),
@@ -1716,7 +1715,7 @@ class SentencingSynchronisationIntTest : SqsIntegrationTestBase() {
 
       @BeforeEach
       fun setUp() {
-        sentencingAdjustmentsNomisApi.stubGetAllByBookingId(
+        nomisApi.stubGetAllByBookingId(
           bookingId = bookingId,
           sentenceAdjustments = listOf(
             sentenceAdjustmentResponse(bookingId = bookingId, sentenceAdjustmentId = 1001),
@@ -1787,7 +1786,7 @@ class SentencingSynchronisationIntTest : SqsIntegrationTestBase() {
 
       @BeforeEach
       fun setUp() {
-        sentencingAdjustmentsNomisApi.stubGetAllByBookingId(
+        nomisApi.stubGetAllByBookingId(
           bookingId = bookingId,
           sentenceAdjustments = listOf(
             sentenceAdjustmentResponse(bookingId = bookingId, sentenceAdjustmentId = 1001),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/NomisApiMockServer.kt
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.junit.jupiter.SpringExtension
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomissync.model.PrisonerId
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.MappingApiExtension.Companion.mappingApi
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.NomisApiExtension.Companion.nomisApi
@@ -286,102 +285,6 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
           ),
       )
     }
-  }
-
-  // //////////////////////////////////// Sentencing //////////////////////////////////////
-
-  fun stubGetSentenceAdjustment(
-    adjustmentId: Long,
-    hiddenForUsers: Boolean = false,
-    prisonId: String = "MDI",
-    bookingId: Long = 2,
-    sentenceSequence: Long = 1,
-    offenderNo: String = "G4803UT",
-    bookingSequence: Int = 1,
-  ) {
-    nomisApi.stubFor(
-      get(
-        urlPathEqualTo("/sentence-adjustments/$adjustmentId"),
-      )
-        .willReturn(
-          aResponse().withHeader("Content-Type", "application/json")
-            .withStatus(HttpStatus.OK.value())
-            .withBody(
-              sentenceAdjustmentResponse(
-                sentenceAdjustmentId = adjustmentId,
-                hiddenForUsers = hiddenForUsers,
-                prisonId = prisonId,
-                bookingId = bookingId,
-                sentenceSequence = sentenceSequence,
-                offenderNo = offenderNo,
-                bookingSequence = bookingSequence,
-              ),
-            ),
-        ),
-    )
-  }
-
-  fun stubGetSentenceAdjustment(
-    adjustmentId: Long,
-    status: HttpStatus,
-    error: ErrorResponse = ErrorResponse(status = status.value()),
-  ) {
-    nomisApi.stubFor(
-      get(
-        urlPathEqualTo("/sentence-adjustments/$adjustmentId"),
-      )
-        .willReturn(
-          aResponse()
-            .withStatus(status.value())
-            .withHeader("Content-Type", "application/json")
-            .withBody(objectMapper.writeValueAsString(error)),
-        ),
-    )
-  }
-
-  fun stubGetKeyDateAdjustment(
-    adjustmentId: Long,
-    prisonId: String = "MDI",
-    bookingId: Long = 2,
-    offenderNo: String = "G4803UT",
-    bookingSequence: Int = 1,
-  ) {
-    nomisApi.stubFor(
-      get(
-        urlPathEqualTo("/key-date-adjustments/$adjustmentId"),
-      )
-        .willReturn(
-          aResponse().withHeader("Content-Type", "application/json")
-            .withStatus(HttpStatus.OK.value())
-            .withBody(
-              keyDateAdjustmentResponse(
-                keyDateAdjustmentId = adjustmentId,
-                prisonId = prisonId,
-                bookingId = bookingId,
-                offenderNo = offenderNo,
-                bookingSequence = bookingSequence,
-              ),
-            ),
-        ),
-    )
-  }
-
-  fun stubGetKeyDateAdjustment(
-    adjustmentId: Long,
-    status: HttpStatus,
-    error: ErrorResponse = ErrorResponse(status = status.value()),
-  ) {
-    nomisApi.stubFor(
-      get(
-        urlPathEqualTo("/key-date-adjustments/$adjustmentId"),
-      )
-        .willReturn(
-          aResponse()
-            .withStatus(status.value())
-            .withHeader("Content-Type", "application/json")
-            .withBody(objectMapper.writeValueAsString(error)),
-        ),
-    )
   }
 
   fun stubMultipleGetAppointmentIdCounts(totalElements: Long, pageSize: Long) {
@@ -707,70 +610,6 @@ fun allocationsIdsPagedResponse(
 ): String {
   val content = ids.map { """{ "allocationId": $it }""" }.joinToString { it }
   return pageContent(content, pageSize, pageNumber, totalElements, ids.size)
-}
-
-private fun sentenceAdjustmentResponse(
-  bookingId: Long = 2,
-  sentenceSequence: Long = 1,
-  offenderNo: String = "G4803UT",
-  sentenceAdjustmentId: Long = 3,
-  hiddenForUsers: Boolean = false,
-  prisonId: String = "MDI",
-  bookingSequence: Int = 1,
-): String {
-  // language=JSON
-  return """
-{
-  "bookingId":$bookingId,
-  "bookingSequence":$bookingSequence,
-  "id":$sentenceAdjustmentId,
-  "offenderNo": "$offenderNo",
-  "sentenceSequence": $sentenceSequence,
-  "commentText":"a comment",
-  "adjustmentDate":"2021-10-06",
-  "adjustmentFromDate":"2021-10-07",
-  "active":true,
-  "hiddenFromUsers":$hiddenForUsers,
-  "adjustmentDays":8,
-  "adjustmentType": {
-    "code": "RST",
-    "description": "RST Desc"
-  },
-  "hasBeenReleased": false,
-  "prisonId": "$prisonId"
-  }
-   
-  """.trimIndent()
-}
-
-private fun keyDateAdjustmentResponse(
-  bookingId: Long = 2,
-  keyDateAdjustmentId: Long = 3,
-  offenderNo: String = "G4803UT",
-  prisonId: String = "MDI",
-  bookingSequence: Int = 1,
-): String {
-  // language=JSON
-  return """
-{
-  "bookingId":$bookingId,
-  "bookingSequence":$bookingSequence,
-  "id":$keyDateAdjustmentId,
-  "offenderNo": "$offenderNo",
-  "commentText":"a comment",
-  "adjustmentDate":"2021-10-06",
-  "adjustmentFromDate":"2021-10-07",
-  "active":true,
-  "adjustmentDays":8,
-  "adjustmentType": {
-    "code": "ADA",
-    "description": "Additional days"
-  },
-  "hasBeenReleased": false,
-  "prisonId": "$prisonId"
-}
-   
-  """.trimIndent()
 }
 
 private fun locationResponse(id: Long = 1234, parentLocationId: Long = 5678): String =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/SentencingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/wiremock/SentencingApiMockServer.kt
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.delete
 import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.patch
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.put
 import org.junit.jupiter.api.extension.AfterAllCallback
@@ -88,6 +89,16 @@ class SentencingApiMockServer : WireMockServer(WIREMOCK_PORT) {
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(HttpStatus.NOT_FOUND.value()),
+      ),
+    )
+  }
+
+  fun stubPatchSentencingAdjustmentCurrentTerm(adjustmentId: String = "654321") {
+    stubFor(
+      patch(WireMock.urlMatching("/legacy/adjustments/$adjustmentId/current-term")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(HttpStatus.OK.value()),
       ),
     )
   }


### PR DESCRIPTION
Initial changes to support a new migration to update a single "currentTerm" flag for all DPS adjustments using a new PATCH endpoint.

* Integration to call the GET adjustments IDs endpoint from NOMIS
* Integration to call the PATCH DPS endpoint to update the currentTerm flag


Also refactored NOMIS API integration so uses own adjustment class and mocks which is standard these days 