### PR TITLE
SDIT-2845 Check parent application exist before trying to create children

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/SqsIntegrationTestBase.kt
@@ -186,7 +186,9 @@ class SqsIntegrationTestBase : TestBase() {
 
   internal val externalMovementsOffenderEventsQueue by lazy { hmppsQueueService.findByQueueId(EXTERNALMOVEMENTS_SYNC_QUEUE_ID) as HmppsQueue }
   internal val awsSqsExternalMovementsOffenderEventsClient by lazy { externalMovementsOffenderEventsQueue.sqsClient }
+  internal val awsSqsExternalMovementsOffenderEventsDlqClient by lazy { externalMovementsOffenderEventsQueue.sqsDlqClient as SqsAsyncClient }
   internal val externalMovementsQueueOffenderEventsUrl by lazy { externalMovementsOffenderEventsQueue.queueUrl }
+  internal val externalMovementsQueueOffenderEventsDlqUrl by lazy { externalMovementsOffenderEventsQueue.dlqUrl as String }
 
   private val allQueues by lazy {
     listOf(


### PR DESCRIPTION
Attempting to create either an outside movement or scheduled movement in DPS BEFORE the movement application has been created will fail - DPS will have a FK missing for the application. (This can happen if events are processed out of order).

In this situation we just fail the event so it goes back to the DLQ and it should work on a retry.