### PR TITLE
SDIT-2753 Add repair contacts endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/personalrelationships/ContactPersonDataRepairResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/personalrelationships/ContactPersonDataRepairResource.kt
@@ -59,4 +59,23 @@ class ContactPersonDataRepairResource(
       )
     }
   }
+
+  @PostMapping("/prisoners/{offenderNo}/resynchronise")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "Resynchronises prisoner contacts from NOMIS back to DPS",
+    description = "Used when an unexpected event has happened in NOMIS that has resulted in the DPS data drifting from NOMIS, so emergency use only. Requires ROLE_MIGRATE_CONTACTPERSON or ROLE_MIGRATE_NOMIS_SYSCON",
+  )
+  suspend fun repairPrisonerContacts(
+    @PathVariable offenderNo: String,
+  ) {
+    contactPersonSynchronisationService.resynchronizePrisonerContacts(offenderNo)
+    telemetryClient.trackEvent(
+      "from-nomis-synch-contactperson-prisoner-resynchronisation-repair",
+      mapOf(
+        "offenderNo" to offenderNo,
+      ),
+      null,
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/personalrelationships/ContactPersonDataRepairResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/personalrelationships/ContactPersonDataRepairResourceIntTest.kt
@@ -172,4 +172,83 @@ class ContactPersonDataRepairResourceIntTest : SqsIntegrationTestBase() {
       }
     }
   }
+
+  @DisplayName("POST /prisoners/{offenderNo}/resynchronise")
+  @Nested
+  inner class RepairPrisonerContacts {
+    val offenderNo = "A1234KT"
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.post().uri("/prisoners/$offenderNo/resynchronise")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.post().uri("/prisoners/$offenderNo/resynchronise")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access unauthorised with no auth token`() {
+        webTestClient.post().uri("/prisoners/$offenderNo/resynchronise")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+      val offenderNo = "A1234KT"
+
+      @BeforeEach
+      fun setUp() {
+        nomisApiMock.stubContactsForPrisoner(offenderNo)
+        dpsApiMock.stubResetPrisonerContacts()
+        mappingApiMock.stubReplaceMappingsForPrisoner(offenderNo)
+
+        webTestClient.post().uri("/prisoners/$offenderNo/resynchronise")
+          .headers(setAuthorisation(roles = listOf("MIGRATE_CONTACTPERSON")))
+          .exchange()
+          .expectStatus().isOk
+      }
+
+      @Test
+      fun `will retrieve prisoner contacts`() {
+        nomisApiMock.verify(getRequestedFor(urlPathEqualTo("/prisoners/$offenderNo/contacts")))
+      }
+
+      @Test
+      fun `will reset prisoner contacts in DPS`() {
+        dpsApiMock.verify(
+          postRequestedFor(urlPathEqualTo("/sync/admin/reset")),
+        )
+      }
+
+      @Test
+      fun `will replace mappings between the DPS and NOMIS contacts`() {
+        mappingApiMock.verify(
+          postRequestedFor(urlPathEqualTo("/mapping/contact-person/replace/prisoner/$offenderNo")),
+        )
+      }
+
+      @Test
+      fun `will track telemetry for the resynchronise`() {
+        verify(telemetryClient).trackEvent(
+          eq("from-nomis-synch-contactperson-prisoner-resynchronisation-repair"),
+          check {
+            assertThat(it["offenderNo"]).isEqualTo(offenderNo)
+          },
+          isNull(),
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION
Can be used as an alternative to repair person; but just resynchronizes the relationships and leave the core person untouched