### PR TITLE
SDIT-2977 Flaky test fix

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/SqsIntegrationTestBase.kt
@@ -254,7 +254,8 @@ class SqsIntegrationTestBase : TestBase() {
 
 internal fun SqsAsyncClient.sendMessage(queueOffenderEventsUrl: String, message: String) = sendMessage(SendMessageRequest.builder().queueUrl(queueOffenderEventsUrl).messageBody(message).build()).get()
 internal fun HmppsQueue.sendMessage(message: String) = this.sqsClient.sendMessage(this.queueUrl, message = message)
-internal fun HmppsQueue.countMessagesOnQueue(message: String) = this.sqsClient.countAllMessagesOnQueue(this.queueUrl)
+internal fun HmppsQueue.countMessagesOnQueue() = this.sqsClient.countAllMessagesOnQueue(this.queueUrl).get()
+internal fun HmppsQueue.countMessagesOnDLQ() = this.sqsClient.countAllMessagesOnQueue(this.dlqUrl!!).get()
 
 internal fun SqsAsyncClient.waitForMessageCountOnQueue(queueUrl: String, messageCount: Int) = await untilCallTo {
   countAllMessagesOnQueue(queueUrl)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -131,6 +131,7 @@ hmpps.sqs:
       dlqMaxReceiveCount: 2
     eventcourtsentencing:
       dlqMaxReceiveCount: 2
+      errorVisibilityTimeout: 0
     eventpersonalrelationships:
       dlqMaxReceiveCount: 1
     eventvisitbalance:


### PR DESCRIPTION
The issue was errorVisibilityTimeout was 1 second running tests, so occasionally we hit retries sometimes we didn't

So changed about 30% tests to waitForCompletion correctly and removed the await assert which was no longer needed.

Still only 60% of tests to do