### PR TITLE
SDIT-2761 Retry on duplicate contacts

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/personalrelationships/ContactPersonSynchronisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/personalrelationships/ContactPersonSynchronisationService.kt
@@ -185,6 +185,7 @@ class ContactPersonSynchronisationService(
                       "type" to "DPS_CONTACT",
                     ),
                   )
+                  throw IllegalStateException("Duplicate contact ${event.contactId} already exists in DPS")
                 }
                 is CreatePrisonerContactSuccess -> {
                   telemetry["dpsPrisonerContactId"] = dpsPrisonerContactResponse.contact.id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/personalrelationships/ContactPersonSynchronisationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/personalrelationships/ContactPersonSynchronisationIntTest.kt
@@ -7,6 +7,8 @@ import com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
 import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -4694,8 +4696,8 @@ class ContactPersonSynchronisationIntTest : SqsIntegrationTestBase() {
       }
 
       @Test
-      fun `will try create the prisoner contact in DPS once`() {
-        dpsApiMock.verify(1, postRequestedFor(urlPathEqualTo("/sync/prisoner-contact")))
+      fun `will try create the prisoner contact in DPS `() {
+        dpsApiMock.verify(postRequestedFor(urlPathEqualTo("/sync/prisoner-contact")))
       }
 
       @Test
@@ -4719,8 +4721,10 @@ class ContactPersonSynchronisationIntTest : SqsIntegrationTestBase() {
       }
 
       @Test
-      fun `message will not be sent to DLQ`() {
-        assertThat(personalRelationshipsOffenderEventsQueue.countAllMessagesOnDLQQueue()).isEqualTo(0)
+      fun `message will  be sent to DLQ`() {
+        await untilAsserted {
+          assertThat(personalRelationshipsOffenderEventsQueue.countAllMessagesOnDLQQueue()).isEqualTo(1)
+        }
       }
     }
 


### PR DESCRIPTION
When a contact is being removed and added at the same time, DPS will correctly return 409 if the contact delete hasn't be processed yet. So just keep retrying until there is manual intervention.