### PR TITLE
SDIT-3666 Ignore cloned breach appearance

### DIFF
--- a/openapi-specs/nomis-prisoner-api-docs.json
+++ b/openapi-specs/nomis-prisoner-api-docs.json
@@ -7,7 +7,7 @@
       "name" : "HMPPS Digital Studio",
       "email" : "feedback@digital.justice.gov.uk"
     },
-    "version" : "2026-04-08.1307.9fe4877"
+    "version" : "2026-04-10.1318.986ffbc"
   },
   "servers" : [ {
     "url" : "https://nomis-prisoner-api-dev.prison.service.justice.gov.uk",
@@ -27554,9 +27554,12 @@
             "items" : {
               "$ref" : "#/components/schemas/CourtOrderResponse"
             }
+          },
+          "isClone" : {
+            "type" : "boolean"
           }
         },
-        "required" : [ "courtEventCharges", "courtEventType", "courtId", "courtOrders", "createdByUsername", "createdDateTime", "eventDateTime", "eventStatus", "id", "offenderNo" ]
+        "required" : [ "courtEventCharges", "courtEventType", "courtId", "courtOrders", "createdByUsername", "createdDateTime", "eventDateTime", "eventStatus", "id", "isClone", "offenderNo" ]
       },
       "CourtOrderResponse" : {
         "type" : "object",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationService.kt
@@ -134,56 +134,61 @@ class CourtSentencingSynchronisationService(
             offenderNo = event.offenderIdDisplay,
             courtAppearanceId = event.eventId,
           )
-        mappingApiService.getCourtAppearanceOrNullByNomisId(event.eventId)?.let { mapping ->
-          telemetryClient.trackEvent(
-            "court-appearance-synchronisation-created-ignored",
-            telemetry + ("dpsCourtAppearanceId" to mapping.dpsCourtAppearanceId) + ("reason" to "appearance already mapped"),
-          )
-        } ?: let {
-          mappingApiService.getCourtCaseOrNullByNomisId(nomisCourtAppearance.caseId!!)?.let { courtCaseMapping ->
-            telemetry["nomisCourtCaseId"] = courtCaseMapping.nomisCourtCaseId.toString()
-            telemetry["dpsCourtCaseId"] = courtCaseMapping.dpsCourtCaseId
-            trackIfFailure(name = "court-appearance-synchronisation-created", telemetry = telemetry.toMutableMap()) {
-              dpsApiService.createCourtAppearance(
-                nomisCourtAppearance.toDpsCourtAppearance(dpsCaseId = courtCaseMapping.dpsCourtCaseId),
-              )
-            }.run {
-              telemetry["dpsCourtAppearanceId"] = this.lifetimeUuid.toString()
-              tryToCreateCourtAppearanceMapping(
-                nomisCourtAppearance = nomisCourtAppearance,
-                dpsCourtAppearanceResponse = this,
-                telemetry,
-              ).also { mappingCreateResult ->
-                if (mappingCreateResult == MappingResponse.MAPPING_FAILED) telemetry["mapping"] = "initial-failure"
-              }
-            }
+
+        if (nomisCourtAppearance.isClone && event.isBreachHearing) {
+          telemetryClient.trackEvent("court-appearance-synchronisation-created-skipped", telemetry + ("reason" to "appearance is a clone of a breach hearing"))
+        } else {
+          mappingApiService.getCourtAppearanceOrNullByNomisId(event.eventId)?.let { mapping ->
             telemetryClient.trackEvent(
-              "court-appearance-synchronisation-created-success",
-              telemetry,
+              "court-appearance-synchronisation-created-ignored",
+              telemetry + ("dpsCourtAppearanceId" to mapping.dpsCourtAppearanceId) + ("reason" to "appearance already mapped"),
             )
-            // this is a breach court event created by DPS so all charges events will be ignored
-            // so add them now via an event
-            if (event.originatesInDps) {
-              nomisCourtAppearance.courtEventCharges.forEach {
-                queueService.sendMessage(
-                  messageType = RECALL_BREACH_COURT_EVENT_CHARGE_INSERTED,
-                  synchronisationType = SynchronisationType.COURT_SENTENCING,
-                  message = RecallBreachCourtEventCharge(
-                    eventId = event.eventId,
-                    chargeId = it.offenderCharge.id,
-                    offenderIdDisplay = event.offenderIdDisplay,
-                    bookingId = event.bookingId,
-                  ),
-                  telemetryAttributes = emptyMap(),
-                )
-              }
-            }
           } ?: let {
-            telemetryClient.trackEvent(
-              "court-appearance-synchronisation-created-failed",
-              telemetry + ("nomisCourtCaseId" to nomisCourtAppearance.caseId.toString()) + ("reason" to "associated court case is not mapped"),
-            )
-            throw ParentEntityNotFoundRetry("Received COURT_EVENTS_INSERTED for court case ${nomisCourtAppearance.caseId} that has never been created/mapped")
+            mappingApiService.getCourtCaseOrNullByNomisId(nomisCourtAppearance.caseId!!)?.let { courtCaseMapping ->
+              telemetry["nomisCourtCaseId"] = courtCaseMapping.nomisCourtCaseId.toString()
+              telemetry["dpsCourtCaseId"] = courtCaseMapping.dpsCourtCaseId
+              trackIfFailure(name = "court-appearance-synchronisation-created", telemetry = telemetry.toMutableMap()) {
+                dpsApiService.createCourtAppearance(
+                  nomisCourtAppearance.toDpsCourtAppearance(dpsCaseId = courtCaseMapping.dpsCourtCaseId),
+                )
+              }.run {
+                telemetry["dpsCourtAppearanceId"] = this.lifetimeUuid.toString()
+                tryToCreateCourtAppearanceMapping(
+                  nomisCourtAppearance = nomisCourtAppearance,
+                  dpsCourtAppearanceResponse = this,
+                  telemetry,
+                ).also { mappingCreateResult ->
+                  if (mappingCreateResult == MappingResponse.MAPPING_FAILED) telemetry["mapping"] = "initial-failure"
+                }
+              }
+              telemetryClient.trackEvent(
+                "court-appearance-synchronisation-created-success",
+                telemetry,
+              )
+              // this is a breach court event created by DPS so all charges events will be ignored
+              // so add them now via an event
+              if (event.originatesInDps) {
+                nomisCourtAppearance.courtEventCharges.forEach {
+                  queueService.sendMessage(
+                    messageType = RECALL_BREACH_COURT_EVENT_CHARGE_INSERTED,
+                    synchronisationType = SynchronisationType.COURT_SENTENCING,
+                    message = RecallBreachCourtEventCharge(
+                      eventId = event.eventId,
+                      chargeId = it.offenderCharge.id,
+                      offenderIdDisplay = event.offenderIdDisplay,
+                      bookingId = event.bookingId,
+                    ),
+                    telemetryAttributes = emptyMap(),
+                  )
+                }
+              }
+            } ?: let {
+              telemetryClient.trackEvent(
+                "court-appearance-synchronisation-created-failed",
+                telemetry + ("nomisCourtCaseId" to nomisCourtAppearance.caseId.toString()) + ("reason" to "associated court case is not mapped"),
+              )
+              throw ParentEntityNotFoundRetry("Received COURT_EVENTS_INSERTED for court case ${nomisCourtAppearance.caseId} that has never been created/mapped")
+            }
           }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingMigrationIntTest.kt
@@ -935,4 +935,5 @@ fun buildCourtEventResponse(
   eventDateTime = eventDateTime,
   courtOrders = emptyList(),
   nextEventDateTime = nextEventDateTime,
+  isClone = false,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingNomisApiMockServer.kt
@@ -281,6 +281,7 @@ class CourtSentencingNomisApiMockServer(private val jsonMapper: JsonMapper) {
     eventDateTime: LocalDateTime = LocalDateTime.now(),
     nextEventDateTime: LocalDateTime = LocalDateTime.now(),
     courtEventCharges: List<CourtEventChargeResponse> = emptyList(),
+    isClone: Boolean = false,
     response: CourtEventResponse = CourtEventResponse(
       id = courtAppearanceId,
       offenderNo = offenderNo,
@@ -296,6 +297,7 @@ class CourtSentencingNomisApiMockServer(private val jsonMapper: JsonMapper) {
       eventDateTime = eventDateTime,
       courtOrders = emptyList(),
       nextEventDateTime = nextEventDateTime,
+      isClone = isClone,
     ),
   ) {
     nomisApi.stubFor(
@@ -653,6 +655,7 @@ class CourtSentencingNomisApiMockServer(private val jsonMapper: JsonMapper) {
         outcomeReasonCode = OffenceResultCodeResponse(chargeStatus = "A", code = "4506", description = "Adjournment", dispositionCode = "I", conviction = false),
         createdDateTime = LocalDateTime.parse("2024-02-08T14:36:16.485181"),
         createdByUsername = "PRISONER_MANAGER_API",
+        isClone = false,
         courtEventCharges = listOf(
           CourtEventChargeResponse(
             eventId = eventId,
@@ -790,6 +793,7 @@ fun courtEventResponse(eventId: Long) = CourtEventResponse(
   createdDateTime = LocalDateTime.parse("2024-02-08T14:36:16.485181"),
   createdByUsername = "PRISONER_MANAGER_API",
   modifiedByUsername = "jbell",
+  isClone = false,
   courtEventCharges = listOf(
     CourtEventChargeResponse(
       eventId = eventId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationIntTest.kt
@@ -2071,6 +2071,76 @@ class CourtSentencingSynchronisationIntTest : SqsIntegrationTestBase() {
     }
 
     @Nested
+    @DisplayName("When court appearance was cloned by DPS for a previous recall")
+    inner class DpsClonedRecallBreachHearing {
+      @Nested
+      @DisplayName("When happy path")
+      inner class HappyPath {
+        val chargeIds =
+          listOf((101L to "e94eea10-dfd1-43c2-b43c-56e8650f8ae7"), (102L to "e94eea10-dfd1-43c2-b43c-56e8650f8ae7"))
+
+        @BeforeEach
+        fun setUp() {
+          courtSentencingNomisApiMockServer.stubGetCourtAppearance(
+            courtCaseId = NOMIS_COURT_CASE_ID,
+            offenderNo = OFFENDER_ID_DISPLAY,
+            courtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
+            eventDateTime = LocalDateTime.parse("2020-01-02T09:00:00"),
+            courtId = "MDI",
+            isClone = true,
+            courtEventCharges = listOf(
+              courtEventChargeResponse(
+                eventId = NOMIS_COURT_APPEARANCE_ID,
+                offenderChargeId = chargeIds[0].first,
+              ),
+              courtEventChargeResponse(
+                eventId = NOMIS_COURT_APPEARANCE_ID,
+                offenderChargeId = chargeIds[1].first,
+              ),
+            ),
+          )
+
+          courtSentencingMappingApiMockServer.stubGetCourtAppearanceByNomisIdNotFoundFollowedBySuccess(
+            nomisCourtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
+            dpsCourtAppearanceId = DPS_COURT_APPEARANCE_ID,
+          )
+          courtSentencingOffenderEventsQueue.sendMessage(
+
+            courtAppearanceEvent(
+              eventType = "COURT_EVENTS-INSERTED",
+              auditModule = "DPS_SYNCHRONISATION",
+              courtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
+              isBreachHearing = true,
+            ),
+          ).also { waitForAnyProcessingToComplete(name = "court-appearance-synchronisation-created-skipped") }
+        }
+
+        @Test
+        fun `will not create a court appearance in DPS`() {
+          dpsCourtSentencingServer.verify(
+            0,
+            postRequestedFor(urlPathEqualTo("/legacy/court-appearance")),
+          )
+        }
+
+        @Test
+        fun `will track a telemetry event for court appearance skipped`() {
+          verify(telemetryClient).trackEvent(
+            eq("court-appearance-synchronisation-created-skipped"),
+            check {
+              assertThat(it["offenderNo"]).isEqualTo(OFFENDER_ID_DISPLAY)
+              assertThat(it["isBreachHearing"]).isEqualTo("true")
+              assertThat(it["nomisBookingId"]).isEqualTo(NOMIS_BOOKING_ID.toString())
+              assertThat(it["nomisCourtAppearanceId"]).isEqualTo(NOMIS_COURT_APPEARANCE_ID.toString())
+              assertThat(it["reason"]).isEqualTo("appearance is a clone of a breach hearing")
+            },
+            isNull(),
+          )
+        }
+      }
+    }
+
+    @Nested
     @DisplayName("duplicate mapping - two messages received at the same time")
     inner class WhenDuplicate {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingTransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingTransformerTest.kt
@@ -168,6 +168,7 @@ class CourtSentencingTransformerTest {
               createdByUsername = "msmith",
             ),
           ),
+          isClone = false,
           courtOrders = listOf(
             CourtOrderResponse(
               id = 1343548,
@@ -300,6 +301,7 @@ class CourtSentencingTransformerTest {
               createdByUsername = "msmith",
             ),
           ),
+          isClone = false,
           courtOrders = listOf(
             CourtOrderResponse(
               id = 1346801,


### PR DESCRIPTION
Initial quick fix to ignore recall breach appearances that are created via case cloning. This relies on the audit information. However long term this is not reliable so we rewrite the sync for Recall Breach Appearance using an entirely different method.

Closes #2675