### PR TITLE
SDIT-2723 Allow large DPS timeout when running manual repair

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/personalrelationships/ContactPersonSynchronisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/personalrelationships/ContactPersonSynchronisationService.kt
@@ -16,8 +16,6 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.telemetry
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.track
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.trackEvent
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.valuesAsStrings
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ContactPersonPhoneMappingIdDto.DpsPhoneType.ADDRESS
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ContactPersonPhoneMappingIdDto.DpsPhoneType.PERSON
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ContactPersonPrisonerMappingsDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ContactPersonSimpleMappingIdDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.PersonAddressMappingDto
@@ -970,7 +968,7 @@ class ContactPersonSynchronisationService(
   }
   suspend fun resetPersonForRepair(personId: Long) {
     val person = nomisApiService.getPerson(nomisPersonId = personId)
-    val mapping = dpsApiService.migrateContact(person.toDpsMigrateContactRequest()).toContactPersonMappingsDto()
+    val mapping = dpsApiService.resyncContactForRepair(person.toDpsMigrateContactRequest()).toContactPersonMappingsDto()
     mappingApiService.replaceMappingsForPerson(personId, mapping)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/personalrelationships/ContactPersonDpsApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/personalrelationships/ContactPersonDpsApiServiceTest.kt
@@ -71,6 +71,32 @@ class ContactPersonDpsApiServiceTest {
   }
 
   @Nested
+  inner class ResyncContactForRepair {
+    @Test
+    internal fun `will pass oath2 token to contact endpoint`() = runTest {
+      dpsContactPersonServer.stubMigrateContact()
+
+      apiService.resyncContactForRepair(migrateContactRequest())
+
+      dpsContactPersonServer.verify(
+        postRequestedFor(anyUrl())
+          .withHeader("Authorization", equalTo("Bearer ABCDE")),
+      )
+    }
+
+    @Test
+    fun `will call the migrate endpoint`() = runTest {
+      dpsContactPersonServer.stubMigrateContact()
+
+      apiService.resyncContactForRepair(migrateContactRequest())
+
+      dpsContactPersonServer.verify(
+        postRequestedFor(urlPathEqualTo("/migrate/contact")),
+      )
+    }
+  }
+
+  @Nested
   inner class CreateContact {
     @Test
     internal fun `will pass oath2 token to contact endpoint`() = runTest {


### PR DESCRIPTION
Repair endpoint for certain POM contacts can take over 30 seconds - this ensures we wait a longer time given this is only called manually