### PR TITLE
SDIT-2832 Switch get all offender taps to new NOMIS API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/ExternalMovementsMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/ExternalMovementsMigrationService.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.M
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncAtAndBy
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.DEFAULT_ESCORT_CODE
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.DEFAULT_TRANSPORT_TYPE
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapsNomisApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.toDpsAuthorisationStatusCode
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ExternalMovementMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ScheduledMovementMappingDto
@@ -28,11 +29,11 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.mod
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceBookingMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingIdsDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.OffenderTemporaryAbsencesResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTapMovementIn
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTapMovementOut
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTapScheduleOut
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.OffenderTapsResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.PrisonerId
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.ScheduledTemporaryAbsence
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.TemporaryAbsence
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.TemporaryAbsenceReturn
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.ByPageNumber
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.ByPageNumberMigrationService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationMessage
@@ -45,7 +46,7 @@ import java.util.*
 class ExternalMovementsMigrationService(
   val migrationMappingService: ExternalMovementsMappingApiService,
   val nomisIdsApiService: NomisApiService,
-  val nomisApiService: ExternalMovementsNomisApiService,
+  val nomisApiService: TapsNomisApiService,
   val dpsApiService: ExternalMovementsDpsApiService,
   jsonMapper: JsonMapper,
   @Value($$"${externalmovements.page.size:1000}") pageSize: Long,
@@ -105,18 +106,18 @@ class ExternalMovementsMigrationService(
     val ignoreMissingTaps = context.properties["ignoreMissingTaps"] as Boolean? ?: true
 
     runCatching {
-      val temporaryAbsences = nomisApiService.getTemporaryAbsencesOrNull(offenderNo)
+      val taps = nomisApiService.getAllOffenderTapsOrNull(offenderNo)
         // carry on even if there is no offender in NOMIS - this could be for a merged prisoner and we still need to update the mappings etc.
-        ?: OffenderTemporaryAbsencesResponse(bookings = emptyList())
-      if (ignoreMissingTaps && temporaryAbsences.bookings.isEmpty()) {
+        ?: OffenderTapsResponse(bookings = emptyList())
+      if (ignoreMissingTaps && taps.bookings.isEmpty()) {
         publishTelemetry("ignored", telemetry.apply { this["reason"] = "The offender has no TAPs" })
         return
       }
       val oldMappingIds = migrationMappingService.getPrisonerMappingIds(offenderNo)
       // Note that we're not expecting to perform a clean migration again so we're calling the DPS /resync endpoint which performs "patch migrations"
-      val dpsResponse = dpsApiService.resyncPrisonerTaps(offenderNo, temporaryAbsences.toDpsRequest(oldMappingIds))
+      val dpsResponse = dpsApiService.resyncPrisonerTaps(offenderNo, taps.toDpsRequest(oldMappingIds))
         ?: MigrateTapResponse(temporaryAbsences = emptyList(), unscheduledMovements = emptyList())
-      val mappings = temporaryAbsences.buildMappings(offenderNo, migrationId, dpsResponse)
+      val mappings = taps.buildMappings(offenderNo, migrationId, dpsResponse)
 
       createMappingOrOnFailureDo(mappings) {
         requeueCreateMapping(mappings, context)
@@ -179,28 +180,28 @@ class ExternalMovementsMigrationService(
     )
   }
 
-  private fun OffenderTemporaryAbsencesResponse.buildMappings(prisonerNumber: String, migrationId: String, dpsResponse: MigrateTapResponse) = TemporaryAbsencesPrisonerMappingDto(
+  private fun OffenderTapsResponse.buildMappings(prisonerNumber: String, migrationId: String, dpsResponse: MigrateTapResponse) = TemporaryAbsencesPrisonerMappingDto(
     prisonerNumber = prisonerNumber,
     migrationId = migrationId,
     bookings = bookings.map { booking ->
       TemporaryAbsenceBookingMappingDto(
         bookingId = booking.bookingId,
-        applications = booking.temporaryAbsenceApplications.map { application ->
+        applications = booking.tapApplications.map { application ->
           TemporaryAbsenceApplicationMappingDto(
-            nomisMovementApplicationId = application.movementApplicationId,
-            dpsMovementApplicationId = dpsResponse.findDpsAuthorisationId(application.movementApplicationId),
-            schedules = application.absences.mapNotNull { it.scheduledTemporaryAbsence }.map { it.toMappingDto(dpsResponse) },
-            movements = application.absences.mapNotNull { it.temporaryAbsence }.map { it.toMappingDto(booking.bookingId, dpsResponse) } +
-              application.absences.mapNotNull { it.temporaryAbsenceReturn }.map { it.toMappingDto(booking.bookingId, dpsResponse) },
+            nomisMovementApplicationId = application.tapApplicationId,
+            dpsMovementApplicationId = dpsResponse.findDpsAuthorisationId(application.tapApplicationId),
+            schedules = application.taps.mapNotNull { it.tapScheduleOut }.map { it.toMappingDto(dpsResponse) },
+            movements = application.taps.mapNotNull { it.tapMovementOut }.map { it.toMappingDto(booking.bookingId, dpsResponse) } +
+              application.taps.mapNotNull { it.tapMovementIn }.map { it.toMappingDto(booking.bookingId, dpsResponse) },
           )
         },
-        unscheduledMovements = booking.unscheduledTemporaryAbsences.map { it.toMappingDto(booking.bookingId, dpsResponse) } +
-          booking.unscheduledTemporaryAbsenceReturns.map { it.toMappingDto(booking.bookingId, dpsResponse) },
+        unscheduledMovements = booking.unscheduledTapMovementOuts.map { it.toMappingDto(booking.bookingId, dpsResponse) } +
+          booking.unscheduledTapMovementIns.map { it.toMappingDto(booking.bookingId, dpsResponse) },
       )
     },
   )
 
-  private fun ScheduledTemporaryAbsence.toMappingDto(dpsResponse: MigrateTapResponse): ScheduledMovementMappingDto = ScheduledMovementMappingDto(
+  private fun BookingTapScheduleOut.toMappingDto(dpsResponse: MigrateTapResponse): ScheduledMovementMappingDto = ScheduledMovementMappingDto(
     nomisEventId = this.eventId,
     dpsOccurrenceId = dpsResponse.findDpsScheduleId(this.eventId),
     nomisAddressId = this.toAddressId,
@@ -211,7 +212,7 @@ class ExternalMovementsMigrationService(
     eventTime = "${this.startTime}",
   )
 
-  private fun TemporaryAbsence.toMappingDto(bookingId: Long, dpsResponse: MigrateTapResponse): ExternalMovementMappingDto = ExternalMovementMappingDto(
+  private fun BookingTapMovementOut.toMappingDto(bookingId: Long, dpsResponse: MigrateTapResponse): ExternalMovementMappingDto = ExternalMovementMappingDto(
     nomisMovementSeq = this.sequence,
     dpsMovementId = dpsResponse.findDpsMovementId(bookingId, this.sequence),
     nomisAddressId = this.toAddressId,
@@ -221,7 +222,7 @@ class ExternalMovementsMigrationService(
     dpsPostcode = this.toAddressPostcode,
   )
 
-  private fun TemporaryAbsenceReturn.toMappingDto(bookingId: Long, dpsResponse: MigrateTapResponse): ExternalMovementMappingDto = ExternalMovementMappingDto(
+  private fun BookingTapMovementIn.toMappingDto(bookingId: Long, dpsResponse: MigrateTapResponse): ExternalMovementMappingDto = ExternalMovementMappingDto(
     nomisMovementSeq = this.sequence,
     dpsMovementId = dpsResponse.findDpsMovementId(bookingId, this.sequence),
     nomisAddressId = this.fromAddressId,
@@ -265,14 +266,14 @@ class ExternalMovementsMigrationService(
   override fun parseContextMapping(json: String): MigrationMessage<*, TemporaryAbsencesPrisonerMappingDto> = jsonMapper.readValue(json)
 }
 
-fun OffenderTemporaryAbsencesResponse.toDpsRequest(oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto) = MigrateTapRequest(
+fun OffenderTapsResponse.toDpsRequest(oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto) = MigrateTapRequest(
   temporaryAbsences = this.bookings.flatMap { booking ->
-    booking.temporaryAbsenceApplications.map { application ->
+    booking.tapApplications.map { application ->
       MigrateTapAuthorisation(
         prisonCode = application.prisonId,
         statusCode = application.applicationStatus.toDpsAuthorisationStatusCode(application.toDate, booking.latestBooking),
-        absenceTypeCode = application.temporaryAbsenceType,
-        absenceSubTypeCode = application.temporaryAbsenceSubType,
+        absenceTypeCode = application.tapType,
+        absenceSubTypeCode = application.tapSubType,
         absenceReasonCode = application.eventSubType,
         accompaniedByCode = application.escortCode ?: DEFAULT_ESCORT_CODE,
         transportCode = application.transportType ?: DEFAULT_TRANSPORT_TYPE,
@@ -282,20 +283,20 @@ fun OffenderTemporaryAbsencesResponse.toDpsRequest(oldMappingIds: TemporaryAbsen
         comments = application.comment,
         created = SyncAtAndBy(application.audit.createDatetime, application.audit.createUsername),
         updated = application.audit.modifyDatetime?.let { SyncAtAndBy(application.audit.modifyDatetime, application.audit.modifyUserId ?: "") },
-        legacyId = application.movementApplicationId,
+        legacyId = application.tapApplicationId,
         startTime = "${application.releaseTime.toLocalTime()}",
         endTime = "${application.returnTime.toLocalTime()}",
         location = Location(description = application.toAddressDescription, address = application.toFullAddress, postcode = application.toAddressPostcode),
-        id = oldMappingIds.applications.find { it.nomisMovementApplicationId == application.movementApplicationId }?.dpsMovementApplicationId,
-        occurrences = application.absences.mapNotNull { absence ->
-          absence.scheduledTemporaryAbsence?.let { scheduleOut ->
+        id = oldMappingIds.applications.find { it.nomisMovementApplicationId == application.tapApplicationId }?.dpsMovementApplicationId,
+        occurrences = application.taps.mapNotNull { tap ->
+          tap.tapScheduleOut?.let { scheduleOut ->
             scheduleOut.toDpsRequest(
               schedulePrison = scheduleOut.fromPrison ?: application.prisonId,
               bookingId = booking.bookingId,
-              movementOut = absence.temporaryAbsence,
-              movementIn = absence.temporaryAbsenceReturn,
-              temporaryAbsenceType = application.temporaryAbsenceType,
-              temporaryAbsenceSubType = application.temporaryAbsenceSubType,
+              movementOut = tap.tapMovementOut,
+              movementIn = tap.tapMovementIn,
+              tapType = application.tapType,
+              tapSubType = application.tapSubType,
               oldMappingIds = oldMappingIds,
             )
           }
@@ -304,30 +305,30 @@ fun OffenderTemporaryAbsencesResponse.toDpsRequest(oldMappingIds: TemporaryAbsen
     }
   },
   unscheduledMovements = this.bookings.flatMap { booking ->
-    booking.unscheduledTemporaryAbsences.map { movementOut ->
+    booking.unscheduledTapMovementOuts.map { movementOut ->
       movementOut.toDpsRequest(booking.bookingId, movementOut.fromPrison ?: "", oldMappingIds)
     } +
-      booking.unscheduledTemporaryAbsenceReturns.map { movementIn ->
+      booking.unscheduledTapMovementIns.map { movementIn ->
         movementIn.toDpsRequest(booking.bookingId, movementIn.toPrison ?: "", oldMappingIds)
       }
   },
 )
 
-private fun ScheduledTemporaryAbsence.toDpsRequest(
-  temporaryAbsenceType: String?,
-  temporaryAbsenceSubType: String?,
+private fun BookingTapScheduleOut.toDpsRequest(
+  tapType: String?,
+  tapSubType: String?,
   schedulePrison: String,
   bookingId: Long,
-  movementOut: TemporaryAbsence?,
-  movementIn: TemporaryAbsenceReturn?,
+  movementOut: BookingTapMovementOut?,
+  movementIn: BookingTapMovementIn?,
   oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto,
 ): MigrateTapOccurrence = MigrateTapOccurrence(
   isCancelled = eventStatus == "CANC",
   start = startTime,
   end = returnTime,
   location = Location(description = toAddressDescription, address = toFullAddress, postcode = toAddressPostcode),
-  absenceTypeCode = temporaryAbsenceType,
-  absenceSubTypeCode = temporaryAbsenceSubType,
+  absenceTypeCode = tapType,
+  absenceSubTypeCode = tapSubType,
   absenceReasonCode = eventSubType,
   accompaniedByCode = escort ?: DEFAULT_ESCORT_CODE,
   transportCode = transportType ?: DEFAULT_TRANSPORT_TYPE,
@@ -340,7 +341,7 @@ private fun ScheduledTemporaryAbsence.toDpsRequest(
   id = oldMappingIds.schedules.find { it.nomisEventId == eventId }?.dpsOccurrenceId,
 )
 
-private fun TemporaryAbsenceReturn.toDpsRequest(
+private fun BookingTapMovementIn.toDpsRequest(
   bookingId: Long,
   schedulePrison: String,
   oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto,
@@ -359,7 +360,7 @@ private fun TemporaryAbsenceReturn.toDpsRequest(
   id = oldMappingIds.movements.find { it.nomisBookingId == bookingId && it.nomisMovementSeq == sequence }?.dpsMovementId,
 )
 
-private fun TemporaryAbsence.toDpsRequest(
+private fun BookingTapMovementOut.toDpsRequest(
   bookingId: Long,
   schedulePrison: String,
   oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/ExternalMovementsMoveBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/ExternalMovementsMoveBookingService.kt
@@ -12,18 +12,18 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.track
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.trackEvent
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.valuesAsStrings
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MoveTemporaryAbsencesRequest
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapsNomisApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceApplicationIdMapping
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceMovementIdMapping
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTemporaryAbsences
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTaps
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.InternalMessage
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.SynchronisationQueueService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.SynchronisationType
-import kotlin.String
 
 @Service
 class ExternalMovementsMoveBookingService(
   private val dpsApi: ExternalMovementsDpsApiService,
-  private val nomisApi: ExternalMovementsNomisApiService,
+  private val nomisApi: TapsNomisApiService,
   private val mappingApi: ExternalMovementsMappingApiService,
   private val queueService: SynchronisationQueueService,
   private val migrationService: ExternalMovementsMigrationService,
@@ -65,15 +65,15 @@ class ExternalMovementsMoveBookingService(
     }
   }
 
-  private suspend fun getNomisBooking(offenderNo: String, bookingId: Long) = nomisApi.getTemporaryAbsencesOrNull(offenderNo)
+  private suspend fun getNomisBooking(offenderNo: String, bookingId: Long) = nomisApi.getAllOffenderTapsOrNull(offenderNo)
     ?.bookings
     ?.firstOrNull { it.bookingId == bookingId }
 
-  private fun BookingTemporaryAbsences.findDpsAuthorisationIds(
+  private fun BookingTaps.findDpsAuthorisationIds(
     mappings: List<TemporaryAbsenceApplicationIdMapping>,
     telemetry: MutableMap<String, Any>,
-  ) = temporaryAbsenceApplications
-    .map { it.movementApplicationId }
+  ) = tapApplications
+    .map { it.tapApplicationId }
     .also { telemetry["nomisApplicationIds"] = "$it" }
     .map { nomisApplicationId ->
       mappings.find { it.applicationId == nomisApplicationId }
@@ -82,10 +82,10 @@ class ExternalMovementsMoveBookingService(
     }
     .also { telemetry["dpsAuthorisationIds"] = "$it" }
 
-  private fun BookingTemporaryAbsences.findDpsMovementIds(
+  private fun BookingTaps.findDpsMovementIds(
     mappings: List<TemporaryAbsenceMovementIdMapping>,
     telemetry: MutableMap<String, Any>,
-  ) = (unscheduledTemporaryAbsences.map { it.sequence } + unscheduledTemporaryAbsenceReturns.map { it.sequence })
+  ) = (unscheduledTapMovementOuts.map { it.sequence } + unscheduledTapMovementIns.map { it.sequence })
     .also { telemetry["nomisUnscheduledMovementSeqs"] = "$it" }
     .map { nomisMovementSeq ->
       mappings.find { it.movementSeq == nomisMovementSeq }
@@ -125,9 +125,9 @@ class ExternalMovementsMoveBookingService(
     migrationService.resyncPrisonerTaps(toOffenderNo)
   }
 
-  private fun BookingTemporaryAbsences.isEmpty() = this.temporaryAbsenceApplications.isEmpty() &&
-    this.unscheduledTemporaryAbsences.isEmpty() &&
-    this.unscheduledTemporaryAbsenceReturns.isEmpty()
+  private fun BookingTaps.isEmpty() = this.tapApplications.isEmpty() &&
+    this.unscheduledTapMovementOuts.isEmpty() &&
+    this.unscheduledTapMovementIns.isEmpty()
 }
 
 class TapMoveBookingException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapApplicationService.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.valuesAsS
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementRetryMappingMessageTypes.RETRY_MAPPING_TEMPORARY_ABSENCE_APPLICATION
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsDpsApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiService
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.MovementApplicationEvent
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.Location
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncAtAndBy
@@ -32,7 +31,7 @@ class TapApplicationService(
   override val telemetryClient: TelemetryClient,
   private val queueService: SynchronisationQueueService,
   private val mappingApiService: ExternalMovementsMappingApiService,
-  private val nomisApiService: ExternalMovementsNomisApiService,
+  private val nomisApiService: TapsNomisApiService,
   private val dpsApiService: ExternalMovementsDpsApiService,
 ) : TelemetryEnabled {
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationService.kt
@@ -14,7 +14,6 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.histo
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.MigrationMessageType
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsDpsApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiService
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.Location
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapAuthorisation
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapMovement
@@ -28,11 +27,11 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.mod
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceBookingMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingIdsDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.OffenderTemporaryAbsencesResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTapMovementIn
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTapMovementOut
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTapScheduleOut
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.OffenderTapsResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.PrisonerId
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.ScheduledTemporaryAbsence
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.TemporaryAbsence
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.TemporaryAbsenceReturn
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.ByPageNumber
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.ByPageNumberMigrationService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationMessage
@@ -45,7 +44,7 @@ import java.util.*
 class TapMigrationService(
   val migrationMappingService: ExternalMovementsMappingApiService,
   val nomisIdsApiService: NomisApiService,
-  val nomisApiService: ExternalMovementsNomisApiService,
+  val nomisApiService: TapsNomisApiService,
   val dpsApiService: ExternalMovementsDpsApiService,
   jsonMapper: JsonMapper,
   @Value($$"${externalmovements.page.size:1000}") pageSize: Long,
@@ -105,18 +104,18 @@ class TapMigrationService(
     val ignoreMissingTaps = context.properties["ignoreMissingTaps"] as Boolean? ?: true
 
     runCatching {
-      val temporaryAbsences = nomisApiService.getTemporaryAbsencesOrNull(offenderNo)
+      val offenderTaps = nomisApiService.getAllOffenderTapsOrNull(offenderNo)
         // carry on even if there is no offender in NOMIS - this could be for a merged prisoner and we still need to update the mappings etc.
-        ?: OffenderTemporaryAbsencesResponse(bookings = emptyList())
-      if (ignoreMissingTaps && temporaryAbsences.bookings.isEmpty()) {
+        ?: OffenderTapsResponse(bookings = emptyList())
+      if (ignoreMissingTaps && offenderTaps.bookings.isEmpty()) {
         publishTelemetry("ignored", telemetry.apply { this["reason"] = "The offender has no TAPs" })
         return
       }
       val oldMappingIds = migrationMappingService.getPrisonerMappingIds(offenderNo)
       // Note that we're not expecting to perform a clean migration again so we're calling the DPS /resync endpoint which performs "patch migrations"
-      val dpsResponse = dpsApiService.resyncPrisonerTaps(offenderNo, temporaryAbsences.toDpsRequest(oldMappingIds))
+      val dpsResponse = dpsApiService.resyncPrisonerTaps(offenderNo, offenderTaps.toDpsRequest(oldMappingIds))
         ?: MigrateTapResponse(temporaryAbsences = emptyList(), unscheduledMovements = emptyList())
-      val mappings = temporaryAbsences.buildMappings(offenderNo, migrationId, dpsResponse)
+      val mappings = offenderTaps.buildMappings(offenderNo, migrationId, dpsResponse)
 
       createMappingOrOnFailureDo(mappings) {
         requeueCreateMapping(mappings, context)
@@ -179,28 +178,28 @@ class TapMigrationService(
     )
   }
 
-  private fun OffenderTemporaryAbsencesResponse.buildMappings(prisonerNumber: String, migrationId: String, dpsResponse: MigrateTapResponse) = TemporaryAbsencesPrisonerMappingDto(
+  private fun OffenderTapsResponse.buildMappings(prisonerNumber: String, migrationId: String, dpsResponse: MigrateTapResponse) = TemporaryAbsencesPrisonerMappingDto(
     prisonerNumber = prisonerNumber,
     migrationId = migrationId,
     bookings = bookings.map { booking ->
       TemporaryAbsenceBookingMappingDto(
         bookingId = booking.bookingId,
-        applications = booking.temporaryAbsenceApplications.map { application ->
+        applications = booking.tapApplications.map { application ->
           TemporaryAbsenceApplicationMappingDto(
-            nomisMovementApplicationId = application.movementApplicationId,
-            dpsMovementApplicationId = dpsResponse.findDpsAuthorisationId(application.movementApplicationId),
-            schedules = application.absences.mapNotNull { it.scheduledTemporaryAbsence }.map { it.toMappingDto(dpsResponse) },
-            movements = application.absences.mapNotNull { it.temporaryAbsence }.map { it.toMappingDto(booking.bookingId, dpsResponse) } +
-              application.absences.mapNotNull { it.temporaryAbsenceReturn }.map { it.toMappingDto(booking.bookingId, dpsResponse) },
+            nomisMovementApplicationId = application.tapApplicationId,
+            dpsMovementApplicationId = dpsResponse.findDpsAuthorisationId(application.tapApplicationId),
+            schedules = application.taps.mapNotNull { it.tapScheduleOut }.map { it.toMappingDto(dpsResponse) },
+            movements = application.taps.mapNotNull { it.tapMovementOut }.map { it.toMappingDto(booking.bookingId, dpsResponse) } +
+              application.taps.mapNotNull { it.tapMovementIn }.map { it.toMappingDto(booking.bookingId, dpsResponse) },
           )
         },
-        unscheduledMovements = booking.unscheduledTemporaryAbsences.map { it.toMappingDto(booking.bookingId, dpsResponse) } +
-          booking.unscheduledTemporaryAbsenceReturns.map { it.toMappingDto(booking.bookingId, dpsResponse) },
+        unscheduledMovements = booking.unscheduledTapMovementOuts.map { it.toMappingDto(booking.bookingId, dpsResponse) } +
+          booking.unscheduledTapMovementIns.map { it.toMappingDto(booking.bookingId, dpsResponse) },
       )
     },
   )
 
-  private fun ScheduledTemporaryAbsence.toMappingDto(dpsResponse: MigrateTapResponse): ScheduledMovementMappingDto = ScheduledMovementMappingDto(
+  private fun BookingTapScheduleOut.toMappingDto(dpsResponse: MigrateTapResponse): ScheduledMovementMappingDto = ScheduledMovementMappingDto(
     nomisEventId = this.eventId,
     dpsOccurrenceId = dpsResponse.findDpsScheduleId(this.eventId),
     nomisAddressId = this.toAddressId,
@@ -211,7 +210,7 @@ class TapMigrationService(
     eventTime = "${this.startTime}",
   )
 
-  private fun TemporaryAbsence.toMappingDto(bookingId: Long, dpsResponse: MigrateTapResponse): ExternalMovementMappingDto = ExternalMovementMappingDto(
+  private fun BookingTapMovementOut.toMappingDto(bookingId: Long, dpsResponse: MigrateTapResponse): ExternalMovementMappingDto = ExternalMovementMappingDto(
     nomisMovementSeq = this.sequence,
     dpsMovementId = dpsResponse.findDpsMovementId(bookingId, this.sequence),
     nomisAddressId = this.toAddressId,
@@ -221,7 +220,7 @@ class TapMigrationService(
     dpsPostcode = this.toAddressPostcode,
   )
 
-  private fun TemporaryAbsenceReturn.toMappingDto(bookingId: Long, dpsResponse: MigrateTapResponse): ExternalMovementMappingDto = ExternalMovementMappingDto(
+  private fun BookingTapMovementIn.toMappingDto(bookingId: Long, dpsResponse: MigrateTapResponse): ExternalMovementMappingDto = ExternalMovementMappingDto(
     nomisMovementSeq = this.sequence,
     dpsMovementId = dpsResponse.findDpsMovementId(bookingId, this.sequence),
     nomisAddressId = this.fromAddressId,
@@ -265,14 +264,14 @@ class TapMigrationService(
   override fun parseContextMapping(json: String): MigrationMessage<*, TemporaryAbsencesPrisonerMappingDto> = jsonMapper.readValue(json)
 }
 
-fun OffenderTemporaryAbsencesResponse.toDpsRequest(oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto) = MigrateTapRequest(
+fun OffenderTapsResponse.toDpsRequest(oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto) = MigrateTapRequest(
   temporaryAbsences = this.bookings.flatMap { booking ->
-    booking.temporaryAbsenceApplications.map { application ->
+    booking.tapApplications.map { application ->
       MigrateTapAuthorisation(
         prisonCode = application.prisonId,
         statusCode = application.applicationStatus.toDpsAuthorisationStatusCode(application.toDate, booking.latestBooking),
-        absenceTypeCode = application.temporaryAbsenceType,
-        absenceSubTypeCode = application.temporaryAbsenceSubType,
+        absenceTypeCode = application.tapType,
+        absenceSubTypeCode = application.tapSubType,
         absenceReasonCode = application.eventSubType,
         accompaniedByCode = application.escortCode ?: DEFAULT_ESCORT_CODE,
         transportCode = application.transportType ?: DEFAULT_TRANSPORT_TYPE,
@@ -282,20 +281,20 @@ fun OffenderTemporaryAbsencesResponse.toDpsRequest(oldMappingIds: TemporaryAbsen
         comments = application.comment,
         created = SyncAtAndBy(application.audit.createDatetime, application.audit.createUsername),
         updated = application.audit.modifyDatetime?.let { SyncAtAndBy(application.audit.modifyDatetime, application.audit.modifyUserId ?: "") },
-        legacyId = application.movementApplicationId,
+        legacyId = application.tapApplicationId,
         startTime = "${application.releaseTime.toLocalTime()}",
         endTime = "${application.returnTime.toLocalTime()}",
         location = Location(description = application.toAddressDescription, address = application.toFullAddress, postcode = application.toAddressPostcode),
-        id = oldMappingIds.applications.find { it.nomisMovementApplicationId == application.movementApplicationId }?.dpsMovementApplicationId,
-        occurrences = application.absences.mapNotNull { absence ->
-          absence.scheduledTemporaryAbsence?.let { scheduleOut ->
+        id = oldMappingIds.applications.find { it.nomisMovementApplicationId == application.tapApplicationId }?.dpsMovementApplicationId,
+        occurrences = application.taps.mapNotNull { tap ->
+          tap.tapScheduleOut?.let { scheduleOut ->
             scheduleOut.toDpsRequest(
               schedulePrison = scheduleOut.fromPrison ?: application.prisonId,
               bookingId = booking.bookingId,
-              movementOut = absence.temporaryAbsence,
-              movementIn = absence.temporaryAbsenceReturn,
-              temporaryAbsenceType = application.temporaryAbsenceType,
-              temporaryAbsenceSubType = application.temporaryAbsenceSubType,
+              movementOut = tap.tapMovementOut,
+              movementIn = tap.tapMovementIn,
+              tapType = application.tapType,
+              tapSubType = application.tapSubType,
               oldMappingIds = oldMappingIds,
             )
           }
@@ -304,30 +303,30 @@ fun OffenderTemporaryAbsencesResponse.toDpsRequest(oldMappingIds: TemporaryAbsen
     }
   },
   unscheduledMovements = this.bookings.flatMap { booking ->
-    booking.unscheduledTemporaryAbsences.map { movementOut ->
+    booking.unscheduledTapMovementOuts.map { movementOut ->
       movementOut.toDpsRequest(booking.bookingId, movementOut.fromPrison ?: "", oldMappingIds)
     } +
-      booking.unscheduledTemporaryAbsenceReturns.map { movementIn ->
+      booking.unscheduledTapMovementIns.map { movementIn ->
         movementIn.toDpsRequest(booking.bookingId, movementIn.toPrison ?: "", oldMappingIds)
       }
   },
 )
 
-private fun ScheduledTemporaryAbsence.toDpsRequest(
-  temporaryAbsenceType: String?,
-  temporaryAbsenceSubType: String?,
+private fun BookingTapScheduleOut.toDpsRequest(
+  tapType: String?,
+  tapSubType: String?,
   schedulePrison: String,
   bookingId: Long,
-  movementOut: TemporaryAbsence?,
-  movementIn: TemporaryAbsenceReturn?,
+  movementOut: BookingTapMovementOut?,
+  movementIn: BookingTapMovementIn?,
   oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto,
 ): MigrateTapOccurrence = MigrateTapOccurrence(
   isCancelled = eventStatus == "CANC",
   start = startTime,
   end = returnTime,
   location = Location(description = toAddressDescription, address = toFullAddress, postcode = toAddressPostcode),
-  absenceTypeCode = temporaryAbsenceType,
-  absenceSubTypeCode = temporaryAbsenceSubType,
+  absenceTypeCode = tapType,
+  absenceSubTypeCode = tapSubType,
   absenceReasonCode = eventSubType,
   accompaniedByCode = escort ?: DEFAULT_ESCORT_CODE,
   transportCode = transportType ?: DEFAULT_TRANSPORT_TYPE,
@@ -340,7 +339,7 @@ private fun ScheduledTemporaryAbsence.toDpsRequest(
   id = oldMappingIds.schedules.find { it.nomisEventId == eventId }?.dpsOccurrenceId,
 )
 
-private fun TemporaryAbsenceReturn.toDpsRequest(
+private fun BookingTapMovementIn.toDpsRequest(
   bookingId: Long,
   schedulePrison: String,
   oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto,
@@ -359,7 +358,7 @@ private fun TemporaryAbsenceReturn.toDpsRequest(
   id = oldMappingIds.movements.find { it.nomisBookingId == bookingId && it.nomisMovementSeq == sequence }?.dpsMovementId,
 )
 
-private fun TemporaryAbsence.toDpsRequest(
+private fun BookingTapMovementOut.toDpsRequest(
   bookingId: Long,
   schedulePrison: String,
   oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMovementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMovementService.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.Externa
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementRetryMappingMessageTypes.RETRY_UPDATE_MAPPING_TEMPORARY_ABSENCE_EXTERNAL_MOVEMENT
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsDpsApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiService
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.Location
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncAtAndBy
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncWriteTapMovement
@@ -35,7 +34,7 @@ class TapMovementService(
   override val telemetryClient: TelemetryClient,
   private val queueService: SynchronisationQueueService,
   private val mappingApiService: ExternalMovementsMappingApiService,
-  private val nomisApiService: ExternalMovementsNomisApiService,
+  private val nomisApiService: TapsNomisApiService,
   private val dpsApiService: ExternalMovementsDpsApiService,
 ) : TelemetryEnabled {
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapScheduleService.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.Externa
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementRetryMappingMessageTypes.RETRY_MAPPING_TEMPORARY_ABSENCE_SCHEDULED_MOVEMENT
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsDpsApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiService
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.MovementType.TAP
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ScheduledMovementEvent
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.Location
@@ -36,7 +35,7 @@ class TapScheduleService(
   override val telemetryClient: TelemetryClient,
   private val queueService: SynchronisationQueueService,
   private val mappingApiService: ExternalMovementsMappingApiService,
-  private val nomisApiService: ExternalMovementsNomisApiService,
+  private val nomisApiService: TapsNomisApiService,
   private val dpsApiService: ExternalMovementsDpsApiService,
 ) : TelemetryEnabled {
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapsNomisApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapsNomisApiService.kt
@@ -1,11 +1,12 @@
-package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps
 
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBody
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.awaitBodyOrNullWhenNotFound
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.OffenderTemporaryAbsencesResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.api.OffenderTapsResourceApi
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.OffenderTapsResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.ScheduledTemporaryAbsenceResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.ScheduledTemporaryAbsenceReturnResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.TemporaryAbsenceApplicationResponse
@@ -13,12 +14,10 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.mod
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.TemporaryAbsenceReturnResponse
 
 @Service
-class ExternalMovementsNomisApiService(@Qualifier("nomisApiWebClient") private val webClient: WebClient) {
-  suspend fun getTemporaryAbsencesOrNull(offenderNo: String): OffenderTemporaryAbsencesResponse? = webClient.get()
-    .uri {
-      it.path("/movements/{offenderNo}/temporary-absences")
-        .build(offenderNo)
-    }
+class TapsNomisApiService(@Qualifier("nomisApiWebClient") private val webClient: WebClient) {
+  private val offenderApi = OffenderTapsResourceApi(webClient)
+
+  suspend fun getAllOffenderTapsOrNull(offenderNo: String): OffenderTapsResponse? = offenderApi.prepare(offenderApi.getAllOffenderTapsRequestConfig(offenderNo))
     .retrieve()
     .awaitBodyOrNullWhenNotFound()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/ExternalMovementsMoveBookingIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/ExternalMovementsMoveBookingIntTest.kt
@@ -23,12 +23,13 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helper.bookingMov
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.sendMessage
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsDpsApiExtension.Companion.dpsExtMovementsServer
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer.Companion.absence
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer.Companion.application
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer.Companion.temporaryAbsence
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer.Companion.temporaryAbsenceReturn
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer.Companion.temporaryAbsencesResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MoveTemporaryAbsencesRequest
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.application
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.tapMovementIn
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.tapMovementOut
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.taps
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.temporaryAbsencesResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceApplicationIdMapping
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceMoveBookingMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceMovementIdMapping
@@ -37,7 +38,7 @@ import java.util.*
 
 class ExternalMovementsMoveBookingIntTest(
   @Autowired private val mappingApi: ExternalMovementsMappingApiMockServer,
-  @Autowired private val externalMovementsNomisApi: ExternalMovementsNomisApiMockServer,
+  @Autowired private val externalMovementsNomisApi: TapNomisApiMockServer,
 ) : SqsIntegrationTestBase() {
 
   private val dpsApi = dpsExtMovementsServer
@@ -72,28 +73,28 @@ class ExternalMovementsMoveBookingIntTest(
 
     private val nomisData = temporaryAbsencesResponse(
       bookingId = 1234567L,
-      applications = listOf(
+      tapApplications = listOf(
         application(
           id = applicationId1,
-          absences = listOf(
-            absence(
-              temporaryAbsence = temporaryAbsence(seq = scheduledMovementSeq1),
-              temporaryAbsenceReturn = temporaryAbsenceReturn(seq = scheduledMovementSeq2),
+          taps = listOf(
+            taps(
+              tapMovementOut = tapMovementOut(seq = scheduledMovementSeq1),
+              tapMovementIn = tapMovementIn(seq = scheduledMovementSeq2),
             ),
           ),
         ),
         application(
           id = applicationId2,
-          absences = listOf(absence()),
+          taps = listOf(taps()),
         ),
       ),
-      unscheduledTemporaryAbsences = listOf(temporaryAbsence(seq = movementSeq1)),
-      unscheduledTemporaryAbsenceReturns = listOf(temporaryAbsenceReturn(seq = movementSeq2)),
+      unscheduledTapMovementOuts = listOf(tapMovementOut(seq = movementSeq1)),
+      unscheduledTapMovementIns = listOf(tapMovementIn(seq = movementSeq2)),
     )
 
     @BeforeEach
     fun setUp() = runTest {
-      externalMovementsNomisApi.stubGetTemporaryAbsences("A1234KT", nomisData)
+      externalMovementsNomisApi.stubGetAllOffenderTaps("A1234KT", nomisData)
       mappingApi.stubGetMoveBookingMappings(1234567L, moveBookingMappings)
       dpsApi.stubMoveBooking()
       mappingApi.stubMoveBookingMappings(bookingId = 1234567L, fromOffenderNo = "A1000KT", toOffenderNo = "A1234KT")
@@ -113,7 +114,7 @@ class ExternalMovementsMoveBookingIntTest(
 
     @Test
     fun `should get all movements from NOMIS`() {
-      externalMovementsNomisApi.verifyGetTemporaryAbsences(offenderNo = "A1234KT")
+      externalMovementsNomisApi.verifyGetAllOffenderTaps(offenderNo = "A1234KT")
     }
 
     @Test
@@ -174,7 +175,7 @@ class ExternalMovementsMoveBookingIntTest(
   inner class FailToFindNomisBookingTaps {
     @BeforeEach
     fun setUp() {
-      externalMovementsNomisApi.stubGetTemporaryAbsences(status = HttpStatus.NOT_FOUND)
+      externalMovementsNomisApi.stubGetAllOffenderTaps(status = HttpStatus.NOT_FOUND)
 
       sendMessage(
         bookingMovedDomainEvent(
@@ -188,7 +189,7 @@ class ExternalMovementsMoveBookingIntTest(
 
     @Test
     fun `should get all movements from NOMIS`() {
-      externalMovementsNomisApi.verifyGetTemporaryAbsences(offenderNo = "A1234KT")
+      externalMovementsNomisApi.verifyGetAllOffenderTaps(offenderNo = "A1234KT")
     }
 
     @Test
@@ -223,14 +224,14 @@ class ExternalMovementsMoveBookingIntTest(
 
     private val nomisData = temporaryAbsencesResponse(
       bookingId = 1234567L,
-      applications = listOf(),
-      unscheduledTemporaryAbsences = listOf(),
-      unscheduledTemporaryAbsenceReturns = listOf(),
+      tapApplications = listOf(),
+      unscheduledTapMovementOuts = listOf(),
+      unscheduledTapMovementIns = listOf(),
     )
 
     @BeforeEach
     fun setUp() {
-      externalMovementsNomisApi.stubGetTemporaryAbsences("A1234KT", nomisData)
+      externalMovementsNomisApi.stubGetAllOffenderTaps("A1234KT", nomisData)
       mappingApi.stubGetMoveBookingMappings(1234567L, moveBookingMappings)
 
       sendMessage(
@@ -279,14 +280,14 @@ class ExternalMovementsMoveBookingIntTest(
 
     private val nomisData = temporaryAbsencesResponse(
       bookingId = 1234567L,
-      applications = listOf(),
-      unscheduledTemporaryAbsences = listOf(temporaryAbsence(seq = movementSeq1)),
-      unscheduledTemporaryAbsenceReturns = listOf(),
+      tapApplications = listOf(),
+      unscheduledTapMovementOuts = listOf(tapMovementOut(seq = movementSeq1)),
+      unscheduledTapMovementIns = listOf(),
     )
 
     @BeforeEach
     fun setUp() {
-      externalMovementsNomisApi.stubGetTemporaryAbsences("A1234KT", nomisData)
+      externalMovementsNomisApi.stubGetAllOffenderTaps("A1234KT", nomisData)
       mappingApi.stubGetMoveBookingMappings(1234567L, moveBookingMappings)
 
       sendMessage(
@@ -338,14 +339,14 @@ class ExternalMovementsMoveBookingIntTest(
 
     private val nomisData = temporaryAbsencesResponse(
       bookingId = 1234567L,
-      applications = listOf(application(id = applicationId1)),
-      unscheduledTemporaryAbsences = listOf(),
-      unscheduledTemporaryAbsenceReturns = listOf(),
+      tapApplications = listOf(application(id = applicationId1)),
+      unscheduledTapMovementOuts = listOf(),
+      unscheduledTapMovementIns = listOf(),
     )
 
     @BeforeEach
     fun setUp() {
-      externalMovementsNomisApi.stubGetTemporaryAbsences("A1234KT", nomisData)
+      externalMovementsNomisApi.stubGetAllOffenderTaps("A1234KT", nomisData)
       mappingApi.stubGetMoveBookingMappings(1234567L, moveBookingMappings)
 
       sendMessage(
@@ -398,19 +399,19 @@ class ExternalMovementsMoveBookingIntTest(
 
     private val nomisData = temporaryAbsencesResponse(
       bookingId = 1234567L,
-      applications = listOf(
+      tapApplications = listOf(
         application(
           id = applicationId1,
-          absences = listOf(),
+          taps = listOf(),
         ),
       ),
-      unscheduledTemporaryAbsences = listOf(),
-      unscheduledTemporaryAbsenceReturns = listOf(),
+      unscheduledTapMovementOuts = listOf(),
+      unscheduledTapMovementIns = listOf(),
     )
 
     @BeforeEach
     fun setUp() {
-      externalMovementsNomisApi.stubGetTemporaryAbsences("A1234KT", nomisData)
+      externalMovementsNomisApi.stubGetAllOffenderTaps("A1234KT", nomisData)
       mappingApi.stubGetMoveBookingMappings(1234567L, moveBookingMappings)
       dpsApi.stubMoveBookingError(status = 500)
 
@@ -462,19 +463,19 @@ class ExternalMovementsMoveBookingIntTest(
 
     private val nomisData = temporaryAbsencesResponse(
       bookingId = 1234567L,
-      applications = listOf(
+      tapApplications = listOf(
         application(
           id = applicationId1,
-          absences = listOf(),
+          taps = listOf(),
         ),
       ),
-      unscheduledTemporaryAbsences = listOf(),
-      unscheduledTemporaryAbsenceReturns = listOf(),
+      unscheduledTapMovementOuts = listOf(),
+      unscheduledTapMovementIns = listOf(),
     )
 
     @BeforeEach
     fun setUp() = runTest {
-      externalMovementsNomisApi.stubGetTemporaryAbsences("A1234KT", nomisData)
+      externalMovementsNomisApi.stubGetAllOffenderTaps("A1234KT", nomisData)
       mappingApi.stubGetMoveBookingMappings(1234567L, moveBookingMappings)
       dpsApi.stubMoveBooking()
       mappingApi.stubMoveBookingMappingsFailureFollowedBySuccess(1234567L, "A1000KT", "A1234KT")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapAddressIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapAddressIntTest.kt
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.SqsIn
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.sendMessage
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsDpsApiExtension.Companion.dpsExtMovementsServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiMockServer
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.temporaryAbsenceScheduledMovementMapping
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ScheduledMovementSyncMappingDto
@@ -27,7 +26,7 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.withRequ
 import java.util.*
 
 class TapAddressIntTest(
-  @Autowired private val nomisApi: ExternalMovementsNomisApiMockServer,
+  @Autowired private val nomisApi: TapNomisApiMockServer,
   @Autowired private val mappingApi: ExternalMovementsMappingApiMockServer,
 ) : SqsIntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapApplicationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapApplicationIntTest.kt
@@ -24,10 +24,9 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.sendM
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsDpsApiExtension.Companion.dpsExtMovementsServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsDpsApiMockServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiMockServer
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer.Companion.temporaryAbsenceApplicationResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncWriteTapAuthorisation
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.temporaryAbsenceApplicationResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.DuplicateErrorContentObject
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.DuplicateMappingErrorResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceApplicationSyncMappingDto
@@ -39,7 +38,7 @@ import java.time.LocalTime
 import java.util.UUID
 
 class TapApplicationIntTest(
-  @Autowired private val nomisApi: ExternalMovementsNomisApiMockServer,
+  @Autowired private val nomisApi: TapNomisApiMockServer,
   @Autowired private val mappingApi: ExternalMovementsMappingApiMockServer,
 ) : SqsIntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapApplicationServiceTest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer.Companion.temporaryAbsenceApplicationResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.temporaryAbsenceApplicationResponse
 import java.time.LocalDate
 
 class TapApplicationServiceTest {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationIntTest.kt
@@ -1,8 +1,11 @@
 package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps
 
 import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.untilAsserted
@@ -30,15 +33,14 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.Externa
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsDpsApiMockServer.Companion.migrateResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiMockServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMigrationFilter
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer.Companion.application
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer.Companion.temporaryAbsencesResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapMovement
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapRequest
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.application
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.temporaryAbsencesResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingIdsDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.OffenderTemporaryAbsencesResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.OffenderTapsResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.NomisApiExtension.Companion.nomisApi
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.withRequestBodyJsonPath
 import java.time.Duration
@@ -49,7 +51,7 @@ import java.util.*
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TapMigrationIntTest(
-  @Autowired private val externalMovementsNomisApi: ExternalMovementsNomisApiMockServer,
+  @Autowired private val externalMovementsNomisApi: TapNomisApiMockServer,
   @Autowired private val mappingApi: ExternalMovementsMappingApiMockServer,
 ) : MigrationTestBase() {
 
@@ -109,7 +111,7 @@ class TapMigrationIntTest(
       .map { index -> "A%04dKT".format(index) }
       .forEach { prisonerNumber ->
         mappingApi.stubGetTemporaryAbsenceMappingIds(prisonerNumber, 12345L, 1, dpsAuthorisationId, 1, dpsOccurrenceId, 3, dpsScheduledMovementOutId, 4, dpsScheduledMovementInId, 1, dpsUnscheduledMovementOutId, 2, dpsUnscheduledMovementInId)
-        externalMovementsNomisApi.stubGetTemporaryAbsences(prisonerNumber)
+        externalMovementsNomisApi.stubGetAllOffenderTaps(prisonerNumber)
         dpsApi.stubResyncPrisonerTaps(
           personIdentifier = prisonerNumber,
           response = migrateResponse(
@@ -142,19 +144,19 @@ class TapMigrationIntTest(
 
     @Test
     fun `will request temporary absences for each prisoner`() {
-      externalMovementsNomisApi.verifyGetTemporaryAbsences(offenderNo = "A0001KT")
-      externalMovementsNomisApi.verifyGetTemporaryAbsences(offenderNo = "A0002KT")
+      externalMovementsNomisApi.verifyGetAllOffenderTaps(offenderNo = "A0001KT")
+      externalMovementsNomisApi.verifyGetAllOffenderTaps(offenderNo = "A0002KT")
     }
 
     @Test
     fun `will create mappings`() {
       mappingApi.verify(
-        WireMock.putRequestedFor(WireMock.urlEqualTo("/mapping/temporary-absence/migrate"))
+        putRequestedFor(urlEqualTo("/mapping/temporary-absence/migrate"))
           .withRequestBodyJsonPath("prisonerNumber", "A0001KT")
           .withRequestBodyJsonPath("migrationId", migrationId),
       )
       mappingApi.verify(
-        WireMock.putRequestedFor(WireMock.urlEqualTo("/mapping/temporary-absence/migrate"))
+        putRequestedFor(urlEqualTo("/mapping/temporary-absence/migrate"))
           .withRequestBodyJsonPath("prisonerNumber", "A0002KT")
           .withRequestBodyJsonPath("migrationId", migrationId),
       )
@@ -163,43 +165,43 @@ class TapMigrationIntTest(
     @Test
     fun `will call DPS for each offender`() {
       dpsApi.verify(
-        WireMock.putRequestedFor(WireMock.urlEqualTo("/resync/temporary-absences/A0001KT")),
+        putRequestedFor(urlEqualTo("/resync/temporary-absences/A0001KT")),
       )
       dpsApi.verify(
-        WireMock.putRequestedFor(WireMock.urlEqualTo("/resync/temporary-absences/A0002KT")),
+        putRequestedFor(urlEqualTo("/resync/temporary-absences/A0002KT")),
       )
     }
 
     @Test
     fun `will populate DPS TAP authorisation`() {
       getRequestBody<MigrateTapRequest>(
-        WireMock.putRequestedFor(WireMock.urlEqualTo("/resync/temporary-absences/A0001KT")),
+        putRequestedFor(urlEqualTo("/resync/temporary-absences/A0001KT")),
       ).apply {
         with(temporaryAbsences[0]) {
-          Assertions.assertThat(prisonCode).isEqualTo("LEI")
-          Assertions.assertThat(statusCode).isEqualTo("APPROVED")
-          Assertions.assertThat(absenceTypeCode).isEqualTo("RR")
-          Assertions.assertThat(absenceSubTypeCode).isEqualTo("SPL")
-          Assertions.assertThat(accompaniedByCode).isEqualTo("U")
-          Assertions.assertThat(transportCode).isEqualTo("VAN")
-          Assertions.assertThat(repeat).isEqualTo(false)
-          Assertions.assertThat(start).isEqualTo(today)
-          Assertions.assertThat(end).isEqualTo(tomorrow)
-          Assertions.assertThat(comments).isEqualTo("application comment")
-          Assertions.assertThat(created.at.toLocalDate()).isEqualTo(today)
-          Assertions.assertThat(created.by).isEqualTo("USER")
-          Assertions.assertThat(updated).isNull()
-          Assertions.assertThat(legacyId).isEqualTo(1)
-          Assertions.assertThat(occurrences.size).isEqualTo(1)
-          Assertions.assertThat(LocalTime.parse(startTime))
+          assertThat(prisonCode).isEqualTo("LEI")
+          assertThat(statusCode).isEqualTo("APPROVED")
+          assertThat(absenceTypeCode).isEqualTo("RR")
+          assertThat(absenceSubTypeCode).isEqualTo("SPL")
+          assertThat(accompaniedByCode).isEqualTo("U")
+          assertThat(transportCode).isEqualTo("VAN")
+          assertThat(repeat).isEqualTo(false)
+          assertThat(start).isEqualTo(today)
+          assertThat(end).isEqualTo(tomorrow)
+          assertThat(comments).isEqualTo("application comment")
+          assertThat(created.at.toLocalDate()).isEqualTo(today)
+          assertThat(created.by).isEqualTo("USER")
+          assertThat(updated).isNull()
+          assertThat(legacyId).isEqualTo(1)
+          assertThat(occurrences.size).isEqualTo(1)
+          assertThat(LocalTime.parse(startTime))
             .isCloseTo(now.minusDays(1).toLocalTime(), Assertions.within(Duration.ofMinutes(5)))
-          Assertions.assertThat(LocalTime.parse(endTime))
+          assertThat(LocalTime.parse(endTime))
             .isCloseTo(now.toLocalTime(), Assertions.within(Duration.ofMinutes(5)))
-          Assertions.assertThat(location!!.uprn).isNull()
-          Assertions.assertThat(location.address).isEqualTo("some full address")
-          Assertions.assertThat(location.description).isEqualTo("some address description")
-          Assertions.assertThat(location.postcode).isEqualTo("S1 1AA")
-          Assertions.assertThat(id).isEqualTo(dpsAuthorisationId)
+          assertThat(location!!.uprn).isNull()
+          assertThat(location.address).isEqualTo("some full address")
+          assertThat(location.description).isEqualTo("some address description")
+          assertThat(location.postcode).isEqualTo("S1 1AA")
+          assertThat(id).isEqualTo(dpsAuthorisationId)
         }
       }
     }
@@ -207,29 +209,29 @@ class TapMigrationIntTest(
     @Test
     fun `will populate DPS TAP occurrence`() {
       getRequestBody<MigrateTapRequest>(
-        WireMock.putRequestedFor(WireMock.urlEqualTo("/resync/temporary-absences/A0001KT")),
+        putRequestedFor(urlEqualTo("/resync/temporary-absences/A0001KT")),
       ).apply {
         with(temporaryAbsences[0].occurrences[0]) {
-          Assertions.assertThat(isCancelled).isFalse
-          Assertions.assertThat(start).isCloseTo(now.minusDays(1), Assertions.within(Duration.ofMinutes(5)))
-          Assertions.assertThat(end).isCloseTo(now.plusDays(1), Assertions.within(Duration.ofMinutes(5)))
-          Assertions.assertThat(location.address).isEqualTo("Schedule full address")
-          Assertions.assertThat(location.description).isEqualTo("Schedule address description")
-          Assertions.assertThat(location.postcode).isEqualTo("S1 1AA")
-          Assertions.assertThat(location.uprn).isNull()
-          Assertions.assertThat(absenceTypeCode).isEqualTo("RR")
-          Assertions.assertThat(absenceSubTypeCode).isEqualTo("SPL")
-          Assertions.assertThat(absenceReasonCode).isEqualTo("C5")
-          Assertions.assertThat(accompaniedByCode).isEqualTo("PECS")
-          Assertions.assertThat(transportCode).isEqualTo("VAN")
-          Assertions.assertThat(contactInformation).isEqualTo("Derek")
-          Assertions.assertThat(comments).isEqualTo("scheduled absence comment")
-          Assertions.assertThat(created.at.toLocalDate()).isEqualTo(today)
-          Assertions.assertThat(created.by).isEqualTo("USER")
-          Assertions.assertThat(updated).isNull()
-          Assertions.assertThat(legacyId).isEqualTo(1)
-          Assertions.assertThat(movements.size).isEqualTo(2)
-          Assertions.assertThat(id).isEqualTo(dpsOccurrenceId)
+          assertThat(isCancelled).isFalse
+          assertThat(start).isCloseTo(now.minusDays(1), Assertions.within(Duration.ofMinutes(5)))
+          assertThat(end).isCloseTo(now.plusDays(1), Assertions.within(Duration.ofMinutes(5)))
+          assertThat(location.address).isEqualTo("Schedule full address")
+          assertThat(location.description).isEqualTo("Schedule address description")
+          assertThat(location.postcode).isEqualTo("S1 1AA")
+          assertThat(location.uprn).isNull()
+          assertThat(absenceTypeCode).isEqualTo("RR")
+          assertThat(absenceSubTypeCode).isEqualTo("SPL")
+          assertThat(absenceReasonCode).isEqualTo("C5")
+          assertThat(accompaniedByCode).isEqualTo("PECS")
+          assertThat(transportCode).isEqualTo("VAN")
+          assertThat(contactInformation).isEqualTo("Derek")
+          assertThat(comments).isEqualTo("scheduled absence comment")
+          assertThat(created.at.toLocalDate()).isEqualTo(today)
+          assertThat(created.by).isEqualTo("USER")
+          assertThat(updated).isNull()
+          assertThat(legacyId).isEqualTo(1)
+          assertThat(movements.size).isEqualTo(2)
+          assertThat(id).isEqualTo(dpsOccurrenceId)
         }
       }
     }
@@ -237,24 +239,24 @@ class TapMigrationIntTest(
     @Test
     fun `will populate DPS TAP OUT movement`() {
       getRequestBody<MigrateTapRequest>(
-        WireMock.putRequestedFor(WireMock.urlEqualTo("/resync/temporary-absences/A0001KT")),
+        putRequestedFor(urlEqualTo("/resync/temporary-absences/A0001KT")),
       ).apply {
         with(temporaryAbsences[0].occurrences[0].movements[0]) {
-          Assertions.assertThat(occurredAt).isCloseTo(now.minusDays(1), Assertions.within(Duration.ofMinutes(5)))
-          Assertions.assertThat(direction).isEqualTo(MigrateTapMovement.Direction.OUT)
-          Assertions.assertThat(absenceReasonCode).isEqualTo("C6")
-          Assertions.assertThat(location.address).isEqualTo("Absence full address")
-          Assertions.assertThat(location.description).isEqualTo("Absence address description")
-          Assertions.assertThat(location.postcode).isEqualTo("S1 1AA")
-          Assertions.assertThat(location.uprn).isNull()
-          Assertions.assertThat(accompaniedByCode).isEqualTo("U")
-          Assertions.assertThat(created.at.toLocalDate()).isEqualTo(today)
-          Assertions.assertThat(created.by).isEqualTo("USER")
-          Assertions.assertThat(legacyId).isEqualTo("12345_3")
-          Assertions.assertThat(accompaniedByComments).isEqualTo("Absence escort text")
-          Assertions.assertThat(comments).isEqualTo("Absence comment text")
-          Assertions.assertThat(updated).isNull()
-          Assertions.assertThat(id).isEqualTo(dpsScheduledMovementOutId)
+          assertThat(occurredAt).isCloseTo(now.minusDays(1), Assertions.within(Duration.ofMinutes(5)))
+          assertThat(direction).isEqualTo(MigrateTapMovement.Direction.OUT)
+          assertThat(absenceReasonCode).isEqualTo("C6")
+          assertThat(location.address).isEqualTo("Absence full address")
+          assertThat(location.description).isEqualTo("Absence address description")
+          assertThat(location.postcode).isEqualTo("S1 1AA")
+          assertThat(location.uprn).isNull()
+          assertThat(accompaniedByCode).isEqualTo("U")
+          assertThat(created.at.toLocalDate()).isEqualTo(today)
+          assertThat(created.by).isEqualTo("USER")
+          assertThat(legacyId).isEqualTo("12345_3")
+          assertThat(accompaniedByComments).isEqualTo("Absence escort text")
+          assertThat(comments).isEqualTo("Absence comment text")
+          assertThat(updated).isNull()
+          assertThat(id).isEqualTo(dpsScheduledMovementOutId)
         }
       }
     }
@@ -262,24 +264,24 @@ class TapMigrationIntTest(
     @Test
     fun `will populate DPS TAP IN movement`() {
       getRequestBody<MigrateTapRequest>(
-        WireMock.putRequestedFor(WireMock.urlEqualTo("/resync/temporary-absences/A0001KT")),
+        putRequestedFor(urlEqualTo("/resync/temporary-absences/A0001KT")),
       ).apply {
         with(temporaryAbsences[0].occurrences[0].movements[1]) {
-          Assertions.assertThat(occurredAt).isCloseTo(now, Assertions.within(Duration.ofMinutes(5)))
-          Assertions.assertThat(direction).isEqualTo(MigrateTapMovement.Direction.IN)
-          Assertions.assertThat(absenceReasonCode).isEqualTo("C5")
-          Assertions.assertThat(location.address).isEqualTo("Absence return full address")
-          Assertions.assertThat(location.description).isEqualTo("Absence return address description")
-          Assertions.assertThat(location.postcode).isEqualTo("S2 2AA")
-          Assertions.assertThat(location.uprn).isNull()
-          Assertions.assertThat(accompaniedByCode).isEqualTo("PECS")
-          Assertions.assertThat(created.at.toLocalDate()).isEqualTo(today)
-          Assertions.assertThat(created.by).isEqualTo("USER")
-          Assertions.assertThat(legacyId).isEqualTo("12345_4")
-          Assertions.assertThat(accompaniedByComments).isEqualTo("Return escort text")
-          Assertions.assertThat(comments).isEqualTo("Return comment text")
-          Assertions.assertThat(updated).isNull()
-          Assertions.assertThat(id).isEqualTo(dpsScheduledMovementInId)
+          assertThat(occurredAt).isCloseTo(now, Assertions.within(Duration.ofMinutes(5)))
+          assertThat(direction).isEqualTo(MigrateTapMovement.Direction.IN)
+          assertThat(absenceReasonCode).isEqualTo("C5")
+          assertThat(location.address).isEqualTo("Absence return full address")
+          assertThat(location.description).isEqualTo("Absence return address description")
+          assertThat(location.postcode).isEqualTo("S2 2AA")
+          assertThat(location.uprn).isNull()
+          assertThat(accompaniedByCode).isEqualTo("PECS")
+          assertThat(created.at.toLocalDate()).isEqualTo(today)
+          assertThat(created.by).isEqualTo("USER")
+          assertThat(legacyId).isEqualTo("12345_4")
+          assertThat(accompaniedByComments).isEqualTo("Return escort text")
+          assertThat(comments).isEqualTo("Return comment text")
+          assertThat(updated).isNull()
+          assertThat(id).isEqualTo(dpsScheduledMovementInId)
         }
       }
     }
@@ -287,24 +289,24 @@ class TapMigrationIntTest(
     @Test
     fun `will populate unscheduled DPS TAP OUT movement`() {
       getRequestBody<MigrateTapRequest>(
-        WireMock.putRequestedFor(WireMock.urlEqualTo("/resync/temporary-absences/A0001KT")),
+        putRequestedFor(urlEqualTo("/resync/temporary-absences/A0001KT")),
       ).apply {
         with(unscheduledMovements[0]) {
-          Assertions.assertThat(occurredAt).isCloseTo(now.minusDays(1), Assertions.within(Duration.ofMinutes(5)))
-          Assertions.assertThat(direction).isEqualTo(MigrateTapMovement.Direction.OUT)
-          Assertions.assertThat(absenceReasonCode).isEqualTo("C6")
-          Assertions.assertThat(location.address).isEqualTo("Absence full address")
-          Assertions.assertThat(location.description).isEqualTo("Absence address description")
-          Assertions.assertThat(location.postcode).isEqualTo("S1 1AA")
-          Assertions.assertThat(location.uprn).isNull()
-          Assertions.assertThat(accompaniedByCode).isEqualTo("U")
-          Assertions.assertThat(created.at.toLocalDate()).isEqualTo(today)
-          Assertions.assertThat(created.by).isEqualTo("USER")
-          Assertions.assertThat(legacyId).isEqualTo("12345_1")
-          Assertions.assertThat(accompaniedByComments).isEqualTo("Absence escort text")
-          Assertions.assertThat(comments).isEqualTo("Absence comment text")
-          Assertions.assertThat(updated).isNull()
-          Assertions.assertThat(id).isEqualTo(dpsUnscheduledMovementOutId)
+          assertThat(occurredAt).isCloseTo(now.minusDays(1), Assertions.within(Duration.ofMinutes(5)))
+          assertThat(direction).isEqualTo(MigrateTapMovement.Direction.OUT)
+          assertThat(absenceReasonCode).isEqualTo("C6")
+          assertThat(location.address).isEqualTo("Absence full address")
+          assertThat(location.description).isEqualTo("Absence address description")
+          assertThat(location.postcode).isEqualTo("S1 1AA")
+          assertThat(location.uprn).isNull()
+          assertThat(accompaniedByCode).isEqualTo("U")
+          assertThat(created.at.toLocalDate()).isEqualTo(today)
+          assertThat(created.by).isEqualTo("USER")
+          assertThat(legacyId).isEqualTo("12345_1")
+          assertThat(accompaniedByComments).isEqualTo("Absence escort text")
+          assertThat(comments).isEqualTo("Absence comment text")
+          assertThat(updated).isNull()
+          assertThat(id).isEqualTo(dpsUnscheduledMovementOutId)
         }
       }
     }
@@ -312,24 +314,24 @@ class TapMigrationIntTest(
     @Test
     fun `will populate unscheduled DPS TAP IN movement`() {
       getRequestBody<MigrateTapRequest>(
-        WireMock.putRequestedFor(WireMock.urlEqualTo("/resync/temporary-absences/A0001KT")),
+        putRequestedFor(urlEqualTo("/resync/temporary-absences/A0001KT")),
       ).apply {
         with(unscheduledMovements[1]) {
-          Assertions.assertThat(occurredAt).isCloseTo(now.minusDays(1), Assertions.within(Duration.ofMinutes(5)))
-          Assertions.assertThat(direction).isEqualTo(MigrateTapMovement.Direction.IN)
-          Assertions.assertThat(absenceReasonCode).isEqualTo("C5")
-          Assertions.assertThat(location.address).isEqualTo("Absence return full address")
-          Assertions.assertThat(location.description).isEqualTo("Absence return address description")
-          Assertions.assertThat(location.postcode).isEqualTo("S2 2AA")
-          Assertions.assertThat(location.uprn).isNull()
-          Assertions.assertThat(accompaniedByCode).isEqualTo("PECS")
-          Assertions.assertThat(created.at.toLocalDate()).isEqualTo(today)
-          Assertions.assertThat(created.by).isEqualTo("USER")
-          Assertions.assertThat(legacyId).isEqualTo("12345_2")
-          Assertions.assertThat(accompaniedByComments).isEqualTo("Return escort text")
-          Assertions.assertThat(comments).isEqualTo("Return comment text")
-          Assertions.assertThat(updated).isNull()
-          Assertions.assertThat(id).isEqualTo(dpsUnscheduledMovementInId)
+          assertThat(occurredAt).isCloseTo(now.minusDays(1), Assertions.within(Duration.ofMinutes(5)))
+          assertThat(direction).isEqualTo(MigrateTapMovement.Direction.IN)
+          assertThat(absenceReasonCode).isEqualTo("C5")
+          assertThat(location.address).isEqualTo("Absence return full address")
+          assertThat(location.description).isEqualTo("Absence return address description")
+          assertThat(location.postcode).isEqualTo("S2 2AA")
+          assertThat(location.uprn).isNull()
+          assertThat(accompaniedByCode).isEqualTo("PECS")
+          assertThat(created.at.toLocalDate()).isEqualTo(today)
+          assertThat(created.by).isEqualTo("USER")
+          assertThat(legacyId).isEqualTo("12345_2")
+          assertThat(accompaniedByComments).isEqualTo("Return escort text")
+          assertThat(comments).isEqualTo("Return comment text")
+          assertThat(updated).isNull()
+          assertThat(id).isEqualTo(dpsUnscheduledMovementInId)
         }
       }
     }
@@ -337,62 +339,62 @@ class TapMigrationIntTest(
     @Test
     fun `will populate correct mapping details`() {
       ExternalMovementsMappingApiMockServer.getRequestBody<TemporaryAbsencesPrisonerMappingDto>(
-        WireMock.putRequestedFor(WireMock.urlEqualTo("/mapping/temporary-absence/migrate")),
+        putRequestedFor(urlEqualTo("/mapping/temporary-absence/migrate")),
       )
         .apply {
-          Assertions.assertThat(bookings[0].bookingId).isEqualTo(12345)
+          assertThat(bookings[0].bookingId).isEqualTo(12345)
 
-          Assertions.assertThat(bookings[0].applications[0].nomisMovementApplicationId).isEqualTo(1)
-          Assertions.assertThat(bookings[0].applications[0].dpsMovementApplicationId).isEqualTo(dpsAuthorisationId)
+          assertThat(bookings[0].applications[0].nomisMovementApplicationId).isEqualTo(1)
+          assertThat(bookings[0].applications[0].dpsMovementApplicationId).isEqualTo(dpsAuthorisationId)
 
           with(bookings[0].applications[0].schedules[0]) {
-            Assertions.assertThat(nomisEventId).isEqualTo(1)
-            Assertions.assertThat(dpsOccurrenceId).isEqualTo(dpsOccurrenceId)
-            Assertions.assertThat(nomisAddressId).isEqualTo(543)
-            Assertions.assertThat(nomisAddressOwnerClass).isEqualTo("CORP")
-            Assertions.assertThat(dpsAddressText).isEqualTo("Schedule full address")
-            Assertions.assertThat(dpsDescription).isEqualTo("Schedule address description")
-            Assertions.assertThat(dpsPostcode).isEqualTo("S1 1AA")
-            Assertions.assertThat(eventTime).contains("${today.minusDays(1)}")
+            assertThat(nomisEventId).isEqualTo(1)
+            assertThat(dpsOccurrenceId).isEqualTo(dpsOccurrenceId)
+            assertThat(nomisAddressId).isEqualTo(543)
+            assertThat(nomisAddressOwnerClass).isEqualTo("CORP")
+            assertThat(dpsAddressText).isEqualTo("Schedule full address")
+            assertThat(dpsDescription).isEqualTo("Schedule address description")
+            assertThat(dpsPostcode).isEqualTo("S1 1AA")
+            assertThat(eventTime).contains("${today.minusDays(1)}")
           }
 
           // We don't map the scheduled return because they don't exist in DPS
-          Assertions.assertThat(bookings[0].applications[0].schedules.size).isEqualTo(1)
+          assertThat(bookings[0].applications[0].schedules.size).isEqualTo(1)
 
           with(bookings[0].applications[0].movements[0]) {
-            Assertions.assertThat(nomisMovementSeq).isEqualTo(3)
-            Assertions.assertThat(dpsMovementId).isEqualTo(dpsScheduledMovementOutId)
-            Assertions.assertThat(nomisAddressId).isEqualTo(432)
-            Assertions.assertThat(nomisAddressOwnerClass).isEqualTo("AGY")
-            Assertions.assertThat(dpsAddressText).isEqualTo("Absence full address")
-            Assertions.assertThat(dpsDescription).isEqualTo("Absence address description")
-            Assertions.assertThat(dpsPostcode).isEqualTo("S1 1AA")
+            assertThat(nomisMovementSeq).isEqualTo(3)
+            assertThat(dpsMovementId).isEqualTo(dpsScheduledMovementOutId)
+            assertThat(nomisAddressId).isEqualTo(432)
+            assertThat(nomisAddressOwnerClass).isEqualTo("AGY")
+            assertThat(dpsAddressText).isEqualTo("Absence full address")
+            assertThat(dpsDescription).isEqualTo("Absence address description")
+            assertThat(dpsPostcode).isEqualTo("S1 1AA")
           }
 
           with(bookings[0].applications[0].movements[1]) {
-            Assertions.assertThat(nomisMovementSeq).isEqualTo(4)
-            Assertions.assertThat(dpsMovementId).isEqualTo(dpsScheduledMovementInId)
-            Assertions.assertThat(nomisAddressId).isEqualTo(321)
-            Assertions.assertThat(nomisAddressOwnerClass).isEqualTo("CORP")
-            Assertions.assertThat(dpsAddressText).isEqualTo("Absence return full address")
+            assertThat(nomisMovementSeq).isEqualTo(4)
+            assertThat(dpsMovementId).isEqualTo(dpsScheduledMovementInId)
+            assertThat(nomisAddressId).isEqualTo(321)
+            assertThat(nomisAddressOwnerClass).isEqualTo("CORP")
+            assertThat(dpsAddressText).isEqualTo("Absence return full address")
           }
 
           with(bookings[0].unscheduledMovements[0]) {
-            Assertions.assertThat(nomisMovementSeq).isEqualTo(1)
-            Assertions.assertThat(dpsMovementId).isEqualTo(dpsUnscheduledMovementOutId)
-            Assertions.assertThat(nomisAddressId).isEqualTo(432)
-            Assertions.assertThat(nomisAddressOwnerClass).isEqualTo("AGY")
-            Assertions.assertThat(dpsAddressText).isEqualTo("Absence full address")
+            assertThat(nomisMovementSeq).isEqualTo(1)
+            assertThat(dpsMovementId).isEqualTo(dpsUnscheduledMovementOutId)
+            assertThat(nomisAddressId).isEqualTo(432)
+            assertThat(nomisAddressOwnerClass).isEqualTo("AGY")
+            assertThat(dpsAddressText).isEqualTo("Absence full address")
           }
 
           with(bookings[0].unscheduledMovements[1]) {
-            Assertions.assertThat(nomisMovementSeq).isEqualTo(2)
-            Assertions.assertThat(dpsMovementId).isEqualTo(dpsUnscheduledMovementInId)
-            Assertions.assertThat(nomisAddressId).isEqualTo(321)
-            Assertions.assertThat(nomisAddressOwnerClass).isEqualTo("CORP")
-            Assertions.assertThat(dpsAddressText).isEqualTo("Absence return full address")
-            Assertions.assertThat(dpsDescription).isEqualTo("Absence return address description")
-            Assertions.assertThat(dpsPostcode).isEqualTo("S2 2AA")
+            assertThat(nomisMovementSeq).isEqualTo(2)
+            assertThat(dpsMovementId).isEqualTo(dpsUnscheduledMovementInId)
+            assertThat(nomisAddressId).isEqualTo(321)
+            assertThat(nomisAddressOwnerClass).isEqualTo("CORP")
+            assertThat(dpsAddressText).isEqualTo("Absence return full address")
+            assertThat(dpsDescription).isEqualTo("Absence return address description")
+            assertThat(dpsPostcode).isEqualTo("S2 2AA")
           }
         }
     }
@@ -402,16 +404,16 @@ class TapMigrationIntTest(
       verify(telemetryClient).trackEvent(
         eq("temporary-absences-migration-entity-migrated"),
         check {
-          Assertions.assertThat(it["offenderNo"]).isEqualTo("A0001KT")
-          Assertions.assertThat(it["migrationId"]).isEqualTo(migrationId)
+          assertThat(it["offenderNo"]).isEqualTo("A0001KT")
+          assertThat(it["migrationId"]).isEqualTo(migrationId)
         },
         isNull(),
       )
       verify(telemetryClient).trackEvent(
         eq("temporary-absences-migration-entity-migrated"),
         check {
-          Assertions.assertThat(it["offenderNo"]).isEqualTo("A0002KT")
-          Assertions.assertThat(it["migrationId"]).isEqualTo(migrationId)
+          assertThat(it["offenderNo"]).isEqualTo("A0002KT")
+          assertThat(it["migrationId"]).isEqualTo(migrationId)
         },
         isNull(),
       )
@@ -439,7 +441,7 @@ class TapMigrationIntTest(
         idMappings = TemporaryAbsencesPrisonerMappingIdsDto(prisonerNumber, listOf(), listOf(), listOf()),
       )
       // The prison on the application and schedules is LEI
-      externalMovementsNomisApi.stubGetTemporaryAbsences(
+      externalMovementsNomisApi.stubGetAllOffenderTaps(
         prisonerNumber,
         response = temporaryAbsencesResponse(movementPrison = movementPrison),
       )
@@ -461,10 +463,10 @@ class TapMigrationIntTest(
     @Test
     fun `will populate DPS TAP OUT movement prison`() {
       getRequestBody<MigrateTapRequest>(
-        WireMock.putRequestedFor(WireMock.urlEqualTo("/resync/temporary-absences/$prisonerNumber")),
+        putRequestedFor(urlEqualTo("/resync/temporary-absences/$prisonerNumber")),
       ).apply {
         with(temporaryAbsences[0].occurrences[0].movements[0]) {
-          Assertions.assertThat(this.prisonCode).isEqualTo(movementPrison)
+          assertThat(this.prisonCode).isEqualTo(movementPrison)
         }
       }
     }
@@ -472,10 +474,10 @@ class TapMigrationIntTest(
     @Test
     fun `will populate DPS TAP IN movement prison`() {
       getRequestBody<MigrateTapRequest>(
-        WireMock.putRequestedFor(WireMock.urlEqualTo("/resync/temporary-absences/$prisonerNumber")),
+        putRequestedFor(urlEqualTo("/resync/temporary-absences/$prisonerNumber")),
       ).apply {
         with(temporaryAbsences[0].occurrences[0].movements[1]) {
-          Assertions.assertThat(prisonCode).isEqualTo(movementPrison)
+          assertThat(prisonCode).isEqualTo(movementPrison)
         }
       }
     }
@@ -501,12 +503,12 @@ class TapMigrationIntTest(
         idMappings = TemporaryAbsencesPrisonerMappingIdsDto(prisonerNumber, listOf(), listOf(), listOf()),
       )
       // The application is approved, on an inactive booking, and is not active
-      externalMovementsNomisApi.stubGetTemporaryAbsences(
+      externalMovementsNomisApi.stubGetAllOffenderTaps(
         prisonerNumber,
         response = temporaryAbsencesResponse(
           activeBooking = true,
           latestBooking = false,
-          applications = listOf(
+          tapApplications = listOf(
             application(
               status = "APP-SCH",
               toDate = LocalDate.now(),
@@ -532,10 +534,10 @@ class TapMigrationIntTest(
     @Test
     fun `will set application status to expired`() {
       getRequestBody<MigrateTapRequest>(
-        WireMock.putRequestedFor(WireMock.urlEqualTo("/resync/temporary-absences/$prisonerNumber")),
+        putRequestedFor(urlEqualTo("/resync/temporary-absences/$prisonerNumber")),
       ).apply {
         with(temporaryAbsences[0]) {
-          Assertions.assertThat(statusCode).isEqualTo("EXPIRED")
+          assertThat(statusCode).isEqualTo("EXPIRED")
         }
       }
     }
@@ -558,9 +560,9 @@ class TapMigrationIntTest(
       verify(telemetryClient).trackEvent(
         eq("temporary-absences-migration-entity-failed"),
         check {
-          Assertions.assertThat(it["offenderNo"]).isEqualTo("A0001KT")
-          Assertions.assertThat(it["migrationId"]).isEqualTo(migrationId)
-          Assertions.assertThat(it["reason"])
+          assertThat(it["offenderNo"]).isEqualTo("A0001KT")
+          assertThat(it["migrationId"]).isEqualTo(migrationId)
+          assertThat(it["reason"])
             .isEqualTo("400 Bad Request from PUT http://localhost:8103/resync/temporary-absences/A0001KT")
         },
         isNull(),
@@ -582,14 +584,14 @@ class TapMigrationIntTest(
 
     @Test
     fun `will request temporary absences only once`() {
-      externalMovementsNomisApi.verifyGetTemporaryAbsences(offenderNo = "A0001KT")
+      externalMovementsNomisApi.verifyGetAllOffenderTaps(offenderNo = "A0001KT")
     }
 
     @Test
     fun `will create mappings twice before succeeding`() {
       mappingApi.verify(
         2,
-        WireMock.putRequestedFor(WireMock.urlEqualTo("/mapping/temporary-absence/migrate"))
+        putRequestedFor(urlEqualTo("/mapping/temporary-absence/migrate"))
           .withRequestBodyJsonPath("prisonerNumber", "A0001KT")
           .withRequestBodyJsonPath("migrationId", migrationId),
       )
@@ -600,8 +602,8 @@ class TapMigrationIntTest(
       verify(telemetryClient, times(1)).trackEvent(
         eq("temporary-absences-migration-entity-migrated"),
         check {
-          Assertions.assertThat(it["offenderNo"]).isEqualTo("A0001KT")
-          Assertions.assertThat(it["migrationId"]).isEqualTo(migrationId)
+          assertThat(it["offenderNo"]).isEqualTo("A0001KT")
+          assertThat(it["migrationId"]).isEqualTo(migrationId)
         },
         isNull(),
       )
@@ -624,9 +626,9 @@ class TapMigrationIntTest(
         "A0001KT",
         idMappings = TemporaryAbsencesPrisonerMappingIdsDto("A0001KT", listOf(), listOf(), listOf()),
       )
-      externalMovementsNomisApi.stubGetTemporaryAbsences(
+      externalMovementsNomisApi.stubGetAllOffenderTaps(
         "A0001KT",
-        response = OffenderTemporaryAbsencesResponse(bookings = listOf()),
+        response = OffenderTapsResponse(bookings = listOf()),
       )
 
       migrationId = performMigration()
@@ -636,7 +638,7 @@ class TapMigrationIntTest(
     fun `will not migrate to DPS`() {
       dpsApi.verify(
         0,
-        WireMock.putRequestedFor(WireMock.urlEqualTo("/resync/temporary-absences/A0001KT")),
+        putRequestedFor(urlEqualTo("/resync/temporary-absences/A0001KT")),
       )
     }
 
@@ -645,9 +647,9 @@ class TapMigrationIntTest(
       verify(telemetryClient).trackEvent(
         eq("temporary-absences-migration-entity-ignored"),
         check {
-          Assertions.assertThat(it["offenderNo"]).isEqualTo("A0001KT")
-          Assertions.assertThat(it["migrationId"]).isEqualTo(migrationId)
-          Assertions.assertThat(it["reason"]).isEqualTo("The offender has no TAPs")
+          assertThat(it["offenderNo"]).isEqualTo("A0001KT")
+          assertThat(it["migrationId"]).isEqualTo(migrationId)
+          assertThat(it["reason"]).isEqualTo("The offender has no TAPs")
         },
         isNull(),
       )
@@ -673,20 +675,20 @@ class TapMigrationIntTest(
 
       @Test
       fun `will request temporary absences from NOMIS`() {
-        externalMovementsNomisApi.verifyGetTemporaryAbsences(offenderNo = "A0001KT")
+        externalMovementsNomisApi.verifyGetAllOffenderTaps(offenderNo = "A0001KT")
       }
 
       @Test
       fun `will create mappings`() {
         mappingApi.verify(
-          WireMock.putRequestedFor(WireMock.urlEqualTo("/mapping/temporary-absence/migrate"))
+          putRequestedFor(urlEqualTo("/mapping/temporary-absence/migrate"))
             .withRequestBodyJsonPath("prisonerNumber", "A0001KT"),
         )
       }
 
       @Test
       fun `will migrate to DPS`() {
-        dpsApi.verify(WireMock.putRequestedFor(WireMock.urlEqualTo("/resync/temporary-absences/A0001KT")))
+        dpsApi.verify(putRequestedFor(urlEqualTo("/resync/temporary-absences/A0001KT")))
       }
 
       @Test
@@ -694,14 +696,14 @@ class TapMigrationIntTest(
         verify(telemetryClient).trackEvent(
           eq("temporary-absences-migration-entity-repair-requested"),
           check {
-            Assertions.assertThat(it["offenderNo"]).isEqualTo("A0001KT")
+            assertThat(it["offenderNo"]).isEqualTo("A0001KT")
           },
           isNull(),
         )
         verify(telemetryClient).trackEvent(
           eq("temporary-absences-migration-entity-migrated"),
           check {
-            Assertions.assertThat(it["offenderNo"]).isEqualTo("A0001KT")
+            assertThat(it["offenderNo"]).isEqualTo("A0001KT")
           },
           isNull(),
         )
@@ -712,9 +714,9 @@ class TapMigrationIntTest(
     inner class DontIgnoreOffendersWithNoMovements {
       @BeforeEach
       fun setUp() = runTest {
-        externalMovementsNomisApi.stubGetTemporaryAbsences(
+        externalMovementsNomisApi.stubGetAllOffenderTaps(
           "A0001KT",
-          response = OffenderTemporaryAbsencesResponse(bookings = listOf()),
+          response = OffenderTapsResponse(bookings = listOf()),
         )
         dpsApi.stubResyncPrisonerTaps("A0001KT", response = MigrateTapResponse(listOf(), listOf()))
 
@@ -723,7 +725,7 @@ class TapMigrationIntTest(
 
       @Test
       fun `will migrate to DPS`() {
-        dpsApi.verify(WireMock.putRequestedFor(WireMock.urlEqualTo("/resync/temporary-absences/A0001KT")))
+        dpsApi.verify(putRequestedFor(urlEqualTo("/resync/temporary-absences/A0001KT")))
       }
 
       @Test
@@ -731,14 +733,14 @@ class TapMigrationIntTest(
         verify(telemetryClient).trackEvent(
           eq("temporary-absences-migration-entity-repair-requested"),
           check {
-            Assertions.assertThat(it["offenderNo"]).isEqualTo("A0001KT")
+            assertThat(it["offenderNo"]).isEqualTo("A0001KT")
           },
           isNull(),
         )
         verify(telemetryClient).trackEvent(
           eq("temporary-absences-migration-entity-migrated"),
           check {
-            Assertions.assertThat(it["offenderNo"]).isEqualTo("A0001KT")
+            assertThat(it["offenderNo"]).isEqualTo("A0001KT")
           },
           isNull(),
         )
@@ -749,7 +751,7 @@ class TapMigrationIntTest(
     inner class DontIgnoreOffendersNotInNomis {
       @BeforeEach
       fun setUp() = runTest {
-        externalMovementsNomisApi.stubGetTemporaryAbsences(status = HttpStatus.NOT_FOUND)
+        externalMovementsNomisApi.stubGetAllOffenderTaps(status = HttpStatus.NOT_FOUND)
         dpsApi.stubResyncPrisonerTapsError("A0001KT", status = 404)
 
         repairPrisonerOk(prisonerNumber)
@@ -757,13 +759,13 @@ class TapMigrationIntTest(
 
       @Test
       fun `will migrate to DPS`() {
-        dpsApi.verify(WireMock.putRequestedFor(WireMock.urlEqualTo("/resync/temporary-absences/A0001KT")))
+        dpsApi.verify(putRequestedFor(urlEqualTo("/resync/temporary-absences/A0001KT")))
       }
 
       @Test
       fun `will update mappings`() {
         mappingApi.verify(
-          WireMock.putRequestedFor(WireMock.urlEqualTo("/mapping/temporary-absence/migrate"))
+          putRequestedFor(urlEqualTo("/mapping/temporary-absence/migrate"))
             .withRequestBodyJsonPath("prisonerNumber", "A0001KT")
             .withRequestBodyJsonPath("bookings.length()", 0),
         )
@@ -774,14 +776,14 @@ class TapMigrationIntTest(
         verify(telemetryClient).trackEvent(
           eq("temporary-absences-migration-entity-repair-requested"),
           check {
-            Assertions.assertThat(it["offenderNo"]).isEqualTo("A0001KT")
+            assertThat(it["offenderNo"]).isEqualTo("A0001KT")
           },
           isNull(),
         )
         verify(telemetryClient).trackEvent(
           eq("temporary-absences-migration-entity-migrated"),
           check {
-            Assertions.assertThat(it["offenderNo"]).isEqualTo("A0001KT")
+            assertThat(it["offenderNo"]).isEqualTo("A0001KT")
           },
           isNull(),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationTest.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer.Companion.application
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer.Companion.temporaryAbsencesResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.application
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.temporaryAbsencesResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.toDpsRequest
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingIdsDto
 import java.time.LocalDate
@@ -20,7 +20,7 @@ class TapMigrationTest {
       val nomisResponse = temporaryAbsencesResponse(
         activeBooking = true,
         latestBooking = false,
-        applications = listOf(
+        tapApplications = listOf(
           application(
             fromDate = LocalDate.now().minusDays(1),
             toDate = LocalDate.now(),
@@ -39,7 +39,7 @@ class TapMigrationTest {
       val nomisResponse = temporaryAbsencesResponse(
         activeBooking = true,
         latestBooking = false,
-        applications = listOf(
+        tapApplications = listOf(
           application(
             fromDate = LocalDate.now().minusDays(1),
             toDate = LocalDate.now(),
@@ -57,7 +57,7 @@ class TapMigrationTest {
     fun `should NOT set expired if active booking is true`() {
       val nomisResponse = temporaryAbsencesResponse(
         activeBooking = true,
-        applications = listOf(
+        tapApplications = listOf(
           application(
             fromDate = LocalDate.now().minusDays(1),
             toDate = LocalDate.now(),
@@ -75,7 +75,7 @@ class TapMigrationTest {
     fun `should NOT set expired if application ended`() {
       val nomisResponse = temporaryAbsencesResponse(
         activeBooking = false,
-        applications = listOf(
+        tapApplications = listOf(
           application(
             fromDate = LocalDate.now().minusDays(2),
             toDate = LocalDate.now().minusDays(1),
@@ -93,7 +93,7 @@ class TapMigrationTest {
     fun `should NOT set expired if application not approved`() {
       val nomisResponse = temporaryAbsencesResponse(
         activeBooking = false,
-        applications = listOf(
+        tapApplications = listOf(
           application(
             fromDate = LocalDate.now().minusDays(1),
             toDate = LocalDate.now(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMovementIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMovementIntTest.kt
@@ -25,7 +25,6 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.sendM
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsDpsApiExtension.Companion.dpsExtMovementsServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsDpsApiMockServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiMockServer
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncWriteTapMovement
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.DuplicateErrorContentObject
@@ -36,7 +35,7 @@ import uk.gov.justice.hmpps.sqs.countAllMessagesOnQueue
 import java.util.*
 
 class TapMovementIntTest(
-  @Autowired private val nomisApi: ExternalMovementsNomisApiMockServer,
+  @Autowired private val nomisApi: TapNomisApiMockServer,
   @Autowired private val mappingApi: ExternalMovementsMappingApiMockServer,
 ) : SqsIntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapNomisApiMockServer.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps
 
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
@@ -10,33 +10,33 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ErrorResponse
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.Absence
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTemporaryAbsences
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTap
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTapApplication
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTapMovementIn
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTapMovementOut
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTapScheduleIn
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTapScheduleOut
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTaps
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.NomisAudit
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.OffenderTemporaryAbsencesResponse
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.ScheduledTemporaryAbsence
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.OffenderTapsResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.ScheduledTemporaryAbsenceResponse
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.ScheduledTemporaryAbsenceReturn
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.ScheduledTemporaryAbsenceReturnResponse
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.TemporaryAbsence
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.TemporaryAbsenceApplication
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.TemporaryAbsenceApplicationResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.TemporaryAbsenceResponse
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.TemporaryAbsenceReturn
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.TemporaryAbsenceReturnResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.NomisApiExtension.Companion.nomisApi
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Component
-class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
+class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
 
-  fun stubGetTemporaryAbsences(
+  fun stubGetAllOffenderTaps(
     offenderNo: String = "A1234BC",
-    response: OffenderTemporaryAbsencesResponse = temporaryAbsencesResponse(),
+    response: OffenderTapsResponse = temporaryAbsencesResponse(),
   ) {
     nomisApi.stubFor(
-      get(urlPathEqualTo("/movements/$offenderNo/temporary-absences")).willReturn(
+      get(urlPathEqualTo("/movements/$offenderNo/taps")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(HttpStatus.OK.value())
@@ -45,16 +45,16 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
     )
   }
 
-  fun verifyGetTemporaryAbsences(offenderNo: String = "A1234BC", count: Int = 1) {
+  fun verifyGetAllOffenderTaps(offenderNo: String = "A1234BC", count: Int = 1) {
     nomisApi.verify(
       count,
-      getRequestedFor(urlPathEqualTo("/movements/$offenderNo/temporary-absences")),
+      getRequestedFor(urlPathEqualTo("/movements/$offenderNo/taps")),
     )
   }
 
-  fun stubGetTemporaryAbsences(status: HttpStatus, error: ErrorResponse = ErrorResponse(status = status.value())) {
+  fun stubGetAllOffenderTaps(status: HttpStatus, error: ErrorResponse = ErrorResponse(status = status.value())) {
     nomisApi.stubFor(
-      get(urlPathMatching("/movements/.*/temporary-absences")).willReturn(
+      get(urlPathMatching("/movements/.*/taps")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(status.value())
@@ -277,19 +277,19 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
       bookingId: Long = 12345L,
       activeBooking: Boolean = true,
       latestBooking: Boolean = true,
-      absences: List<Absence> = listOf(absence(movementPrison = movementPrison)),
-      applications: List<TemporaryAbsenceApplication> = listOf(application(absences = absences)),
-      unscheduledTemporaryAbsences: List<TemporaryAbsence> = listOf(temporaryAbsence(seq = 1).copy(movementDate = yesterday.toLocalDate(), movementTime = yesterday)),
-      unscheduledTemporaryAbsenceReturns: List<TemporaryAbsenceReturn> = listOf(temporaryAbsenceReturn(seq = 2).copy(movementDate = yesterday.toLocalDate(), movementTime = yesterday)),
-    ): OffenderTemporaryAbsencesResponse = OffenderTemporaryAbsencesResponse(
+      taps: List<BookingTap> = listOf(taps(movementPrison = movementPrison)),
+      tapApplications: List<BookingTapApplication> = listOf(application(taps = taps)),
+      unscheduledTapMovementOuts: List<BookingTapMovementOut> = listOf(tapMovementOut(seq = 1).copy(movementDate = yesterday.toLocalDate(), movementTime = yesterday)),
+      unscheduledTapMovementIns: List<BookingTapMovementIn> = listOf(tapMovementIn(seq = 2).copy(movementDate = yesterday.toLocalDate(), movementTime = yesterday)),
+    ): OffenderTapsResponse = OffenderTapsResponse(
       bookings = listOf(
-        BookingTemporaryAbsences(
+        BookingTaps(
           bookingId = bookingId,
           activeBooking = activeBooking,
           latestBooking = latestBooking,
-          temporaryAbsenceApplications = applications,
-          unscheduledTemporaryAbsences = unscheduledTemporaryAbsences,
-          unscheduledTemporaryAbsenceReturns = unscheduledTemporaryAbsenceReturns,
+          tapApplications = tapApplications,
+          unscheduledTapMovementOuts = unscheduledTapMovementOuts,
+          unscheduledTapMovementIns = unscheduledTapMovementIns,
         ),
       ),
     )
@@ -299,9 +299,9 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
       fromDate: LocalDate = now.toLocalDate(),
       toDate: LocalDate = tomorrow.toLocalDate(),
       status: String = "APP-SCH",
-      absences: List<Absence> = listOf(absence(movementPrison = "LEI")),
-    ) = TemporaryAbsenceApplication(
-      movementApplicationId = id,
+      taps: List<BookingTap> = listOf(taps(movementPrison = "LEI")),
+    ) = BookingTapApplication(
+      tapApplicationId = id,
       eventSubType = "C5",
       applicationDate = now.toLocalDate(),
       fromDate = fromDate,
@@ -321,32 +321,32 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
       toFullAddress = "some full address",
       toAddressPostcode = "S1 1AA",
       contactPersonName = "Jeff",
-      temporaryAbsenceType = "RR",
-      temporaryAbsenceSubType = "SPL",
-      absences = absences,
+      tapType = "RR",
+      tapSubType = "SPL",
+      taps = taps,
       audit = NomisAudit(
         createDatetime = now,
         createUsername = "USER",
       ),
     )
 
-    fun absence(
+    fun taps(
       movementPrison: String = "LEI",
-      scheduledAbsence: ScheduledTemporaryAbsence = scheduledAbsence(),
-      scheduledAbsenceReturn: ScheduledTemporaryAbsenceReturn = scheduledAbsenceReturn(),
-      temporaryAbsence: TemporaryAbsence = temporaryAbsence(seq = 3).copy(
+      tapScheduleOut: BookingTapScheduleOut = tapScheduleOut(),
+      tapScheduleIn: BookingTapScheduleIn = tapScheduleIn(),
+      tapMovementOut: BookingTapMovementOut = tapMovementOut(seq = 3).copy(
         movementDate = yesterday.toLocalDate(),
         movementTime = yesterday,
         fromPrison = movementPrison,
       ),
-      temporaryAbsenceReturn: TemporaryAbsenceReturn = temporaryAbsenceReturn(seq = 4).copy(
+      tapMovementIn: BookingTapMovementIn = tapMovementIn(seq = 4).copy(
         movementDate = now.toLocalDate(),
         movementTime = now,
         toPrison = movementPrison,
       ),
-    ) = Absence(scheduledAbsence, scheduledAbsenceReturn, temporaryAbsence, temporaryAbsenceReturn)
+    ) = BookingTap(tapScheduleOut, tapScheduleIn, tapMovementOut, tapMovementIn)
 
-    fun temporaryAbsenceReturn(seq: Int = 2) = TemporaryAbsenceReturn(
+    fun tapMovementIn(seq: Int = 2) = BookingTapMovementIn(
       sequence = seq,
       movementDate = now.toLocalDate(),
       movementTime = now,
@@ -367,7 +367,7 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
       ),
     )
 
-    fun temporaryAbsence(seq: Int = 1) = TemporaryAbsence(
+    fun tapMovementOut(seq: Int = 1) = BookingTapMovementOut(
       sequence = seq,
       movementDate = now.toLocalDate(),
       movementTime = now,
@@ -389,7 +389,7 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
       ),
     )
 
-    fun scheduledAbsenceReturn(id: Long = 2) = ScheduledTemporaryAbsenceReturn(
+    fun tapScheduleIn(id: Long = 2) = BookingTapScheduleIn(
       eventId = id,
       eventSubType = "C5",
       eventStatus = "SCH",
@@ -405,7 +405,7 @@ class ExternalMovementsNomisApiMockServer(private val jsonMapper: JsonMapper) {
       ),
     )
 
-    fun scheduledAbsence(id: Long = 1): ScheduledTemporaryAbsence = ScheduledTemporaryAbsence(
+    fun tapScheduleOut(id: Long = 1): BookingTapScheduleOut = BookingTapScheduleOut(
       eventId = id,
       eventSubType = "C5",
       eventStatus = "SCH",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapNomisApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapNomisApiServiceTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps
 
 import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
@@ -20,13 +20,13 @@ import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
 @SpringAPIServiceTest
-@Import(ExternalMovementsNomisApiService::class, ExternalMovementsNomisApiMockServer::class)
-class ExternalMovementsNomisApiServiceTest {
+@Import(TapsNomisApiService::class, TapNomisApiMockServer::class)
+class TapNomisApiServiceTest {
   @Autowired
-  private lateinit var apiService: ExternalMovementsNomisApiService
+  private lateinit var apiService: TapsNomisApiService
 
   @Autowired
-  private lateinit var externalMovementsNomisApiMockServer: ExternalMovementsNomisApiMockServer
+  private lateinit var tapNomisApiMockServer: TapNomisApiMockServer
 
   private val now = LocalDateTime.now()
   private val today = now.toLocalDate()
@@ -34,59 +34,59 @@ class ExternalMovementsNomisApiServiceTest {
   private val tomorrow = now.plusDays(1)
 
   @Nested
-  inner class GetTemporaryAbsences {
+  inner class GetOffenderAllTapsTest {
     @Test
     internal fun `will pass oath2 token to service`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsences(offenderNo = "A1234BC")
+      tapNomisApiMockServer.stubGetAllOffenderTaps(offenderNo = "A1234BC")
 
-      apiService.getTemporaryAbsencesOrNull(offenderNo = "A1234BC")
+      apiService.getAllOffenderTapsOrNull(offenderNo = "A1234BC")
 
-      externalMovementsNomisApiMockServer.verify(
+      tapNomisApiMockServer.verify(
         getRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
       )
     }
 
     @Test
     internal fun `will pass offender number to service`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsences(offenderNo = "A1234BC")
+      tapNomisApiMockServer.stubGetAllOffenderTaps(offenderNo = "A1234BC")
 
-      apiService.getTemporaryAbsencesOrNull(offenderNo = "A1234BC")
+      apiService.getAllOffenderTapsOrNull(offenderNo = "A1234BC")
 
-      externalMovementsNomisApiMockServer.verify(
-        getRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences")),
+      tapNomisApiMockServer.verify(
+        getRequestedFor(urlPathEqualTo("/movements/A1234BC/taps")),
       )
     }
 
     @Test
     fun `will return temporary absences`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsences(offenderNo = "A1234BC")
+      tapNomisApiMockServer.stubGetAllOffenderTaps(offenderNo = "A1234BC")
 
-      val result = apiService.getTemporaryAbsencesOrNull(offenderNo = "A1234BC")!!
+      val result = apiService.getAllOffenderTapsOrNull(offenderNo = "A1234BC")!!
 
       assertThat(result.bookings).hasSize(1)
       assertThat(result.bookings[0].bookingId).isEqualTo(12345)
-      assertThat(result.bookings[0].temporaryAbsenceApplications).hasSize(1)
-      assertThat(result.bookings[0].temporaryAbsenceApplications[0].absences[0].scheduledTemporaryAbsence?.eventId).isEqualTo(1)
-      assertThat(result.bookings[0].temporaryAbsenceApplications[0].absences[0].scheduledTemporaryAbsenceReturn?.eventId).isEqualTo(2)
-      assertThat(result.bookings[0].temporaryAbsenceApplications[0].absences[0].temporaryAbsence?.sequence).isEqualTo(3)
-      assertThat(result.bookings[0].temporaryAbsenceApplications[0].absences[0].temporaryAbsenceReturn?.sequence).isEqualTo(4)
-      assertThat(result.bookings[0].unscheduledTemporaryAbsences[0].sequence).isEqualTo(1)
-      assertThat(result.bookings[0].unscheduledTemporaryAbsenceReturns[0].sequence).isEqualTo(2)
+      assertThat(result.bookings[0].tapApplications).hasSize(1)
+      assertThat(result.bookings[0].tapApplications[0].taps[0].tapScheduleOut?.eventId).isEqualTo(1)
+      assertThat(result.bookings[0].tapApplications[0].taps[0].tapScheduleIn?.eventId).isEqualTo(2)
+      assertThat(result.bookings[0].tapApplications[0].taps[0].tapMovementOut?.sequence).isEqualTo(3)
+      assertThat(result.bookings[0].tapApplications[0].taps[0].tapMovementIn?.sequence).isEqualTo(4)
+      assertThat(result.bookings[0].unscheduledTapMovementOuts[0].sequence).isEqualTo(1)
+      assertThat(result.bookings[0].unscheduledTapMovementIns[0].sequence).isEqualTo(2)
     }
 
     @Test
     fun `will return null when offender does not exist`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsences(NOT_FOUND)
+      tapNomisApiMockServer.stubGetAllOffenderTaps(NOT_FOUND)
 
-      assertThat(apiService.getTemporaryAbsencesOrNull(offenderNo = "A1234BC")).isNull()
+      assertThat(apiService.getAllOffenderTapsOrNull(offenderNo = "A1234BC")).isNull()
     }
 
     @Test
     fun `will throw error when API returns an error`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsences(INTERNAL_SERVER_ERROR)
+      tapNomisApiMockServer.stubGetAllOffenderTaps(INTERNAL_SERVER_ERROR)
 
       assertThrows<WebClientResponseException.InternalServerError> {
-        apiService.getTemporaryAbsencesOrNull(offenderNo = "A1234BC")
+        apiService.getAllOffenderTapsOrNull(offenderNo = "A1234BC")
       }
     }
   }
@@ -95,29 +95,29 @@ class ExternalMovementsNomisApiServiceTest {
   inner class GetTemporaryAbsenceApplication {
     @Test
     internal fun `will pass oath2 token to service`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceApplication(offenderNo = "A1234BC", applicationId = 111)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceApplication(offenderNo = "A1234BC", applicationId = 111)
 
       apiService.getTemporaryAbsenceApplication(offenderNo = "A1234BC", applicationId = 111)
 
-      externalMovementsNomisApiMockServer.verify(
+      tapNomisApiMockServer.verify(
         getRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
       )
     }
 
     @Test
     internal fun `will pass offender number and application ID to service`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceApplication(offenderNo = "A1234BC", applicationId = 111)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceApplication(offenderNo = "A1234BC", applicationId = 111)
 
       apiService.getTemporaryAbsenceApplication(offenderNo = "A1234BC", applicationId = 111)
 
-      externalMovementsNomisApiMockServer.verify(
+      tapNomisApiMockServer.verify(
         getRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/application/111")),
       )
     }
 
     @Test
     fun `will return temporary absence application`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceApplication(offenderNo = "A1234BC", applicationId = 111)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceApplication(offenderNo = "A1234BC", applicationId = 111)
 
       apiService.getTemporaryAbsenceApplication(offenderNo = "A1234BC", applicationId = 111)
         .apply {
@@ -133,7 +133,7 @@ class ExternalMovementsNomisApiServiceTest {
 
     @Test
     fun `will throw error when offender does not exist`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceApplication(status = NOT_FOUND)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceApplication(status = NOT_FOUND)
 
       assertThrows<WebClientResponseException.NotFound> {
         apiService.getTemporaryAbsenceApplication(offenderNo = "A1234BC", applicationId = 111)
@@ -142,7 +142,7 @@ class ExternalMovementsNomisApiServiceTest {
 
     @Test
     fun `will throw error when API returns an error`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceApplication(status = INTERNAL_SERVER_ERROR)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceApplication(status = INTERNAL_SERVER_ERROR)
 
       assertThrows<WebClientResponseException.InternalServerError> {
         apiService.getTemporaryAbsenceApplication(offenderNo = "A1234BC", applicationId = 111)
@@ -154,29 +154,29 @@ class ExternalMovementsNomisApiServiceTest {
   inner class GetTemporaryAbsenceScheduledMovement {
     @Test
     internal fun `will pass oath2 token to service`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceScheduledMovement(offenderNo = "A1234BC", eventId = 1)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceScheduledMovement(offenderNo = "A1234BC", eventId = 1)
 
       apiService.getTemporaryAbsenceScheduledMovement(offenderNo = "A1234BC", eventId = 1)
 
-      externalMovementsNomisApiMockServer.verify(
+      tapNomisApiMockServer.verify(
         getRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
       )
     }
 
     @Test
     internal fun `will pass offender number and event ID to service`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceScheduledMovement(offenderNo = "A1234BC", eventId = 1)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceScheduledMovement(offenderNo = "A1234BC", eventId = 1)
 
       apiService.getTemporaryAbsenceScheduledMovement(offenderNo = "A1234BC", eventId = 1)
 
-      externalMovementsNomisApiMockServer.verify(
+      tapNomisApiMockServer.verify(
         getRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/scheduled-temporary-absence/1")),
       )
     }
 
     @Test
     fun `will return scheduled temporary absence`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceScheduledMovement(offenderNo = "A1234BC", eventId = 1)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceScheduledMovement(offenderNo = "A1234BC", eventId = 1)
 
       apiService.getTemporaryAbsenceScheduledMovement(offenderNo = "A1234BC", eventId = 1)
         .apply {
@@ -194,7 +194,7 @@ class ExternalMovementsNomisApiServiceTest {
 
     @Test
     fun `will throw error when offender does not exist`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceScheduledMovement(NOT_FOUND)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceScheduledMovement(NOT_FOUND)
 
       assertThrows<WebClientResponseException.NotFound> {
         apiService.getTemporaryAbsenceScheduledMovement(offenderNo = "A1234BC", eventId = 1)
@@ -203,7 +203,7 @@ class ExternalMovementsNomisApiServiceTest {
 
     @Test
     fun `will throw error when API returns an error`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceScheduledMovement(INTERNAL_SERVER_ERROR)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceScheduledMovement(INTERNAL_SERVER_ERROR)
 
       assertThrows<WebClientResponseException.InternalServerError> {
         apiService.getTemporaryAbsenceScheduledMovement(offenderNo = "A1234BC", eventId = 1)
@@ -215,29 +215,29 @@ class ExternalMovementsNomisApiServiceTest {
   inner class GetTemporaryAbsenceScheduledReturnMovement {
     @Test
     internal fun `will pass oath2 token to service`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceScheduledReturnMovement(offenderNo = "A1234BC", eventId = 2)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceScheduledReturnMovement(offenderNo = "A1234BC", eventId = 2)
 
       apiService.getTemporaryAbsenceScheduledReturnMovement(offenderNo = "A1234BC", eventId = 2)
 
-      externalMovementsNomisApiMockServer.verify(
+      tapNomisApiMockServer.verify(
         getRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
       )
     }
 
     @Test
     internal fun `will pass offender number and event ID to service`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceScheduledReturnMovement(offenderNo = "A1234BC", eventId = 2)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceScheduledReturnMovement(offenderNo = "A1234BC", eventId = 2)
 
       apiService.getTemporaryAbsenceScheduledReturnMovement(offenderNo = "A1234BC", eventId = 2)
 
-      externalMovementsNomisApiMockServer.verify(
+      tapNomisApiMockServer.verify(
         getRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/scheduled-temporary-absence-return/2")),
       )
     }
 
     @Test
     fun `will return scheduled temporary absence return`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceScheduledReturnMovement(offenderNo = "A1234BC", eventId = 2)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceScheduledReturnMovement(offenderNo = "A1234BC", eventId = 2)
 
       apiService.getTemporaryAbsenceScheduledReturnMovement(offenderNo = "A1234BC", eventId = 2)
         .apply {
@@ -256,7 +256,7 @@ class ExternalMovementsNomisApiServiceTest {
 
     @Test
     fun `will throw error when offender does not exist`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceScheduledReturnMovement(NOT_FOUND)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceScheduledReturnMovement(NOT_FOUND)
 
       assertThrows<WebClientResponseException.NotFound> {
         apiService.getTemporaryAbsenceScheduledReturnMovement(offenderNo = "A1234BC", eventId = 2)
@@ -265,7 +265,7 @@ class ExternalMovementsNomisApiServiceTest {
 
     @Test
     fun `will throw error when API returns an error`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceScheduledReturnMovement(INTERNAL_SERVER_ERROR)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceScheduledReturnMovement(INTERNAL_SERVER_ERROR)
 
       assertThrows<WebClientResponseException.InternalServerError> {
         apiService.getTemporaryAbsenceScheduledReturnMovement(offenderNo = "A1234BC", eventId = 2)
@@ -277,29 +277,29 @@ class ExternalMovementsNomisApiServiceTest {
   inner class GetTemporaryAbsenceMovement {
     @Test
     internal fun `will pass oath2 token to service`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
 
       apiService.getTemporaryAbsenceMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
 
-      externalMovementsNomisApiMockServer.verify(
+      tapNomisApiMockServer.verify(
         getRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
       )
     }
 
     @Test
     internal fun `will pass offender number, booking ID and movement sequence to service`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
 
       apiService.getTemporaryAbsenceMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
 
-      externalMovementsNomisApiMockServer.verify(
+      tapNomisApiMockServer.verify(
         getRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/temporary-absence/12345/1")),
       )
     }
 
     @Test
     fun `will return temporary absence`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
 
       apiService.getTemporaryAbsenceMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
         .apply {
@@ -326,7 +326,7 @@ class ExternalMovementsNomisApiServiceTest {
 
     @Test
     fun `will return unscheduled temporary absence`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceMovement(
+      tapNomisApiMockServer.stubGetTemporaryAbsenceMovement(
         offenderNo = "A1234BC",
         bookingId = 12345,
         movementSeq = 1,
@@ -345,7 +345,7 @@ class ExternalMovementsNomisApiServiceTest {
 
     @Test
     fun `will throw error when offender does not exist`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceMovement(NOT_FOUND)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceMovement(NOT_FOUND)
 
       assertThrows<WebClientResponseException.NotFound> {
         apiService.getTemporaryAbsenceMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
@@ -354,7 +354,7 @@ class ExternalMovementsNomisApiServiceTest {
 
     @Test
     fun `will throw error when API returns an error`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceMovement(INTERNAL_SERVER_ERROR)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceMovement(INTERNAL_SERVER_ERROR)
 
       assertThrows<WebClientResponseException.InternalServerError> {
         apiService.getTemporaryAbsenceMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
@@ -366,18 +366,18 @@ class ExternalMovementsNomisApiServiceTest {
   inner class TemporaryAbsenceReturnMovementTest {
     @Test
     fun `will call the correct endpoint`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceReturnMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceReturnMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
 
       apiService.getTemporaryAbsenceReturnMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
 
-      externalMovementsNomisApiMockServer.verify(
+      tapNomisApiMockServer.verify(
         getRequestedFor(urlPathEqualTo("/movements/A1234BC/temporary-absences/temporary-absence-return/12345/1")),
       )
     }
 
     @Test
     fun `will return temporary absence return`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceReturnMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceReturnMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
 
       apiService.getTemporaryAbsenceReturnMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
         .apply {
@@ -401,7 +401,7 @@ class ExternalMovementsNomisApiServiceTest {
 
     @Test
     fun `will return unscheduled temporary absence return`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceReturnMovement(
+      tapNomisApiMockServer.stubGetTemporaryAbsenceReturnMovement(
         offenderNo = "A1234BC",
         bookingId = 12345,
         movementSeq = 1,
@@ -420,7 +420,7 @@ class ExternalMovementsNomisApiServiceTest {
 
     @Test
     fun `will throw error when offender does not exist`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceReturnMovement(NOT_FOUND)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceReturnMovement(NOT_FOUND)
 
       assertThrows<WebClientResponseException.NotFound> {
         apiService.getTemporaryAbsenceReturnMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
@@ -429,7 +429,7 @@ class ExternalMovementsNomisApiServiceTest {
 
     @Test
     fun `will throw error when API returns an error`() = runTest {
-      externalMovementsNomisApiMockServer.stubGetTemporaryAbsenceReturnMovement(INTERNAL_SERVER_ERROR)
+      tapNomisApiMockServer.stubGetTemporaryAbsenceReturnMovement(INTERNAL_SERVER_ERROR)
 
       assertThrows<WebClientResponseException.InternalServerError> {
         apiService.getTemporaryAbsenceReturnMovement(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapScheduleIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapScheduleIntTest.kt
@@ -30,7 +30,6 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.sendM
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsDpsApiExtension.Companion.dpsExtMovementsServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsDpsApiMockServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiMockServer
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncWriteTapOccurrence
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.DuplicateErrorContentObject
@@ -43,7 +42,7 @@ import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 class TapScheduleIntTest(
-  @Autowired private val nomisApi: ExternalMovementsNomisApiMockServer,
+  @Autowired private val nomisApi: TapNomisApiMockServer,
   @Autowired private val mappingApi: ExternalMovementsMappingApiMockServer,
 ) : SqsIntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapScheduleServiceTest.kt
@@ -4,8 +4,8 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsNomisApiMockServer.Companion.scheduledTemporaryAbsenceResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.Location
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.scheduledTemporaryAbsenceResponse
 
 class TapScheduleServiceTest {
 


### PR DESCRIPTION
The only real change is to switch to the new endpoint to get all offender TAP details. However the model returned by that endpoint is huge and so this change is huge.

Ultimately we'll have to rely on the tests here.