### PR TITLE
SDIT-2832 Copy migration into taps package

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationFilter.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Filter specifying what should be migrated from NOMIS to DPS")
+class TapMigrationFilter(
+  @Schema(
+    description = "Only migrate a single prisoner - used for testing",
+    example = "A1234BC",
+  )
+  val prisonerNumber: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationResource.kt
@@ -1,0 +1,97 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements
+
+import com.microsoft.applicationinsights.TelemetryClient
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapMigrationFilter
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapMigrationService
+
+@RestController
+@RequestMapping("/migrate/taps", produces = [MediaType.APPLICATION_JSON_VALUE])
+@Tag(name = "Taps Migration Resource")
+@PreAuthorize("hasRole('ROLE_PRISONER_FROM_NOMIS__MIGRATION__RW')")
+class TapMigrationResource(
+  private val migrationService: TapMigrationService,
+  private val telemetryClient: TelemetryClient,
+) {
+  @PostMapping
+  @ResponseStatus(value = HttpStatus.ACCEPTED)
+  @Operation(
+    summary = "Starts a tap full repair",
+    description = "Starts an asynchronous migration process to repair TAPs for all prisoners. This has been repurposed from the TAP migration. Requires role <b>PRISONER_FROM_NOMIS__MIGRATION__RW</b> ot <b>PRISONER_FROM_NOMIS__MIGRATION__RW</b>",
+    responses = [
+      ApiResponse(
+        responseCode = "202",
+        description = "Full TAP repair process started",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to start migration",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  suspend fun migrateTaps(
+    @RequestBody @Valid migrationFilter: TapMigrationFilter,
+  ) = migrationService.startMigration(migrationFilter)
+
+  @PreAuthorize("hasAnyRole('ROLE_PRISONER_FROM_NOMIS__MIGRATION__RW','ROLE_PRISONER_FROM_NOMIS__REPAIR_MOVEMENTS__RW')")
+  @PutMapping("/repair/{prisonerNumber}")
+  @Operation(
+    summary = "Repair all TAP applications, schedules and movements for a single prisoner",
+    description = "Resyncs a single prisoner to DPS. For prisoners with lots of movements this could be a lengthy process - maybe up to 2 minutes.",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Prisoner re-synchronised",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to start migration",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Prisoner not found in NOMIS",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  suspend fun repairPrisonerTaps(
+    @Schema(description = "The prisoner to resync")
+    @PathVariable prisonerNumber: String,
+  ) {
+    telemetryClient.trackEvent(
+      "temporary-absences-migration-entity-repair-requested",
+      mapOf("offenderNo" to prisonerNumber),
+      null,
+    )
+
+    migrationService.resyncPrisonerTaps(prisonerNumber)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationService.kt
@@ -1,0 +1,381 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.readValue
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.config.trackEvent
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.data.MigrationContext
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.data.generateBatchId
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.DuplicateErrorResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.MigrationMessageType
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsDpsApiService
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiService
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiService
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.Location
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapAuthorisation
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapMovement
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapOccurrence
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapRequest
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncAtAndBy
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ExternalMovementMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ScheduledMovementMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceApplicationMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceBookingMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingIdsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.OffenderTemporaryAbsencesResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.PrisonerId
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.ScheduledTemporaryAbsence
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.TemporaryAbsence
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.TemporaryAbsenceReturn
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.ByPageNumber
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.ByPageNumberMigrationService
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationMessage
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationPage
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationType
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.NomisApiService
+import java.util.*
+
+@Service
+class TapMigrationService(
+  val migrationMappingService: ExternalMovementsMappingApiService,
+  val nomisIdsApiService: NomisApiService,
+  val nomisApiService: ExternalMovementsNomisApiService,
+  val dpsApiService: ExternalMovementsDpsApiService,
+  jsonMapper: JsonMapper,
+  @Value($$"${externalmovements.page.size:1000}") pageSize: Long,
+  @Value($$"${externalmovements.complete-check.delay-seconds}") completeCheckDelaySeconds: Int,
+  @Value($$"${externalmovements.complete-check.retry-seconds:1}") completeCheckRetrySeconds: Int,
+  @Value($$"${externalmovements.complete-check.count}") completeCheckCount: Int,
+  @Value($$"${complete-check.scheduled-retry-seconds:10}") completeCheckScheduledRetrySeconds: Int,
+) : ByPageNumberMigrationService<TapMigrationFilter, PrisonerId, TemporaryAbsencesPrisonerMappingDto>(
+  mappingService = migrationMappingService,
+  migrationType = MigrationType.EXTERNAL_MOVEMENTS,
+  pageSize = pageSize,
+  completeCheckDelaySeconds = completeCheckDelaySeconds,
+  completeCheckCount = completeCheckCount,
+  completeCheckRetrySeconds = completeCheckRetrySeconds,
+  completeCheckScheduledRetrySeconds = completeCheckScheduledRetrySeconds,
+  jsonMapper = jsonMapper,
+) {
+  suspend fun getIds(
+    migrationFilter: TapMigrationFilter,
+    pageSize: Long,
+    pageNumber: Long,
+  ): PageImpl<PrisonerId> = if (migrationFilter.prisonerNumber.isNullOrEmpty()) {
+    nomisIdsApiService.getPrisonerIds(
+      pageNumber = pageNumber,
+      pageSize = pageSize,
+    )
+  } else {
+    // If a single prisoner migration is requested, then we'll trust the input as we're probably testing. Pretend that we called nomis-prisoner-api which found a single prisoner.
+    PageImpl(mutableListOf(PrisonerId(migrationFilter.prisonerNumber)), Pageable.ofSize(1), 1)
+  }
+
+  override suspend fun getPageOfIds(
+    migrationFilter: TapMigrationFilter,
+    pageSize: Long,
+    pageNumber: Long,
+  ): List<PrisonerId> = getIds(migrationFilter, pageSize, pageNumber).content
+
+  override suspend fun getTotalNumberOfIds(migrationFilter: TapMigrationFilter): Long = getIds(migrationFilter, 1, 0).totalElements
+
+  suspend fun resyncPrisonerTaps(prisonerNumber: String) = migrateNomisEntity(
+    MigrationContext(
+      MigrationType.EXTERNAL_MOVEMENTS,
+      generateBatchId(),
+      1,
+      PrisonerId(prisonerNumber),
+      mutableMapOf("ignoreMissingTaps" to false),
+    ),
+  )
+
+  override suspend fun migrateNomisEntity(context: MigrationContext<PrisonerId>) {
+    val offenderNo = context.body.offenderNo
+    val migrationId = context.migrationId
+    val telemetry = mutableMapOf(
+      "offenderNo" to offenderNo,
+      "migrationId" to migrationId,
+    )
+    val ignoreMissingTaps = context.properties["ignoreMissingTaps"] as Boolean? ?: true
+
+    runCatching {
+      val temporaryAbsences = nomisApiService.getTemporaryAbsencesOrNull(offenderNo)
+        // carry on even if there is no offender in NOMIS - this could be for a merged prisoner and we still need to update the mappings etc.
+        ?: OffenderTemporaryAbsencesResponse(bookings = emptyList())
+      if (ignoreMissingTaps && temporaryAbsences.bookings.isEmpty()) {
+        publishTelemetry("ignored", telemetry.apply { this["reason"] = "The offender has no TAPs" })
+        return
+      }
+      val oldMappingIds = migrationMappingService.getPrisonerMappingIds(offenderNo)
+      // Note that we're not expecting to perform a clean migration again so we're calling the DPS /resync endpoint which performs "patch migrations"
+      val dpsResponse = dpsApiService.resyncPrisonerTaps(offenderNo, temporaryAbsences.toDpsRequest(oldMappingIds))
+        ?: MigrateTapResponse(temporaryAbsences = emptyList(), unscheduledMovements = emptyList())
+      val mappings = temporaryAbsences.buildMappings(offenderNo, migrationId, dpsResponse)
+
+      createMappingOrOnFailureDo(mappings) {
+        requeueCreateMapping(mappings, context)
+      }
+    }
+      .onFailure {
+        publishTelemetry("failed", telemetry.apply { this["reason"] = it.message ?: "Unknown error" })
+        throw it
+      }
+  }
+
+  override suspend fun retryCreateMapping(context: MigrationContext<TemporaryAbsencesPrisonerMappingDto>) {
+    createMappingOrOnFailureDo(context.body) {
+      throw it
+    }
+  }
+
+  private suspend fun createMappingOrOnFailureDo(
+    mapping: TemporaryAbsencesPrisonerMappingDto,
+    failureHandler: suspend (error: Throwable) -> Unit,
+  ) {
+    runCatching {
+      createMapping(mapping)
+    }.onSuccess {
+      publishTelemetry(
+        if (it.isError) "duplicate" else "migrated",
+        mapOf(
+          "offenderNo" to mapping.prisonerNumber,
+          "migrationId" to mapping.migrationId,
+        ),
+      )
+    }.onFailure {
+      failureHandler(it)
+    }
+  }
+
+  private suspend fun createMapping(mapping: TemporaryAbsencesPrisonerMappingDto) = migrationMappingService.createMapping(
+    mapping,
+    object :
+      ParameterizedTypeReference<DuplicateErrorResponse<TemporaryAbsencesPrisonerMappingDto>>() {},
+  )
+
+  private suspend fun requeueCreateMapping(
+    mapping: TemporaryAbsencesPrisonerMappingDto,
+    context: MigrationContext<*>,
+  ) {
+    queueService.sendMessage(
+      MigrationMessageType.RETRY_MIGRATION_MAPPING,
+      MigrationContext(
+        context = context,
+        body = mapping,
+      ),
+    )
+  }
+
+  private fun publishTelemetry(type: String, telemetry: Map<String, String>) {
+    telemetryClient.trackEvent(
+      "temporary-absences-migration-entity-$type",
+      telemetry,
+    )
+  }
+
+  private fun OffenderTemporaryAbsencesResponse.buildMappings(prisonerNumber: String, migrationId: String, dpsResponse: MigrateTapResponse) = TemporaryAbsencesPrisonerMappingDto(
+    prisonerNumber = prisonerNumber,
+    migrationId = migrationId,
+    bookings = bookings.map { booking ->
+      TemporaryAbsenceBookingMappingDto(
+        bookingId = booking.bookingId,
+        applications = booking.temporaryAbsenceApplications.map { application ->
+          TemporaryAbsenceApplicationMappingDto(
+            nomisMovementApplicationId = application.movementApplicationId,
+            dpsMovementApplicationId = dpsResponse.findDpsAuthorisationId(application.movementApplicationId),
+            schedules = application.absences.mapNotNull { it.scheduledTemporaryAbsence }.map { it.toMappingDto(dpsResponse) },
+            movements = application.absences.mapNotNull { it.temporaryAbsence }.map { it.toMappingDto(booking.bookingId, dpsResponse) } +
+              application.absences.mapNotNull { it.temporaryAbsenceReturn }.map { it.toMappingDto(booking.bookingId, dpsResponse) },
+          )
+        },
+        unscheduledMovements = booking.unscheduledTemporaryAbsences.map { it.toMappingDto(booking.bookingId, dpsResponse) } +
+          booking.unscheduledTemporaryAbsenceReturns.map { it.toMappingDto(booking.bookingId, dpsResponse) },
+      )
+    },
+  )
+
+  private fun ScheduledTemporaryAbsence.toMappingDto(dpsResponse: MigrateTapResponse): ScheduledMovementMappingDto = ScheduledMovementMappingDto(
+    nomisEventId = this.eventId,
+    dpsOccurrenceId = dpsResponse.findDpsScheduleId(this.eventId),
+    nomisAddressId = this.toAddressId,
+    nomisAddressOwnerClass = this.toAddressOwnerClass,
+    dpsAddressText = this.toFullAddress ?: "",
+    dpsDescription = this.toAddressDescription,
+    dpsPostcode = this.toAddressPostcode,
+    eventTime = "${this.startTime}",
+  )
+
+  private fun TemporaryAbsence.toMappingDto(bookingId: Long, dpsResponse: MigrateTapResponse): ExternalMovementMappingDto = ExternalMovementMappingDto(
+    nomisMovementSeq = this.sequence,
+    dpsMovementId = dpsResponse.findDpsMovementId(bookingId, this.sequence),
+    nomisAddressId = this.toAddressId,
+    nomisAddressOwnerClass = this.toAddressOwnerClass,
+    dpsAddressText = this.toFullAddress ?: "",
+    dpsDescription = this.toAddressDescription,
+    dpsPostcode = this.toAddressPostcode,
+  )
+
+  private fun TemporaryAbsenceReturn.toMappingDto(bookingId: Long, dpsResponse: MigrateTapResponse): ExternalMovementMappingDto = ExternalMovementMappingDto(
+    nomisMovementSeq = this.sequence,
+    dpsMovementId = dpsResponse.findDpsMovementId(bookingId, this.sequence),
+    nomisAddressId = this.fromAddressId,
+    nomisAddressOwnerClass = this.fromAddressOwnerClass,
+    dpsAddressText = this.fromFullAddress ?: "",
+    dpsDescription = this.fromAddressDescription,
+    dpsPostcode = this.fromAddressPostcode,
+  )
+
+  private fun MigrateTapResponse.findDpsAuthorisationId(nomisApplicationId: Long) = temporaryAbsences.firstOrNull { it.legacyId == nomisApplicationId }
+    ?.id
+    ?: throw TapMigrationException("No matching DPS authorisation found for nomis application id $nomisApplicationId, we found only ${temporaryAbsences.map { it.legacyId to it.id }}")
+
+  private fun MigrateTapResponse.findDpsScheduleId(nomisEventId: Long): UUID {
+    val occurrenceResponses = temporaryAbsences.flatMap { it.occurrences }
+    return occurrenceResponses
+      .firstOrNull { it.legacyId == nomisEventId }
+      ?.id
+      ?: throw TapMigrationException("No matching DPS occurrence found for nomis event id $nomisEventId, we found only ${occurrenceResponses.map { it.legacyId to it.id }}")
+  }
+
+  private fun MigrateTapResponse.findDpsMovementId(nomisBookingId: Long, nomisMovementSeq: Int): UUID {
+    val movementResponses = (temporaryAbsences.flatMap { it.occurrences.flatMap { it.movements } } + unscheduledMovements)
+    return movementResponses
+      .firstOrNull {
+        val (bookingId, sequence) = it.legacyId.parseNomisMovementId()
+        bookingId == nomisBookingId && sequence == nomisMovementSeq
+      }
+      ?.id
+      ?: throw TapMigrationException("No matching DPS movement found for nomis booking with sequence $nomisBookingId / $nomisMovementSeq, we found only ${movementResponses.map { it.legacyId to it.id }}")
+  }
+
+  private fun String.parseNomisMovementId() = split("_").let { it[0].toLong() to it[1].toInt() }
+
+  override fun parseContextFilter(json: String): MigrationMessage<*, TapMigrationFilter> = jsonMapper.readValue(json)
+
+  override fun parseContextPageFilter(json: String): MigrationMessage<*, MigrationPage<TapMigrationFilter, ByPageNumber>> = jsonMapper.readValue(json)
+
+  override fun parseContextNomisId(json: String): MigrationMessage<*, PrisonerId> = jsonMapper.readValue(json)
+
+  override fun parseContextMapping(json: String): MigrationMessage<*, TemporaryAbsencesPrisonerMappingDto> = jsonMapper.readValue(json)
+}
+
+fun OffenderTemporaryAbsencesResponse.toDpsRequest(oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto) = MigrateTapRequest(
+  temporaryAbsences = this.bookings.flatMap { booking ->
+    booking.temporaryAbsenceApplications.map { application ->
+      MigrateTapAuthorisation(
+        prisonCode = application.prisonId,
+        statusCode = application.applicationStatus.toDpsAuthorisationStatusCode(application.toDate, booking.latestBooking),
+        absenceTypeCode = application.temporaryAbsenceType,
+        absenceSubTypeCode = application.temporaryAbsenceSubType,
+        absenceReasonCode = application.eventSubType,
+        accompaniedByCode = application.escortCode ?: DEFAULT_ESCORT_CODE,
+        transportCode = application.transportType ?: DEFAULT_TRANSPORT_TYPE,
+        repeat = application.applicationType == "REPEATING",
+        start = application.fromDate,
+        end = application.toDate,
+        comments = application.comment,
+        created = SyncAtAndBy(application.audit.createDatetime, application.audit.createUsername),
+        updated = application.audit.modifyDatetime?.let { SyncAtAndBy(application.audit.modifyDatetime, application.audit.modifyUserId ?: "") },
+        legacyId = application.movementApplicationId,
+        startTime = "${application.releaseTime.toLocalTime()}",
+        endTime = "${application.returnTime.toLocalTime()}",
+        location = Location(description = application.toAddressDescription, address = application.toFullAddress, postcode = application.toAddressPostcode),
+        id = oldMappingIds.applications.find { it.nomisMovementApplicationId == application.movementApplicationId }?.dpsMovementApplicationId,
+        occurrences = application.absences.mapNotNull { absence ->
+          absence.scheduledTemporaryAbsence?.let { scheduleOut ->
+            scheduleOut.toDpsRequest(
+              schedulePrison = scheduleOut.fromPrison ?: application.prisonId,
+              bookingId = booking.bookingId,
+              movementOut = absence.temporaryAbsence,
+              movementIn = absence.temporaryAbsenceReturn,
+              temporaryAbsenceType = application.temporaryAbsenceType,
+              temporaryAbsenceSubType = application.temporaryAbsenceSubType,
+              oldMappingIds = oldMappingIds,
+            )
+          }
+        },
+      )
+    }
+  },
+  unscheduledMovements = this.bookings.flatMap { booking ->
+    booking.unscheduledTemporaryAbsences.map { movementOut ->
+      movementOut.toDpsRequest(booking.bookingId, movementOut.fromPrison ?: "", oldMappingIds)
+    } +
+      booking.unscheduledTemporaryAbsenceReturns.map { movementIn ->
+        movementIn.toDpsRequest(booking.bookingId, movementIn.toPrison ?: "", oldMappingIds)
+      }
+  },
+)
+
+private fun ScheduledTemporaryAbsence.toDpsRequest(
+  temporaryAbsenceType: String?,
+  temporaryAbsenceSubType: String?,
+  schedulePrison: String,
+  bookingId: Long,
+  movementOut: TemporaryAbsence?,
+  movementIn: TemporaryAbsenceReturn?,
+  oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto,
+): MigrateTapOccurrence = MigrateTapOccurrence(
+  isCancelled = eventStatus == "CANC",
+  start = startTime,
+  end = returnTime,
+  location = Location(description = toAddressDescription, address = toFullAddress, postcode = toAddressPostcode),
+  absenceTypeCode = temporaryAbsenceType,
+  absenceSubTypeCode = temporaryAbsenceSubType,
+  absenceReasonCode = eventSubType,
+  accompaniedByCode = escort ?: DEFAULT_ESCORT_CODE,
+  transportCode = transportType ?: DEFAULT_TRANSPORT_TYPE,
+  contactInformation = contactPersonName,
+  comments = comment,
+  created = SyncAtAndBy(audit.createDatetime, audit.createUsername),
+  updated = audit.modifyDatetime?.let { modified -> SyncAtAndBy(modified, audit.modifyUserId ?: "") },
+  legacyId = eventId,
+  movements = listOfNotNull(movementOut?.toDpsRequest(bookingId, schedulePrison, oldMappingIds), movementIn?.toDpsRequest(bookingId, schedulePrison, oldMappingIds)),
+  id = oldMappingIds.schedules.find { it.nomisEventId == eventId }?.dpsOccurrenceId,
+)
+
+private fun TemporaryAbsenceReturn.toDpsRequest(
+  bookingId: Long,
+  schedulePrison: String,
+  oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto,
+): MigrateTapMovement = MigrateTapMovement(
+  occurredAt = movementTime,
+  direction = MigrateTapMovement.Direction.IN,
+  absenceReasonCode = movementReason,
+  location = Location(description = fromAddressDescription, address = fromFullAddress, postcode = fromAddressPostcode),
+  accompaniedByCode = escort ?: DEFAULT_ESCORT_CODE,
+  created = SyncAtAndBy(audit.createDatetime, audit.createUsername),
+  legacyId = "${bookingId}_$sequence",
+  accompaniedByComments = escortText,
+  comments = commentText,
+  updated = audit.modifyDatetime?.let { modified -> SyncAtAndBy(modified, audit.modifyUserId ?: "") },
+  prisonCode = toPrison ?: schedulePrison,
+  id = oldMappingIds.movements.find { it.nomisBookingId == bookingId && it.nomisMovementSeq == sequence }?.dpsMovementId,
+)
+
+private fun TemporaryAbsence.toDpsRequest(
+  bookingId: Long,
+  schedulePrison: String,
+  oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto,
+): MigrateTapMovement = MigrateTapMovement(
+  occurredAt = movementTime,
+  direction = MigrateTapMovement.Direction.OUT,
+  absenceReasonCode = movementReason,
+  location = Location(description = toAddressDescription, address = toFullAddress, postcode = toAddressPostcode),
+  accompaniedByCode = escort ?: DEFAULT_ESCORT_CODE,
+  created = SyncAtAndBy(audit.createDatetime, audit.createUsername),
+  legacyId = "${bookingId}_$sequence",
+  accompaniedByComments = escortText,
+  comments = commentText,
+  updated = audit.modifyDatetime?.let { modified -> SyncAtAndBy(modified, audit.modifyUserId ?: "") },
+  prisonCode = fromPrison ?: schedulePrison,
+  id = oldMappingIds.movements.find { it.nomisBookingId == bookingId && it.nomisMovementSeq == sequence }?.dpsMovementId,
+)
+
+class TapMigrationException(message: String) : RuntimeException(message)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/ExternalMovementsMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/ExternalMovementsMigrationIntTest.kt
@@ -74,7 +74,7 @@ class ExternalMovementsMigrationIntTest(
   inner class Security {
     @Test
     fun `access forbidden when no role`() {
-      webTestClient.post().uri("/migrate/external-movements")
+      webTestClient.post().uri("/migrate/taps")
         .headers(setAuthorisation(roles = listOf()))
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(ExternalMovementsMigrationFilter())
@@ -84,7 +84,7 @@ class ExternalMovementsMigrationIntTest(
 
     @Test
     fun `access forbidden with wrong role`() {
-      webTestClient.post().uri("/migrate/external-movements")
+      webTestClient.post().uri("/migrate/taps")
         .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(ExternalMovementsMigrationFilter())
@@ -94,7 +94,7 @@ class ExternalMovementsMigrationIntTest(
 
     @Test
     fun `access unauthorised with no auth token`() {
-      webTestClient.post().uri("/migrate/external-movements")
+      webTestClient.post().uri("/migrate/taps")
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(ExternalMovementsMigrationFilter())
         .exchange()
@@ -734,7 +734,7 @@ class ExternalMovementsMigrationIntTest(
 
       @Test
       fun `access forbidden when no role`() {
-        webTestClient.put().uri("/migrate/external-movements/repair/$prisonerNumber")
+        webTestClient.put().uri("/migrate/taps/repair/$prisonerNumber")
           .headers(setAuthorisation(roles = listOf()))
           .contentType(MediaType.APPLICATION_JSON)
           .bodyValue(ExternalMovementsMigrationFilter())
@@ -744,7 +744,7 @@ class ExternalMovementsMigrationIntTest(
 
       @Test
       fun `access forbidden with wrong role`() {
-        webTestClient.put().uri("/migrate/external-movements/repair/$prisonerNumber")
+        webTestClient.put().uri("/migrate/taps/repair/$prisonerNumber")
           .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
           .contentType(MediaType.APPLICATION_JSON)
           .bodyValue(ExternalMovementsMigrationFilter())
@@ -754,7 +754,7 @@ class ExternalMovementsMigrationIntTest(
 
       @Test
       fun `access unauthorised with no auth token`() {
-        webTestClient.put().uri("/migrate/external-movements/repair/$prisonerNumber")
+        webTestClient.put().uri("/migrate/taps/repair/$prisonerNumber")
           .contentType(MediaType.APPLICATION_JSON)
           .bodyValue(ExternalMovementsMigrationFilter())
           .exchange()
@@ -763,7 +763,7 @@ class ExternalMovementsMigrationIntTest(
 
       @Test
       fun `access allowed with temporary role`() {
-        webTestClient.put().uri("/migrate/external-movements/repair/$prisonerNumber")
+        webTestClient.put().uri("/migrate/taps/repair/$prisonerNumber")
           .headers(setAuthorisation(roles = listOf("ROLE_PRISONER_FROM_NOMIS__REPAIR_MOVEMENTS__RW")))
           .contentType(MediaType.APPLICATION_JSON)
           .bodyValue(ExternalMovementsMigrationFilter())
@@ -774,7 +774,7 @@ class ExternalMovementsMigrationIntTest(
 
     private fun repairPrisoner(prisonerNumber: String) = webTestClient.put()
       .uri {
-        it.path("/migrate/external-movements/repair/$prisonerNumber")
+        it.path("/migrate/taps/repair/$prisonerNumber")
           .build(prisonerNumber)
       }
       .headers(setAuthorisation(roles = listOf("ROLE_PRISONER_FROM_NOMIS__MIGRATION__RW")))
@@ -785,7 +785,7 @@ class ExternalMovementsMigrationIntTest(
   }
 
   private fun performMigration(prisonerNumber: String? = null): String = webTestClient.post()
-    .uri("/migrate/external-movements")
+    .uri("/migrate/taps")
     .headers(setAuthorisation(roles = listOf("ROLE_PRISONER_FROM_NOMIS__MIGRATION__RW")))
     .contentType(MediaType.APPLICATION_JSON)
     .apply { prisonerNumber?.let { bodyValue("""{"prisonerNumber":"$prisonerNumber"}""") } ?: bodyValue("{}") }


### PR DESCRIPTION
For TAPs, we've repurposed the migration as a repair utility so we need to keep it. So it needs moving into the TAP package and we'll write another migration for the next entity we tackle. The only change is to the endpoint URLs - changed to indicate they apply only to taps.

Still keeping the old migration endpoints for now, until I've had a chance to switch to the new ones in the migration UI.