### PR TITLE
SDIT-2982 Amend resync case booking event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingEventListener.kt
@@ -125,9 +125,10 @@ class CourtSentencingEventListener(
         CASE_RESYNCHRONISATION -> courtSentencingSynchronisationService.nomisCaseResynchronisation(
           sqsMessage.Message.fromJson(),
         )
-        CASE_BOOKING_RESYNCHRONISATION -> courtSentencingSynchronisationService.nomisCaseBookingResynchronisation(
-          sqsMessage.Message.fromJson(),
-        )
+        CASE_BOOKING_RESYNCHRONISATION -> {
+          sentencingAdjustmentsSynchronisationService.nomisSentenceAdjustmentsBookingMoveResynchronisation(sqsMessage.Message.fromJson())
+          courtSentencingSynchronisationService.nomisCaseBookingMoveResynchronisation(sqsMessage.Message.fromJson())
+        }
         RETRY_COURT_CASE_BOOKING_CLONE_SYNCHRONISATION_MAPPING ->
           courtSentencingSynchronisationService.retryCreateCaseBookingCloneMapping(
             sqsMessage.Message.fromJson(),
@@ -225,7 +226,20 @@ data class OffenderCaseResynchronisationEvent(
 
 data class OffenderCaseBookingResynchronisationEvent(
   val offenderNo: String,
+  val fromBookingId: Long = 0,
+  val toBookingId: Long = 0,
   val caseIds: List<Long>,
+  val sentenceAdjustments: List<SentenceIdAndAdjustmentType> = emptyList(),
+  val casesMoved: List<CaseBookingChanged> = emptyList(),
+)
+
+data class CaseBookingChanged(
+  val caseId: Long,
+  val sentence: List<SentenceBookingChanged>,
+)
+
+data class SentenceBookingChanged(
+  val sentenceSequence: Int,
 )
 
 data class OffenderSentenceTermEvent(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsSynchronisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/sentencing/SentencingAdjustmentsSynchronisationService.kt
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.config.trackEvent
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtsentencing.OffenderCaseBookingResynchronisationEvent
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtsentencing.SyncSentenceAdjustment
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.data.NomisPrisonerMergeEvent
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.DuplicateErrorResponse
@@ -79,6 +80,20 @@ class SentencingAdjustmentsSynchronisationService(
 
   suspend fun nomisSentenceAdjustmentsUpdate(event: SyncSentenceAdjustment) {
     event.sentences.forEach { sentence ->
+      sentence.adjustmentIds.forEach { adjustmentId ->
+        createOrUpdateSentenceAdjustment(
+          request = SentenceAdjustmentUpdateOrCreateRequest(
+            offenderNumber = event.offenderNo,
+            bookingId = sentence.sentenceId.offenderBookingId,
+            sentenceSeq = sentence.sentenceId.sentenceSequence,
+            adjustmentId = adjustmentId,
+          ),
+        )
+      }
+    }
+  }
+  suspend fun nomisSentenceAdjustmentsBookingMoveResynchronisation(event: OffenderCaseBookingResynchronisationEvent) {
+    event.sentenceAdjustments.forEach { sentence ->
       sentence.adjustmentIds.forEach { adjustmentId ->
         createOrUpdateSentenceAdjustment(
           request = SentenceAdjustmentUpdateOrCreateRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationIntTest.kt
@@ -731,6 +731,8 @@ class CourtSentencingSynchronisationIntTest : SqsIntegrationTestBase() {
               Message = OffenderCaseBookingResynchronisationEvent(
                 offenderNo = OFFENDER_ID_DISPLAY,
                 caseIds = listOf(NOMIS_COURT_CASE_ID),
+                fromBookingId = 54321,
+                toBookingId = NOMIS_BOOKING_ID,
               ).toJson(),
             ).toJson(),
           ).also { waitForAnyProcessingToComplete() }
@@ -743,6 +745,8 @@ class CourtSentencingSynchronisationIntTest : SqsIntegrationTestBase() {
             check {
               assertThat(it["offenderNo"]).isEqualTo(OFFENDER_ID_DISPLAY)
               assertThat(it["nomisCaseIds"]).isEqualTo("$NOMIS_COURT_CASE_ID")
+              assertThat(it["toBookingId"]).isEqualTo("$NOMIS_BOOKING_ID")
+              assertThat(it["fromBookingId"]).isEqualTo("54321")
             },
             isNull(),
           )
@@ -764,6 +768,7 @@ class CourtSentencingSynchronisationIntTest : SqsIntegrationTestBase() {
               Message = OffenderCaseBookingResynchronisationEvent(
                 offenderNo = OFFENDER_ID_DISPLAY,
                 caseIds = listOf(NOMIS_COURT_CASE_ID),
+                toBookingId = NOMIS_BOOKING_ID,
               ).toJson(),
             ).toJson(),
           ).also { waitForAnyProcessingToComplete("from-nomis-synch-court-case-booking-clone-mapping-retry-success") }


### PR DESCRIPTION
Refactor prep work before update service sends these new fields for cases updated with new booking id and the adjustments that have been created.

TODO - assert logic works then send the new fields