### PR TITLE
SDIT-2832 Switch to new tap mappings migrate and move booking APIs

### DIFF
--- a/openapi-specs/nomis-mapping-service-api-docs.json
+++ b/openapi-specs/nomis-mapping-service-api-docs.json
@@ -25041,12 +25041,12 @@
             "type" : "integer",
             "format" : "int32"
           },
+          "paged" : {
+            "type" : "boolean"
+          },
           "pageNumber" : {
             "type" : "integer",
             "format" : "int32"
-          },
-          "paged" : {
-            "type" : "boolean"
           },
           "unpaged" : {
             "type" : "boolean"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapAddressService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapAddressService.kt
@@ -4,12 +4,11 @@ import com.microsoft.applicationinsights.TelemetryClient
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.TelemetryEnabled
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.track
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiService
 
 @Service
 class TapAddressService(
   override val telemetryClient: TelemetryClient,
-  private val mappingApiService: ExternalMovementsMappingApiService,
+  private val mappingApiService: TapMappingApiService,
   private val tapScheduleService: TapScheduleService,
 ) : TelemetryEnabled {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapApplicationService.kt
@@ -9,11 +9,10 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.Telemetry
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.track
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.trackEvent
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.valuesAsStrings
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.Location
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncAtAndBy
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncWriteTapAuthorisation
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_MAPPING_TEMPORARY_ABSENCE_APPLICATION
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_MAPPING_TAP_APPLICATION
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapApplicationMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapApplicationMappingDto.MappingType.NOMIS_CREATED
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.TapApplication
@@ -28,7 +27,7 @@ private const val TELEMETRY_PREFIX: String = "${TAP_TELEMETRY_PREFIX}-applicatio
 class TapApplicationService(
   override val telemetryClient: TelemetryClient,
   private val queueService: SynchronisationQueueService,
-  private val mappingApiService: ExternalMovementsMappingApiService,
+  private val mappingApiService: TapMappingApiService,
   private val nomisApiService: TapsNomisApiService,
   private val dpsApiService: TapDpsApiService,
 ) : TelemetryEnabled {
@@ -125,7 +124,7 @@ class TapApplicationService(
     } catch (e: Exception) {
       log.error("Failed to create mapping for temporary absence application NOMIS id ${mapping.nomisApplicationId}", e)
       queueService.sendMessage(
-        messageType = RETRY_MAPPING_TEMPORARY_ABSENCE_APPLICATION.name,
+        messageType = RETRY_MAPPING_TAP_APPLICATION.name,
         synchronisationType = SynchronisationType.EXTERNAL_MOVEMENTS,
         message = mapping,
         telemetryAttributes = telemetry.valuesAsStrings(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapEventListener.kt
@@ -10,12 +10,12 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.EventAudi
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.EventFeatureSwitch
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.SQSMessage
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.asCompletableFuture
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_MAPPING_TEMPORARY_ABSENCE_APPLICATION
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_MAPPING_TEMPORARY_ABSENCE_EXTERNAL_MOVEMENT
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_MAPPING_TEMPORARY_ABSENCE_SCHEDULED_MOVEMENT
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_MOVE_BOOKING_MAPPING_TEMPORARY_ABSENCE
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_UPDATE_MAPPING_TEMPORARY_ABSENCE_EXTERNAL_MOVEMENT
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_UPDATE_MAPPING_TEMPORARY_ABSENCE_SCHEDULED_MOVEMENT
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_MAPPING_TAP_APPLICATION
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_MAPPING_TAP_MOVEMENT
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_MAPPING_TAP_SCHEDULE
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_MOVE_BOOKING_MAPPING_TAP
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_UPDATE_MAPPING_TAP_MOVEMENT
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_UPDATE_MAPPING_TAP_SCHEDULE
 import java.util.concurrent.CompletableFuture
 
 @Service
@@ -67,12 +67,12 @@ class TapEventListener(
   }
 
   private suspend fun retryMapping(type: String, message: String) = when (ExternalMovementRetryMappingMessageTypes.valueOf(type)) {
-    RETRY_MAPPING_TEMPORARY_ABSENCE_APPLICATION -> tapApplicationService.retryCreateApplicationMapping(message.fromJson())
-    RETRY_MAPPING_TEMPORARY_ABSENCE_SCHEDULED_MOVEMENT -> tapScheduleService.retryCreateScheduledMovementMapping(message.fromJson())
-    RETRY_MAPPING_TEMPORARY_ABSENCE_EXTERNAL_MOVEMENT -> tapMovementService.retryCreateExternalMovementMapping(message.fromJson())
-    RETRY_UPDATE_MAPPING_TEMPORARY_ABSENCE_EXTERNAL_MOVEMENT -> tapMovementService.retryUpdateExternalMovementMapping(message.fromJson())
-    RETRY_UPDATE_MAPPING_TEMPORARY_ABSENCE_SCHEDULED_MOVEMENT -> tapScheduleService.retryUpdateScheduledMovementMapping(message.fromJson())
-    RETRY_MOVE_BOOKING_MAPPING_TEMPORARY_ABSENCE -> moveBookingService.retryMoveBookingMapping(message.fromJson())
+    RETRY_MAPPING_TAP_APPLICATION -> tapApplicationService.retryCreateApplicationMapping(message.fromJson())
+    RETRY_MAPPING_TAP_SCHEDULE -> tapScheduleService.retryCreateScheduledMovementMapping(message.fromJson())
+    RETRY_MAPPING_TAP_MOVEMENT -> tapMovementService.retryCreateExternalMovementMapping(message.fromJson())
+    RETRY_UPDATE_MAPPING_TAP_MOVEMENT -> tapMovementService.retryUpdateExternalMovementMapping(message.fromJson())
+    RETRY_UPDATE_MAPPING_TAP_SCHEDULE -> tapScheduleService.retryUpdateScheduledMovementMapping(message.fromJson())
+    RETRY_MOVE_BOOKING_MAPPING_TAP -> moveBookingService.retryMoveBookingMapping(message.fromJson())
   }
 
   private inline fun <reified T> String.fromJson(): T = jsonMapper.readValue(this)
@@ -134,10 +134,10 @@ enum class DirectionCode { IN, OUT }
 enum class MovementType { ADM, CRT, REL, TAP, TRN, }
 
 enum class ExternalMovementRetryMappingMessageTypes {
-  RETRY_MAPPING_TEMPORARY_ABSENCE_APPLICATION,
-  RETRY_MAPPING_TEMPORARY_ABSENCE_SCHEDULED_MOVEMENT,
-  RETRY_MAPPING_TEMPORARY_ABSENCE_EXTERNAL_MOVEMENT,
-  RETRY_UPDATE_MAPPING_TEMPORARY_ABSENCE_SCHEDULED_MOVEMENT,
-  RETRY_UPDATE_MAPPING_TEMPORARY_ABSENCE_EXTERNAL_MOVEMENT,
-  RETRY_MOVE_BOOKING_MAPPING_TEMPORARY_ABSENCE,
+  RETRY_MAPPING_TAP_APPLICATION,
+  RETRY_MAPPING_TAP_SCHEDULE,
+  RETRY_MAPPING_TAP_MOVEMENT,
+  RETRY_UPDATE_MAPPING_TAP_SCHEDULE,
+  RETRY_UPDATE_MAPPING_TAP_MOVEMENT,
+  RETRY_MOVE_BOOKING_MAPPING_TAP,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMappingApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMappingApiService.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps
 
 import kotlinx.coroutines.reactive.awaitFirstOrDefault
 import kotlinx.coroutines.reactive.awaitSingle
@@ -15,33 +15,33 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.histo
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.MigrationMapping
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.api.TapApplicationResourceApi
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.api.TapMovementResourceApi
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.api.TapPrisonerResourceApi
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.api.TapScheduleResourceApi
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.api.TemporaryAbsenceResourceApi
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.FindTapScheduleMappingsForAddressResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapApplicationMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapMoveBookingMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapMovementMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapPrisonerMappingIdsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapPrisonerMappingsDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapScheduleMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceMoveBookingMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingIdsDto
 
 @Service
-class ExternalMovementsMappingApiService(@Qualifier("tapsMappingApiWebClient") webClient: WebClient) : MigrationMapping<TemporaryAbsencesPrisonerMappingDto>(domainUrl = "/mapping/temporary-absence", webClient) {
+class TapMappingApiService(@Qualifier("tapsMappingApiWebClient") webClient: WebClient) : MigrationMapping<TapPrisonerMappingsDto>(domainUrl = "/mapping/taps", webClient) {
 
-  private val mappingApi = TemporaryAbsenceResourceApi(webClient)
   private val applicationApi = TapApplicationResourceApi(webClient)
   private val scheduleApi = TapScheduleResourceApi(webClient)
   private val movementApi = TapMovementResourceApi(webClient)
+  private val prisonerApi = TapPrisonerResourceApi(webClient)
 
   override suspend fun createMapping(
-    mapping: TemporaryAbsencesPrisonerMappingDto,
-    errorJavaClass: ParameterizedTypeReference<DuplicateErrorResponse<TemporaryAbsencesPrisonerMappingDto>>,
-  ): CreateMappingResult<TemporaryAbsencesPrisonerMappingDto> = webClient.put()
+    mapping: TapPrisonerMappingsDto,
+    errorJavaClass: ParameterizedTypeReference<DuplicateErrorResponse<TapPrisonerMappingsDto>>,
+  ): CreateMappingResult<TapPrisonerMappingsDto> = webClient.put()
     .uri(createMappingUrl())
     .bodyValue(mapping)
     .retrieve()
     .bodyToMono(Unit::class.java)
-    .map { CreateMappingResult<TemporaryAbsencesPrisonerMappingDto>() }
+    .map { CreateMappingResult<TapPrisonerMappingsDto>() }
     .onErrorResume(WebClientResponseException.Conflict::class.java) {
       Mono.just(CreateMappingResult(it.getResponseBodyAs(errorJavaClass)))
     }
@@ -90,10 +90,10 @@ class ExternalMovementsMappingApiService(@Qualifier("tapsMappingApiWebClient") w
   suspend fun findTapScheduleMappingsForAddress(nomisAddressId: Long): FindTapScheduleMappingsForAddressResponse = scheduleApi.findTapScheduleMappingsByNomisAddressId(nomisAddressId)
     .awaitSingle()
 
-  suspend fun getMoveBookingMappings(bookingId: Long): TemporaryAbsenceMoveBookingMappingDto = mappingApi.getMoveBookingMappings(bookingId).awaitSingle()
+  suspend fun getTapMoveBookingMappings(bookingId: Long): TapMoveBookingMappingDto = prisonerApi.getPrisonerBookingMappings(bookingId).awaitSingle()
 
-  suspend fun moveBookingMappings(bookingId: Long, fromOffenderNo: String, toOffenderNo: String): Unit = mappingApi.moveBookingMappings(bookingId, fromOffenderNo, toOffenderNo)
+  suspend fun moveTapBookingMappings(bookingId: Long, fromOffenderNo: String, toOffenderNo: String): Unit = prisonerApi.movePrisonerBookingMappings(bookingId, fromOffenderNo, toOffenderNo)
     .awaitSingle()
 
-  suspend fun getPrisonerMappingIds(prisoner: String): TemporaryAbsencesPrisonerMappingIdsDto = mappingApi.getTemporaryAbsenceMappings(prisoner).awaitSingle()
+  suspend fun getTapPrisonerMappingIds(prisoner: String): TapPrisonerMappingIdsDto = prisonerApi.getAllPrisonerMappingIds(prisoner).awaitSingle()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationService.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.data.MigrationCon
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.data.generateBatchId
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.DuplicateErrorResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.MigrationMessageType
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.Location
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapAuthorisation
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapMovement
@@ -20,12 +19,12 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.M
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapRequest
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncAtAndBy
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ExternalMovementMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ScheduledMovementMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceApplicationMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceBookingMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingIdsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapApplicationMappingsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapBookingMappingsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapMovementMappingsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapPrisonerMappingIdsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapPrisonerMappingsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapScheduleMappingsDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTapMovementIn
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTapMovementOut
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTapScheduleOut
@@ -41,7 +40,7 @@ import java.util.*
 
 @Service
 class TapMigrationService(
-  val migrationMappingService: ExternalMovementsMappingApiService,
+  val migrationMappingService: TapMappingApiService,
   val nomisIdsApiService: NomisApiService,
   val nomisApiService: TapsNomisApiService,
   val dpsApiService: TapDpsApiService,
@@ -51,7 +50,7 @@ class TapMigrationService(
   @Value($$"${externalmovements.complete-check.retry-seconds:1}") completeCheckRetrySeconds: Int,
   @Value($$"${externalmovements.complete-check.count}") completeCheckCount: Int,
   @Value($$"${complete-check.scheduled-retry-seconds:10}") completeCheckScheduledRetrySeconds: Int,
-) : ByPageNumberMigrationService<TapMigrationFilter, PrisonerId, TemporaryAbsencesPrisonerMappingDto>(
+) : ByPageNumberMigrationService<TapMigrationFilter, PrisonerId, TapPrisonerMappingsDto>(
   mappingService = migrationMappingService,
   migrationType = MigrationType.EXTERNAL_MOVEMENTS,
   pageSize = pageSize,
@@ -110,7 +109,7 @@ class TapMigrationService(
         publishTelemetry("ignored", telemetry.apply { this["reason"] = "The offender has no TAPs" })
         return
       }
-      val oldMappingIds = migrationMappingService.getPrisonerMappingIds(offenderNo)
+      val oldMappingIds = migrationMappingService.getTapPrisonerMappingIds(offenderNo)
       // Note that we're not expecting to perform a clean migration again so we're calling the DPS /resync endpoint which performs "patch migrations"
       val dpsResponse = dpsApiService.resyncPrisonerTaps(offenderNo, offenderTaps.toDpsRequest(oldMappingIds))
         ?: MigrateTapResponse(temporaryAbsences = emptyList(), unscheduledMovements = emptyList())
@@ -126,14 +125,14 @@ class TapMigrationService(
       }
   }
 
-  override suspend fun retryCreateMapping(context: MigrationContext<TemporaryAbsencesPrisonerMappingDto>) {
+  override suspend fun retryCreateMapping(context: MigrationContext<TapPrisonerMappingsDto>) {
     createMappingOrOnFailureDo(context.body) {
       throw it
     }
   }
 
   private suspend fun createMappingOrOnFailureDo(
-    mapping: TemporaryAbsencesPrisonerMappingDto,
+    mapping: TapPrisonerMappingsDto,
     failureHandler: suspend (error: Throwable) -> Unit,
   ) {
     runCatching {
@@ -151,14 +150,14 @@ class TapMigrationService(
     }
   }
 
-  private suspend fun createMapping(mapping: TemporaryAbsencesPrisonerMappingDto) = migrationMappingService.createMapping(
+  private suspend fun createMapping(mapping: TapPrisonerMappingsDto) = migrationMappingService.createMapping(
     mapping,
     object :
-      ParameterizedTypeReference<DuplicateErrorResponse<TemporaryAbsencesPrisonerMappingDto>>() {},
+      ParameterizedTypeReference<DuplicateErrorResponse<TapPrisonerMappingsDto>>() {},
   )
 
   private suspend fun requeueCreateMapping(
-    mapping: TemporaryAbsencesPrisonerMappingDto,
+    mapping: TapPrisonerMappingsDto,
     context: MigrationContext<*>,
   ) {
     queueService.sendMessage(
@@ -177,16 +176,16 @@ class TapMigrationService(
     )
   }
 
-  private fun OffenderTapsResponse.buildMappings(prisonerNumber: String, migrationId: String, dpsResponse: MigrateTapResponse) = TemporaryAbsencesPrisonerMappingDto(
+  private fun OffenderTapsResponse.buildMappings(prisonerNumber: String, migrationId: String, dpsResponse: MigrateTapResponse) = TapPrisonerMappingsDto(
     prisonerNumber = prisonerNumber,
     migrationId = migrationId,
     bookings = bookings.map { booking ->
-      TemporaryAbsenceBookingMappingDto(
+      TapBookingMappingsDto(
         bookingId = booking.bookingId,
         applications = booking.tapApplications.map { application ->
-          TemporaryAbsenceApplicationMappingDto(
-            nomisMovementApplicationId = application.tapApplicationId,
-            dpsMovementApplicationId = dpsResponse.findDpsAuthorisationId(application.tapApplicationId),
+          TapApplicationMappingsDto(
+            nomisApplicationId = application.tapApplicationId,
+            dpsAuthorisationId = dpsResponse.findDpsAuthorisationId(application.tapApplicationId),
             schedules = application.taps.mapNotNull { it.tapScheduleOut }.map { it.toMappingDto(dpsResponse) },
             movements = application.taps.mapNotNull { it.tapMovementOut }.map { it.toMappingDto(booking.bookingId, dpsResponse) } +
               application.taps.mapNotNull { it.tapMovementIn }.map { it.toMappingDto(booking.bookingId, dpsResponse) },
@@ -198,7 +197,7 @@ class TapMigrationService(
     },
   )
 
-  private fun BookingTapScheduleOut.toMappingDto(dpsResponse: MigrateTapResponse): ScheduledMovementMappingDto = ScheduledMovementMappingDto(
+  private fun BookingTapScheduleOut.toMappingDto(dpsResponse: MigrateTapResponse): TapScheduleMappingsDto = TapScheduleMappingsDto(
     nomisEventId = this.eventId,
     dpsOccurrenceId = dpsResponse.findDpsScheduleId(this.eventId),
     nomisAddressId = this.toAddressId,
@@ -209,7 +208,7 @@ class TapMigrationService(
     eventTime = "${this.startTime}",
   )
 
-  private fun BookingTapMovementOut.toMappingDto(bookingId: Long, dpsResponse: MigrateTapResponse): ExternalMovementMappingDto = ExternalMovementMappingDto(
+  private fun BookingTapMovementOut.toMappingDto(bookingId: Long, dpsResponse: MigrateTapResponse): TapMovementMappingsDto = TapMovementMappingsDto(
     nomisMovementSeq = this.sequence,
     dpsMovementId = dpsResponse.findDpsMovementId(bookingId, this.sequence),
     nomisAddressId = this.toAddressId,
@@ -219,7 +218,7 @@ class TapMigrationService(
     dpsPostcode = this.toAddressPostcode,
   )
 
-  private fun BookingTapMovementIn.toMappingDto(bookingId: Long, dpsResponse: MigrateTapResponse): ExternalMovementMappingDto = ExternalMovementMappingDto(
+  private fun BookingTapMovementIn.toMappingDto(bookingId: Long, dpsResponse: MigrateTapResponse): TapMovementMappingsDto = TapMovementMappingsDto(
     nomisMovementSeq = this.sequence,
     dpsMovementId = dpsResponse.findDpsMovementId(bookingId, this.sequence),
     nomisAddressId = this.fromAddressId,
@@ -260,10 +259,10 @@ class TapMigrationService(
 
   override fun parseContextNomisId(json: String): MigrationMessage<*, PrisonerId> = jsonMapper.readValue(json)
 
-  override fun parseContextMapping(json: String): MigrationMessage<*, TemporaryAbsencesPrisonerMappingDto> = jsonMapper.readValue(json)
+  override fun parseContextMapping(json: String): MigrationMessage<*, TapPrisonerMappingsDto> = jsonMapper.readValue(json)
 }
 
-fun OffenderTapsResponse.toDpsRequest(oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto) = MigrateTapRequest(
+fun OffenderTapsResponse.toDpsRequest(oldMappingIds: TapPrisonerMappingIdsDto) = MigrateTapRequest(
   temporaryAbsences = this.bookings.flatMap { booking ->
     booking.tapApplications.map { application ->
       MigrateTapAuthorisation(
@@ -284,7 +283,7 @@ fun OffenderTapsResponse.toDpsRequest(oldMappingIds: TemporaryAbsencesPrisonerMa
         startTime = "${application.releaseTime.toLocalTime()}",
         endTime = "${application.returnTime.toLocalTime()}",
         location = Location(description = application.toAddressDescription, address = application.toFullAddress, postcode = application.toAddressPostcode),
-        id = oldMappingIds.applications.find { it.nomisMovementApplicationId == application.tapApplicationId }?.dpsMovementApplicationId,
+        id = oldMappingIds.applications.find { it.nomisApplicationId == application.tapApplicationId }?.dpsAuthorisationId,
         occurrences = application.taps.mapNotNull { tap ->
           tap.tapScheduleOut?.let { scheduleOut ->
             scheduleOut.toDpsRequest(
@@ -318,7 +317,7 @@ private fun BookingTapScheduleOut.toDpsRequest(
   bookingId: Long,
   movementOut: BookingTapMovementOut?,
   movementIn: BookingTapMovementIn?,
-  oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto,
+  oldMappingIds: TapPrisonerMappingIdsDto,
 ): MigrateTapOccurrence = MigrateTapOccurrence(
   isCancelled = eventStatus == "CANC",
   start = startTime,
@@ -341,7 +340,7 @@ private fun BookingTapScheduleOut.toDpsRequest(
 private fun BookingTapMovementIn.toDpsRequest(
   bookingId: Long,
   schedulePrison: String,
-  oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto,
+  oldMappingIds: TapPrisonerMappingIdsDto,
 ): MigrateTapMovement = MigrateTapMovement(
   occurredAt = movementTime,
   direction = MigrateTapMovement.Direction.IN,
@@ -360,7 +359,7 @@ private fun BookingTapMovementIn.toDpsRequest(
 private fun BookingTapMovementOut.toDpsRequest(
   bookingId: Long,
   schedulePrison: String,
-  oldMappingIds: TemporaryAbsencesPrisonerMappingIdsDto,
+  oldMappingIds: TapPrisonerMappingIdsDto,
 ): MigrateTapMovement = MigrateTapMovement(
   occurredAt = movementTime,
   direction = MigrateTapMovement.Direction.OUT,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMoveBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMoveBookingService.kt
@@ -11,10 +11,9 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.Telemetry
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.track
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.trackEvent
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.valuesAsStrings
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MoveTemporaryAbsencesRequest
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceApplicationIdMapping
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceMovementIdMapping
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapApplicationIdMapping
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapMovementIdMapping
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingTaps
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.InternalMessage
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.SynchronisationQueueService
@@ -24,7 +23,7 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.Synchroni
 class TapMoveBookingService(
   private val dpsApi: TapDpsApiService,
   private val nomisApi: TapsNomisApiService,
-  private val mappingApi: ExternalMovementsMappingApiService,
+  private val mappingApi: TapMappingApiService,
   private val queueService: SynchronisationQueueService,
   private val migrationService: TapMigrationService,
   override val telemetryClient: TelemetryClient,
@@ -49,7 +48,7 @@ class TapMoveBookingService(
         return
       }
 
-      val mappings = mappingApi.getMoveBookingMappings(bookingId)
+      val mappings = mappingApi.getTapMoveBookingMappings(bookingId)
 
       val dpsAuthorisationIds = booking.findDpsAuthorisationIds(mappings.applicationIds, telemetry)
       val dpsUnscheduleMovementIds = booking.findDpsMovementIds(mappings.movementIds, telemetry)
@@ -70,7 +69,7 @@ class TapMoveBookingService(
     ?.firstOrNull { it.bookingId == bookingId }
 
   private fun BookingTaps.findDpsAuthorisationIds(
-    mappings: List<TemporaryAbsenceApplicationIdMapping>,
+    mappings: List<TapApplicationIdMapping>,
     telemetry: MutableMap<String, Any>,
   ) = tapApplications
     .map { it.tapApplicationId }
@@ -83,7 +82,7 @@ class TapMoveBookingService(
     .also { telemetry["dpsAuthorisationIds"] = "$it" }
 
   private fun BookingTaps.findDpsMovementIds(
-    mappings: List<TemporaryAbsenceMovementIdMapping>,
+    mappings: List<TapMovementIdMapping>,
     telemetry: MutableMap<String, Any>,
   ) = (unscheduledTapMovementOuts.map { it.sequence } + unscheduledTapMovementIns.map { it.sequence })
     .also { telemetry["nomisUnscheduledMovementSeqs"] = "$it" }
@@ -100,7 +99,7 @@ class TapMoveBookingService(
     } catch (e: Exception) {
       log.error("Failed to move booking mappings for bookingId=$bookingId", e)
       queueService.sendMessage(
-        messageType = ExternalMovementRetryMappingMessageTypes.RETRY_MOVE_BOOKING_MAPPING_TEMPORARY_ABSENCE.name,
+        messageType = ExternalMovementRetryMappingMessageTypes.RETRY_MOVE_BOOKING_MAPPING_TAP.name,
         synchronisationType = SynchronisationType.EXTERNAL_MOVEMENTS,
         message = BookingMovedAdditionalInformationEvent(toOffenderNo, fromOffenderNo, bookingId),
         telemetryAttributes = telemetry.valuesAsStrings(),
@@ -120,7 +119,7 @@ class TapMoveBookingService(
   }
 
   suspend fun moveMappingsAndResync(bookingId: Long, fromOffenderNo: String, toOffenderNo: String) {
-    mappingApi.moveBookingMappings(bookingId, fromOffenderNo, toOffenderNo)
+    mappingApi.moveTapBookingMappings(bookingId, fromOffenderNo, toOffenderNo)
     migrationService.resyncPrisonerTaps(fromOffenderNo)
     migrationService.resyncPrisonerTaps(toOffenderNo)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMovementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMovementService.kt
@@ -10,12 +10,11 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.track
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.trackEvent
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.tryFetchParent
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.valuesAsStrings
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.Location
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncAtAndBy
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncWriteTapMovement
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_MAPPING_TEMPORARY_ABSENCE_EXTERNAL_MOVEMENT
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_UPDATE_MAPPING_TEMPORARY_ABSENCE_EXTERNAL_MOVEMENT
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_MAPPING_TAP_MOVEMENT
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_UPDATE_MAPPING_TAP_MOVEMENT
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.MovementType.TAP
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapMovementMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.TapMovementIn
@@ -31,7 +30,7 @@ private const val TELEMETRY_PREFIX: String = "${TAP_TELEMETRY_PREFIX}-external-m
 class TapMovementService(
   override val telemetryClient: TelemetryClient,
   private val queueService: SynchronisationQueueService,
-  private val mappingApiService: ExternalMovementsMappingApiService,
+  private val mappingApiService: TapMappingApiService,
   private val nomisApiService: TapsNomisApiService,
   private val dpsApiService: TapDpsApiService,
 ) : TelemetryEnabled {
@@ -275,7 +274,7 @@ class TapMovementService(
         e,
       )
       queueService.sendMessage(
-        messageType = RETRY_MAPPING_TEMPORARY_ABSENCE_EXTERNAL_MOVEMENT.name,
+        messageType = RETRY_MAPPING_TAP_MOVEMENT.name,
         synchronisationType = SynchronisationType.EXTERNAL_MOVEMENTS,
         message = mapping,
         telemetryAttributes = telemetry.valuesAsStrings(),
@@ -352,7 +351,7 @@ class TapMovementService(
         e,
       )
       queueService.sendMessage(
-        messageType = RETRY_UPDATE_MAPPING_TEMPORARY_ABSENCE_EXTERNAL_MOVEMENT.name,
+        messageType = RETRY_UPDATE_MAPPING_TAP_MOVEMENT.name,
         synchronisationType = SynchronisationType.EXTERNAL_MOVEMENTS,
         message = mapping,
         telemetryAttributes = telemetry.valuesAsStrings(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapScheduleService.kt
@@ -10,11 +10,10 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.track
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.trackEvent
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.tryFetchParent
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.valuesAsStrings
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.Location
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncAtAndBy
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncWriteTapOccurrence
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_MAPPING_TEMPORARY_ABSENCE_SCHEDULED_MOVEMENT
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.ExternalMovementRetryMappingMessageTypes.RETRY_MAPPING_TAP_SCHEDULE
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.MovementType.TAP
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapScheduleMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapScheduleMappingDto.MappingType.NOMIS_CREATED
@@ -30,7 +29,7 @@ private const val TELEMETRY_PREFIX: String = "${TAP_TELEMETRY_PREFIX}-scheduled-
 class TapScheduleService(
   override val telemetryClient: TelemetryClient,
   private val queueService: SynchronisationQueueService,
-  private val mappingApiService: ExternalMovementsMappingApiService,
+  private val mappingApiService: TapMappingApiService,
   private val nomisApiService: TapsNomisApiService,
   private val dpsApiService: TapDpsApiService,
 ) : TelemetryEnabled {
@@ -185,7 +184,7 @@ class TapScheduleService(
     } catch (e: Exception) {
       log.error("Failed to create mapping for temporary absence scheduled movement NOMIS id ${mapping.nomisEventId}", e)
       queueService.sendMessage(
-        messageType = RETRY_MAPPING_TEMPORARY_ABSENCE_SCHEDULED_MOVEMENT.name,
+        messageType = RETRY_MAPPING_TAP_SCHEDULE.name,
         synchronisationType = SynchronisationType.EXTERNAL_MOVEMENTS,
         message = mapping,
         telemetryAttributes = telemetry.valuesAsStrings(),
@@ -199,7 +198,7 @@ class TapScheduleService(
     } catch (e: Exception) {
       log.error("Failed to update mapping for temporary absence scheduled movement NOMIS id ${mapping.nomisEventId}", e)
       queueService.sendMessage(
-        messageType = ExternalMovementRetryMappingMessageTypes.RETRY_UPDATE_MAPPING_TEMPORARY_ABSENCE_SCHEDULED_MOVEMENT.name,
+        messageType = ExternalMovementRetryMappingMessageTypes.RETRY_UPDATE_MAPPING_TAP_SCHEDULE.name,
         synchronisationType = SynchronisationType.EXTERNAL_MOVEMENTS,
         message = mapping,
         telemetryAttributes = telemetry.valuesAsStrings(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/GeneralMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/GeneralMappingService.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.csra.CsraMappingS
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.finance.PrisonBalanceMappingApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.finance.PrisonerBalanceMappingApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.incidents.IncidentsMappingService
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiService
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapMappingApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.officialvisits.OfficialVisitsMappingService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.officialvisits.VisitSlotsMappingService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.visits.VisitMappingService
@@ -27,7 +27,7 @@ class GeneralMappingService(
   private val courtSentencingMappingService: CourtSentencingMappingApiService,
   private val prisonBalanceMappingApiService: PrisonBalanceMappingApiService,
   private val prisonerBalanceMappingApiService: PrisonerBalanceMappingApiService,
-  private val externalMovementsMappingApiService: ExternalMovementsMappingApiService,
+  private val tapMappingApiService: TapMappingApiService,
   private val visitSlotsMappingService: VisitSlotsMappingService,
   private val officialVisitsMappingService: OfficialVisitsMappingService,
 ) {
@@ -38,7 +38,7 @@ class GeneralMappingService(
     MigrationType.CORE_PERSON_RELIGION -> religionsMappingService.getMigrationCount(migrationId)
     MigrationType.COURT_SENTENCING -> courtSentencingMappingService.getMigrationCount(migrationId)
     MigrationType.CSRA -> csraMappingService.getMigrationCount(migrationId)
-    MigrationType.EXTERNAL_MOVEMENTS -> externalMovementsMappingApiService.getMigrationCount(migrationId)
+    MigrationType.EXTERNAL_MOVEMENTS -> tapMappingApiService.getMigrationCount(migrationId)
     MigrationType.INCIDENTS -> incidentsMappingService.getMigrationCount(migrationId)
     MigrationType.OFFICIAL_VISITS -> officialVisitsMappingService.getMigrationCount(migrationId)
     MigrationType.PRISON_BALANCE -> prisonBalanceMappingApiService.getPagedModelMigrationCount(migrationId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapAddressIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapAddressIntTest.kt
@@ -17,9 +17,7 @@ import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.sendMessage
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiMockServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncResponse
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.tapScheduleMapping
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapDpsApiExtension.Companion.dpsExtMovementsServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapScheduleMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.withRequestBodyJsonPath
@@ -27,7 +25,7 @@ import java.util.*
 
 class TapAddressIntTest(
   @Autowired private val nomisApi: TapNomisApiMockServer,
-  @Autowired private val mappingApi: ExternalMovementsMappingApiMockServer,
+  @Autowired private val mappingApi: TapMappingApiMockServer,
 ) : SqsIntegrationTestBase() {
 
   private val dpsApi = dpsExtMovementsServer
@@ -487,7 +485,7 @@ class TapAddressIntTest(
           tapScheduleMapping(2L, "B1234BB", UUID.randomUUID(), nomisAddressOwnerClass = addressOwnerClass),
         ),
       ).take(mappings)
-      mappingApi.stubFindScheduledMovementsForAddressMappings(321, scheduleMappings.map { it.mapping })
+      mappingApi.stubFindTapScheduleMappingsForAddressForMappings(321, scheduleMappings.map { it.mapping })
       scheduleMappings.forEach {
         mappingApi.stubGetTapApplicationMapping(it.nomisApplicationId, it.dpsAuthorisationId)
         nomisApi.stubGetTapScheduleOut(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapApplicationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapApplicationIntTest.kt
@@ -21,7 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus.NOT_FOUND
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.sendMessage
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiMockServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncWriteTapAuthorisation
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapDpsApiExtension.Companion.dpsExtMovementsServer
@@ -38,7 +37,7 @@ import java.util.*
 
 class TapApplicationIntTest(
   @Autowired private val nomisApi: TapNomisApiMockServer,
-  @Autowired private val mappingApi: ExternalMovementsMappingApiMockServer,
+  @Autowired private val mappingApi: TapMappingApiMockServer,
 ) : SqsIntegrationTestBase() {
 
   private val dpsApi = dpsExtMovementsServer
@@ -148,7 +147,7 @@ class TapApplicationIntTest(
       fun `should NOT create mapping`() {
         mappingApi.verify(
           count = 0,
-          postRequestedFor(urlPathEqualTo("/mapping/temporary-absence/application")),
+          postRequestedFor(urlPathEqualTo("/mapping/taps/application")),
         )
       }
 
@@ -185,7 +184,7 @@ class TapApplicationIntTest(
       fun `should NOT create mapping`() {
         mappingApi.verify(
           count = 0,
-          postRequestedFor(urlPathEqualTo("/mapping/temporary-absence/application")),
+          postRequestedFor(urlPathEqualTo("/mapping/taps/application")),
         )
       }
 
@@ -225,7 +224,7 @@ class TapApplicationIntTest(
       fun `should NOT create mapping`() {
         mappingApi.verify(
           count = 0,
-          postRequestedFor(urlPathEqualTo("/mapping/temporary-absence/application")),
+          postRequestedFor(urlPathEqualTo("/mapping/taps/application")),
         )
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMappingApiMockServer.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps
 
 import com.github.tomakehurst.wiremock.client.CountMatchingStrategy
 import com.github.tomakehurst.wiremock.client.WireMock
@@ -14,20 +14,20 @@ import org.springframework.stereotype.Component
 import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.DuplicateMappingErrorResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ErrorResponse
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ExternalMovementMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ExternalMovementMappingIdsDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.FindTapScheduleMappingsForAddressResponse
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ScheduledMovementMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ScheduledMovementMappingIdsDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapApplicationMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapApplicationMappingIdsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapApplicationMappingsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapBookingMappingsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapMoveBookingMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapMovementMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapMovementMappingIdsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapMovementMappingsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapPrisonerMappingIdsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapPrisonerMappingsDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapScheduleMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceApplicationMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceApplicationMappingIdsDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceBookingMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceMoveBookingMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingIdsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapScheduleMappingIdsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapScheduleMappingsDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.MappingApiExtension.Companion.jsonMapper
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.MappingApiExtension.Companion.mappingApi
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.getRequestBody
@@ -35,14 +35,14 @@ import java.time.LocalDateTime
 import java.util.*
 
 @Component
-class ExternalMovementsMappingApiMockServer(private val jsonMapper: JsonMapper) {
+class TapMappingApiMockServer(private val jsonMapper: JsonMapper) {
   companion object {
     inline fun <reified T> getRequestBody(pattern: RequestPatternBuilder): T = mappingApi.getRequestBody(pattern, jsonMapper = jsonMapper)
   }
 
-  fun stubCreateTemporaryAbsenceMapping() {
+  fun stubCreateTapPrisonerMappings() {
     mappingApi.stubFor(
-      put("/mapping/temporary-absence/migrate")
+      put("/mapping/taps/migrate")
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
@@ -51,9 +51,9 @@ class ExternalMovementsMappingApiMockServer(private val jsonMapper: JsonMapper) 
     )
   }
 
-  fun stubCreateTemporaryAbsenceMapping(status: HttpStatus, error: ErrorResponse = ErrorResponse(status = status.value())) {
+  fun stubCreateTapPrisonerMappings(status: HttpStatus, error: ErrorResponse = ErrorResponse(status = status.value())) {
     mappingApi.stubFor(
-      put("/mapping/temporary-absence/migrate").willReturn(
+      put("/mapping/taps/migrate").willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(status.value())
@@ -62,11 +62,11 @@ class ExternalMovementsMappingApiMockServer(private val jsonMapper: JsonMapper) 
     )
   }
 
-  fun stubCreateTemporaryAbsenceMappingFailureFollowedBySuccess() {
-    mappingApi.stubMappingCreateFailureFollowedBySuccess(url = "/mapping/temporary-absence/migrate", WireMock::put)
+  fun stubCreateTapPrisonerMappingsFailureFollowedBySuccess() {
+    mappingApi.stubMappingCreateFailureFollowedBySuccess(url = "/mapping/taps/migrate", WireMock::put)
   }
 
-  fun stubGetTemporaryAbsenceMappingIds(
+  fun stubGetTapPrisonerMappingIds(
     prisonerNumber: String = "A1234BC",
     bookingId: Long = 12345,
     nomisApplicationId: Long = 1,
@@ -81,10 +81,10 @@ class ExternalMovementsMappingApiMockServer(private val jsonMapper: JsonMapper) 
     dpsUnscheduledMovementOutId: UUID = UUID.randomUUID(),
     nomisUnscheduledMovementInSeq: Int = 6,
     dpsUnscheduledMovementInId: UUID = UUID.randomUUID(),
-    idMappings: TemporaryAbsencesPrisonerMappingIdsDto = temporaryAbsencePrisonerIdMappings(bookingId, nomisApplicationId, dpsAuthorisationId, nomisScheduleOutEventId, dpsOccurrenceId, nomisMovementOutSeq, dpsMovementOutId, nomisMovementInSeq, dpsMovementInId, nomisUnscheduledMovementOutSeq, dpsUnscheduledMovementOutId, nomisUnscheduledMovementInSeq, dpsUnscheduledMovementInId),
+    idMappings: TapPrisonerMappingIdsDto = tapPrisonerIdMappings(bookingId, nomisApplicationId, dpsAuthorisationId, nomisScheduleOutEventId, dpsOccurrenceId, nomisMovementOutSeq, dpsMovementOutId, nomisMovementInSeq, dpsMovementInId, nomisUnscheduledMovementOutSeq, dpsUnscheduledMovementOutId, nomisUnscheduledMovementInSeq, dpsUnscheduledMovementInId),
   ) {
     mappingApi.stubFor(
-      get(urlPathMatching("/mapping/temporary-absence/$prisonerNumber/ids")).willReturn(
+      get(urlPathMatching("/mapping/taps/$prisonerNumber/ids")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withBody(jsonMapper.writeValueAsString(idMappings)),
@@ -92,9 +92,9 @@ class ExternalMovementsMappingApiMockServer(private val jsonMapper: JsonMapper) 
     )
   }
 
-  fun stubGetTemporaryAbsenceMappingIds(prisonerNumber: String = "A1234BC", status: HttpStatus, error: ErrorResponse = ErrorResponse(status = status.value())) {
+  fun stubGetTapPrisonerMappingIds(prisonerNumber: String = "A1234BC", status: HttpStatus, error: ErrorResponse = ErrorResponse(status = status.value())) {
     mappingApi.stubFor(
-      get(urlPathMatching("/mapping/temporary-absence/$prisonerNumber/ids")).willReturn(
+      get(urlPathMatching("/mapping/taps/$prisonerNumber/ids")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(status.value())
@@ -396,7 +396,7 @@ class ExternalMovementsMappingApiMockServer(private val jsonMapper: JsonMapper) 
     )
   }
 
-  fun stubFindScheduledMovementsForAddress(
+  fun stubFindTapScheduleMappingsForAddressForPrisoners(
     nomisAddressId: Long = 123L,
     prisoners: List<String> = listOf("A1234AA", "B1234BB"),
   ) {
@@ -417,7 +417,7 @@ class ExternalMovementsMappingApiMockServer(private val jsonMapper: JsonMapper) 
     )
   }
 
-  fun stubFindScheduledMovementsForAddressMappings(
+  fun stubFindTapScheduleMappingsForAddressForMappings(
     nomisAddressId: Long = 321L,
     mappings: List<TapScheduleMappingDto>,
   ) {
@@ -434,7 +434,7 @@ class ExternalMovementsMappingApiMockServer(private val jsonMapper: JsonMapper) 
     )
   }
 
-  fun stubFindScheduledMovementsForAddressError(nomisAddressId: Long = 123L, status: HttpStatus, error: ErrorResponse = ErrorResponse(status = status.value())) {
+  fun stubFindTapScheduleMappingsForAddressError(nomisAddressId: Long = 123L, status: HttpStatus, error: ErrorResponse = ErrorResponse(status = status.value())) {
     mappingApi.stubFor(
       get(urlPathMatching("/mapping/taps/schedule/nomis-address-id/$nomisAddressId")).willReturn(
         aResponse()
@@ -447,10 +447,10 @@ class ExternalMovementsMappingApiMockServer(private val jsonMapper: JsonMapper) 
 
   fun stubGetMoveBookingMappings(
     bookingId: Long = 12345,
-    mappings: TemporaryAbsenceMoveBookingMappingDto,
+    mappings: TapMoveBookingMappingDto,
   ) {
     mappingApi.stubFor(
-      get(urlPathMatching("/mapping/temporary-absence/move-booking/$bookingId")).willReturn(
+      get(urlPathMatching("/mapping/taps/move-booking/$bookingId")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withBody(jsonMapper.writeValueAsString(mappings)),
@@ -460,7 +460,7 @@ class ExternalMovementsMappingApiMockServer(private val jsonMapper: JsonMapper) 
 
   fun stubGetMoveBookingMappingsError(bookingId: Long = 12345, status: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR, error: ErrorResponse = ErrorResponse(status = status.value())) {
     mappingApi.stubFor(
-      get(urlPathMatching("/mapping/temporary-absence/move-booking/$bookingId")).willReturn(
+      get(urlPathMatching("/mapping/taps/move-booking/$bookingId")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(status.value())
@@ -471,7 +471,7 @@ class ExternalMovementsMappingApiMockServer(private val jsonMapper: JsonMapper) 
 
   fun stubMoveBookingMappings(bookingId: Long = 12345L, fromOffenderNo: String = "A1234AA", toOffenderNo: String = "B1234BB") {
     mappingApi.stubFor(
-      put("/mapping/temporary-absence/move-booking/$bookingId/from/$fromOffenderNo/to/$toOffenderNo")
+      put("/mapping/taps/move-booking/$bookingId/from/$fromOffenderNo/to/$toOffenderNo")
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
@@ -482,7 +482,7 @@ class ExternalMovementsMappingApiMockServer(private val jsonMapper: JsonMapper) 
 
   fun stubMoveBookingMappingsError(bookingId: Long = 12345L, fromOffenderNo: String = "A1234AA", toOffenderNo: String = "B1234BB", status: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR, error: ErrorResponse = ErrorResponse(status = status.value())) {
     mappingApi.stubFor(
-      put("/mapping/temporary-absence/move-booking/$bookingId/from/$fromOffenderNo/to/$toOffenderNo").willReturn(
+      put("/mapping/taps/move-booking/$bookingId/from/$fromOffenderNo/to/$toOffenderNo").willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(status.value())
@@ -491,25 +491,25 @@ class ExternalMovementsMappingApiMockServer(private val jsonMapper: JsonMapper) 
     )
   }
 
-  fun stubMoveBookingMappingsFailureFollowedBySuccess(bookingId: Long = 12345L, fromOffenderNo: String = "A1234AA", toOffenderNo: String = "B1234BB") = mappingApi.stubMappingUpdateFailureFollowedBySuccess("/mapping/temporary-absence/move-booking/$bookingId/from/$fromOffenderNo/to/$toOffenderNo")
+  fun stubMoveBookingMappingsFailureFollowedBySuccess(bookingId: Long = 12345L, fromOffenderNo: String = "A1234AA", toOffenderNo: String = "B1234BB") = mappingApi.stubMappingUpdateFailureFollowedBySuccess("/mapping/taps/move-booking/$bookingId/from/$fromOffenderNo/to/$toOffenderNo")
 
   fun verify(pattern: RequestPatternBuilder) = mappingApi.verify(pattern)
   fun verify(count: Int, pattern: RequestPatternBuilder) = mappingApi.verify(count, pattern)
   fun verify(count: CountMatchingStrategy, pattern: RequestPatternBuilder) = mappingApi.verify(count, pattern)
 }
 
-fun temporaryAbsencePrisonerMappings(prisonerNumber: String = "A1234BC") = TemporaryAbsencesPrisonerMappingDto(
+fun tapPrisonerMappings(prisonerNumber: String = "A1234BC") = TapPrisonerMappingsDto(
   prisonerNumber = prisonerNumber,
   migrationId = "2020-01-01T11:10:00",
   bookings = listOf(
-    TemporaryAbsenceBookingMappingDto(
+    TapBookingMappingsDto(
       bookingId = 12345,
       applications = listOf(
-        TemporaryAbsenceApplicationMappingDto(
-          nomisMovementApplicationId = 1,
-          dpsMovementApplicationId = UUID.randomUUID(),
+        TapApplicationMappingsDto(
+          nomisApplicationId = 1,
+          dpsAuthorisationId = UUID.randomUUID(),
           schedules = listOf(
-            ScheduledMovementMappingDto(
+            TapScheduleMappingsDto(
               nomisEventId = 1,
               dpsOccurrenceId = UUID.randomUUID(),
               nomisAddressId = 321,
@@ -517,7 +517,7 @@ fun temporaryAbsencePrisonerMappings(prisonerNumber: String = "A1234BC") = Tempo
               dpsAddressText = "schedule OFF address",
               eventTime = "${LocalDateTime.now()}",
             ),
-            ScheduledMovementMappingDto(
+            TapScheduleMappingsDto(
               nomisEventId = 2,
               dpsOccurrenceId = UUID.randomUUID(),
               nomisAddressId = 432,
@@ -527,14 +527,14 @@ fun temporaryAbsencePrisonerMappings(prisonerNumber: String = "A1234BC") = Tempo
             ),
           ),
           movements = listOf(
-            ExternalMovementMappingDto(
+            TapMovementMappingsDto(
               nomisMovementSeq = 3,
               dpsMovementId = UUID.randomUUID(),
               nomisAddressId = 543,
               nomisAddressOwnerClass = "AGY",
               dpsAddressText = "movement AGY address",
             ),
-            ExternalMovementMappingDto(
+            TapMovementMappingsDto(
               nomisMovementSeq = 4,
               dpsMovementId = UUID.randomUUID(),
               nomisAddressId = 654,
@@ -545,14 +545,14 @@ fun temporaryAbsencePrisonerMappings(prisonerNumber: String = "A1234BC") = Tempo
         ),
       ),
       unscheduledMovements = listOf(
-        ExternalMovementMappingDto(
+        TapMovementMappingsDto(
           nomisMovementSeq = 1,
           dpsMovementId = UUID.randomUUID(),
           nomisAddressId = 654,
           nomisAddressOwnerClass = "CORP",
           dpsAddressText = "movement CORP address",
         ),
-        ExternalMovementMappingDto(
+        TapMovementMappingsDto(
           nomisMovementSeq = 2,
           dpsMovementId = UUID.randomUUID(),
           nomisAddressId = 765,
@@ -617,7 +617,7 @@ fun tapMovementMapping(
   dpsPostcode = if (city == null) "S1 1AB" else null,
 )
 
-fun temporaryAbsencePrisonerIdMappings(
+fun tapPrisonerIdMappings(
   bookingId: Long = 12345,
   nomisApplicationId: Long = 1,
   dpsAuthorisationId: UUID = UUID.randomUUID(),
@@ -631,14 +631,14 @@ fun temporaryAbsencePrisonerIdMappings(
   dpsUnscheduledMovementOutId: UUID = UUID.randomUUID(),
   nomisUnscheduledMovementInSeq: Int = 6,
   dpsUnscheduledMovementInId: UUID = UUID.randomUUID(),
-) = TemporaryAbsencesPrisonerMappingIdsDto(
+) = TapPrisonerMappingIdsDto(
   prisonerNumber = "A1234BC",
-  applications = listOf(TemporaryAbsenceApplicationMappingIdsDto(nomisApplicationId, dpsAuthorisationId)),
-  schedules = listOf(ScheduledMovementMappingIdsDto(nomisScheduleOutEventId, dpsOccurrenceId)),
+  applications = listOf(TapApplicationMappingIdsDto(nomisApplicationId, dpsAuthorisationId)),
+  schedules = listOf(TapScheduleMappingIdsDto(nomisScheduleOutEventId, dpsOccurrenceId)),
   movements = listOf(
-    ExternalMovementMappingIdsDto(bookingId, nomisMovementOutSeq, dpsMovementOutId),
-    ExternalMovementMappingIdsDto(bookingId, nomisMovementInSeq, dpsMovementInId),
-    ExternalMovementMappingIdsDto(bookingId, nomisUnscheduledMovementOutSeq, dpsUnscheduledMovementOutId),
-    ExternalMovementMappingIdsDto(bookingId, nomisUnscheduledMovementInSeq, dpsUnscheduledMovementInId),
+    TapMovementMappingIdsDto(bookingId, nomisMovementOutSeq, dpsMovementOutId),
+    TapMovementMappingIdsDto(bookingId, nomisMovementInSeq, dpsMovementInId),
+    TapMovementMappingIdsDto(bookingId, nomisUnscheduledMovementOutSeq, dpsUnscheduledMovementOutId),
+    TapMovementMappingIdsDto(bookingId, nomisUnscheduledMovementInSeq, dpsUnscheduledMovementInId),
   ),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMappingApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMappingApiServiceTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps
 
 import com.github.tomakehurst.wiremock.client.WireMock.absent
 import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
@@ -22,36 +22,35 @@ import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helper.SpringAPIServiceTest
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.DuplicateErrorResponse
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapConfiguration
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.DuplicateErrorContentObject
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.DuplicateMappingErrorResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapApplicationIdMapping
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapApplicationMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapMoveBookingMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapMovementIdMapping
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapMovementMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapPrisonerMappingsDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapScheduleMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceApplicationIdMapping
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceMoveBookingMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceMovementIdMapping
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingDto
 import java.util.*
 
 @SpringAPIServiceTest
-@Import(ExternalMovementsMappingApiService::class, ExternalMovementsMappingApiMockServer::class, TapConfiguration::class)
-class ExternalMovementsMappingApiServiceTest {
+@Import(TapMappingApiService::class, TapMappingApiMockServer::class, TapConfiguration::class)
+class TapMappingApiServiceTest {
   @Autowired
-  private lateinit var apiService: ExternalMovementsMappingApiService
+  private lateinit var apiService: TapMappingApiService
 
   @Autowired
-  private lateinit var mappingApi: ExternalMovementsMappingApiMockServer
+  private lateinit var mappingApi: TapMappingApiMockServer
 
   @Nested
   inner class CreateMappings {
     @Test
     internal fun `should pass oath2 token to service`() = runTest {
-      mappingApi.stubCreateTemporaryAbsenceMapping()
+      mappingApi.stubCreateTapPrisonerMappings()
 
       apiService.createMapping(
-        temporaryAbsencePrisonerMappings(),
-        object : ParameterizedTypeReference<DuplicateErrorResponse<TemporaryAbsencesPrisonerMappingDto>>() {},
+        tapPrisonerMappings(),
+        object : ParameterizedTypeReference<DuplicateErrorResponse<TapPrisonerMappingsDto>>() {},
       )
 
       mappingApi.verify(
@@ -61,31 +60,31 @@ class ExternalMovementsMappingApiServiceTest {
 
     @Test
     internal fun `should pass data to service`() = runTest {
-      mappingApi.stubCreateTemporaryAbsenceMapping()
+      mappingApi.stubCreateTapPrisonerMappings()
 
       apiService.createMapping(
-        temporaryAbsencePrisonerMappings(),
-        object : ParameterizedTypeReference<DuplicateErrorResponse<TemporaryAbsencesPrisonerMappingDto>>() {},
+        tapPrisonerMappings(),
+        object : ParameterizedTypeReference<DuplicateErrorResponse<TapPrisonerMappingsDto>>() {},
       )
 
       mappingApi.verify(
         putRequestedFor(anyUrl())
           .withRequestBody(matchingJsonPath("prisonerNumber", equalTo("A1234BC")))
           .withRequestBody(matchingJsonPath("bookings[0].bookingId", equalTo("12345")))
-          .withRequestBody(matchingJsonPath("bookings[0].applications[0].nomisMovementApplicationId", equalTo("1")))
-          .withRequestBody(matchingJsonPath("bookings[0].applications[0].dpsMovementApplicationId", not(absent())))
+          .withRequestBody(matchingJsonPath("bookings[0].applications[0].nomisApplicationId", equalTo("1")))
+          .withRequestBody(matchingJsonPath("bookings[0].applications[0].dpsAuthorisationId", not(absent())))
           .withRequestBody(matchingJsonPath("migrationId", equalTo("2020-01-01T11:10:00"))),
       )
     }
 
     @Test
     fun `should throw if API calls fail`() = runTest {
-      mappingApi.stubCreateTemporaryAbsenceMapping(status = INTERNAL_SERVER_ERROR)
+      mappingApi.stubCreateTapPrisonerMappings(status = INTERNAL_SERVER_ERROR)
 
       assertThrows<WebClientResponseException.InternalServerError> {
         apiService.createMapping(
-          temporaryAbsencePrisonerMappings(),
-          object : ParameterizedTypeReference<DuplicateErrorResponse<TemporaryAbsencesPrisonerMappingDto>>() {},
+          tapPrisonerMappings(),
+          object : ParameterizedTypeReference<DuplicateErrorResponse<TapPrisonerMappingsDto>>() {},
         )
       }
     }
@@ -423,7 +422,7 @@ class ExternalMovementsMappingApiServiceTest {
   }
 
   @Nested
-  inner class CreateExternalMovementMappings {
+  inner class CreateTapMovementMappings {
     @Test
     internal fun `should pass oath2 token to service`() = runTest {
       mappingApi.stubCreateTapMovementMapping()
@@ -503,7 +502,7 @@ class ExternalMovementsMappingApiServiceTest {
   }
 
   @Nested
-  inner class UpdateExternalMovementMappings {
+  inner class UpdateTapMovementMappings {
     @Test
     internal fun `should pass oath2 token to service`() = runTest {
       mappingApi.stubUpdateTapMovementMapping()
@@ -545,7 +544,7 @@ class ExternalMovementsMappingApiServiceTest {
   }
 
   @Nested
-  inner class GetExternalMovementMappings {
+  inner class GetTapMovementMappings {
     @Test
     internal fun `should pass oath2 token to service`() = runTest {
       mappingApi.stubGetTapMovementMapping()
@@ -576,7 +575,7 @@ class ExternalMovementsMappingApiServiceTest {
   }
 
   @Nested
-  inner class DeleteExternalMovementMappings {
+  inner class DeleteTapMovementMappings {
     @Test
     internal fun `should pass oath2 token to service`() = runTest {
       mappingApi.stubDeleteTapMovementMapping()
@@ -599,10 +598,10 @@ class ExternalMovementsMappingApiServiceTest {
   }
 
   @Nested
-  inner class FindScheduledMovementsForAddresses {
+  inner class FindTapScheduleMappingsForAddresses {
     @Test
     internal fun `should pass oath2 token to service`() = runTest {
-      mappingApi.stubFindScheduledMovementsForAddress()
+      mappingApi.stubFindTapScheduleMappingsForAddressForPrisoners()
 
       apiService.findTapScheduleMappingsForAddress(123L)
 
@@ -613,7 +612,7 @@ class ExternalMovementsMappingApiServiceTest {
 
     @Test
     fun `should return list of schedule mappings`() = runTest {
-      mappingApi.stubFindScheduledMovementsForAddress()
+      mappingApi.stubFindTapScheduleMappingsForAddressForPrisoners()
 
       with(apiService.findTapScheduleMappingsForAddress(123L)) {
         assertThat(scheduleMappings).extracting("prisonerNumber").containsExactlyInAnyOrder("A1234AA", "B1234BB")
@@ -622,7 +621,7 @@ class ExternalMovementsMappingApiServiceTest {
 
     @Test
     fun `should handle empty list if none found`() = runTest {
-      mappingApi.stubFindScheduledMovementsForAddress(prisoners = listOf())
+      mappingApi.stubFindTapScheduleMappingsForAddressForPrisoners(prisoners = listOf())
 
       with(apiService.findTapScheduleMappingsForAddress(123L)) {
         assertThat(scheduleMappings.size).isEqualTo(0)
@@ -631,7 +630,7 @@ class ExternalMovementsMappingApiServiceTest {
 
     @Test
     fun `should throw if API calls fail`() = runTest {
-      mappingApi.stubFindScheduledMovementsForAddressError(status = INTERNAL_SERVER_ERROR)
+      mappingApi.stubFindTapScheduleMappingsForAddressError(status = INTERNAL_SERVER_ERROR)
 
       assertThrows<WebClientResponseException.InternalServerError> {
         apiService.findTapScheduleMappingsForAddress(123L)
@@ -641,16 +640,16 @@ class ExternalMovementsMappingApiServiceTest {
 
   @Nested
   inner class GetMoveBookingMappings {
-    val response = TemporaryAbsenceMoveBookingMappingDto(
-      applicationIds = listOf(TemporaryAbsenceApplicationIdMapping(777L, UUID.randomUUID())),
-      movementIds = listOf(TemporaryAbsenceMovementIdMapping(77, UUID.randomUUID())),
+    val response = TapMoveBookingMappingDto(
+      applicationIds = listOf(TapApplicationIdMapping(777L, UUID.randomUUID())),
+      movementIds = listOf(TapMovementIdMapping(77, UUID.randomUUID())),
     )
 
     @Test
     internal fun `should pass oath2 token to service`() = runTest {
       mappingApi.stubGetMoveBookingMappings(12345L, response)
 
-      apiService.getMoveBookingMappings(12345L)
+      apiService.getTapMoveBookingMappings(12345L)
 
       mappingApi.verify(
         getRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
@@ -661,9 +660,9 @@ class ExternalMovementsMappingApiServiceTest {
     fun `should return mappings`() = runTest {
       mappingApi.stubGetMoveBookingMappings(12345L, response)
 
-      with(apiService.getMoveBookingMappings(12345L)) {
-        assertThat(applicationIds).containsExactly(TemporaryAbsenceApplicationIdMapping(777, response.applicationIds.first().authorisationId))
-        assertThat(movementIds).containsExactly(TemporaryAbsenceMovementIdMapping(77, response.movementIds.first().dpsMovementId))
+      with(apiService.getTapMoveBookingMappings(12345L)) {
+        assertThat(applicationIds).containsExactly(TapApplicationIdMapping(777, response.applicationIds.first().authorisationId))
+        assertThat(movementIds).containsExactly(TapMovementIdMapping(77, response.movementIds.first().dpsMovementId))
       }
     }
 
@@ -672,7 +671,7 @@ class ExternalMovementsMappingApiServiceTest {
       mappingApi.stubGetMoveBookingMappingsError(12345L)
 
       assertThrows<WebClientResponseException.InternalServerError> {
-        apiService.getMoveBookingMappings(12345L)
+        apiService.getTapMoveBookingMappings(12345L)
       }
     }
   }
@@ -683,7 +682,7 @@ class ExternalMovementsMappingApiServiceTest {
     fun `should pass oath2 token to service`() = runTest {
       mappingApi.stubMoveBookingMappings()
 
-      apiService.moveBookingMappings(12345L, "A1234AA", "B1234BB")
+      apiService.moveTapBookingMappings(12345L, "A1234AA", "B1234BB")
 
       mappingApi.verify(
         putRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
@@ -695,23 +694,23 @@ class ExternalMovementsMappingApiServiceTest {
       mappingApi.stubMoveBookingMappingsError(status = INTERNAL_SERVER_ERROR)
 
       assertThrows<WebClientResponseException.InternalServerError> {
-        apiService.moveBookingMappings(12345L, "A1234AA", "B1234BB")
+        apiService.moveTapBookingMappings(12345L, "A1234AA", "B1234BB")
       }
     }
   }
 
   @Nested
   inner class GetPrisonerMappingIds {
-    val response = TemporaryAbsenceMoveBookingMappingDto(
-      applicationIds = listOf(TemporaryAbsenceApplicationIdMapping(777L, UUID.randomUUID())),
-      movementIds = listOf(TemporaryAbsenceMovementIdMapping(77, UUID.randomUUID())),
+    val response = TapMoveBookingMappingDto(
+      applicationIds = listOf(TapApplicationIdMapping(777L, UUID.randomUUID())),
+      movementIds = listOf(TapMovementIdMapping(77, UUID.randomUUID())),
     )
 
     @Test
     internal fun `should pass oath2 token to service`() = runTest {
-      mappingApi.stubGetTemporaryAbsenceMappingIds()
+      mappingApi.stubGetTapPrisonerMappingIds()
 
-      apiService.getPrisonerMappingIds("A1234BC")
+      apiService.getTapPrisonerMappingIds("A1234BC")
 
       mappingApi.verify(
         getRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
@@ -720,10 +719,10 @@ class ExternalMovementsMappingApiServiceTest {
 
     @Test
     fun `should return mappings`() = runTest {
-      mappingApi.stubGetTemporaryAbsenceMappingIds()
+      mappingApi.stubGetTapPrisonerMappingIds()
 
-      with(apiService.getPrisonerMappingIds("A1234BC")) {
-        assertThat(applications[0].nomisMovementApplicationId).isEqualTo(1)
+      with(apiService.getTapPrisonerMappingIds("A1234BC")) {
+        assertThat(applications[0].nomisApplicationId).isEqualTo(1)
         assertThat(schedules[0].nomisEventId).isEqualTo(2)
         assertThat(movements[0].nomisMovementSeq).isEqualTo(3)
       }
@@ -731,10 +730,10 @@ class ExternalMovementsMappingApiServiceTest {
 
     @Test
     fun `should throw if API calls fail`() = runTest {
-      mappingApi.stubGetTemporaryAbsenceMappingIds("A1234BC", status = INTERNAL_SERVER_ERROR)
+      mappingApi.stubGetTapPrisonerMappingIds("A1234BC", status = INTERNAL_SERVER_ERROR)
 
       assertThrows<WebClientResponseException.InternalServerError> {
-        apiService.getPrisonerMappingIds("A1234BC")
+        apiService.getTapPrisonerMappingIds("A1234BC")
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationIntTest.kt
@@ -29,7 +29,6 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helper.MigrationResult
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.MigrationTestBase
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiMockServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapMovement
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapRequest
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MigrateTapResponse
@@ -37,9 +36,9 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.Ta
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapDpsApiMockServer.Companion.getRequestBody
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapDpsApiMockServer.Companion.migrateResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.application
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.temporaryAbsencesResponse
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingIdsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.offenderTapsResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapPrisonerMappingIdsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapPrisonerMappingsDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.OffenderTapsResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.NomisApiExtension.Companion.nomisApi
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.withRequestBodyJsonPath
@@ -52,7 +51,7 @@ import java.util.*
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TapMigrationIntTest(
   @Autowired private val externalMovementsNomisApi: TapNomisApiMockServer,
-  @Autowired private val mappingApi: ExternalMovementsMappingApiMockServer,
+  @Autowired private val mappingApi: TapMappingApiMockServer,
 ) : MigrationTestBase() {
 
   private val dpsApi = dpsExtMovementsServer
@@ -106,11 +105,11 @@ class TapMigrationIntTest(
 
   private fun stubMigrationDependencies(entities: Int = 2) {
     nomisApi.stubGetPrisonerIds(totalElements = entities.toLong(), pageSize = 10, firstOffenderNo = "A0001KT")
-    mappingApi.stubCreateTemporaryAbsenceMapping()
+    mappingApi.stubCreateTapPrisonerMappings()
     (1..entities)
       .map { index -> "A%04dKT".format(index) }
       .forEach { prisonerNumber ->
-        mappingApi.stubGetTemporaryAbsenceMappingIds(prisonerNumber, 12345L, 1, dpsAuthorisationId, 1, dpsOccurrenceId, 3, dpsScheduledMovementOutId, 4, dpsScheduledMovementInId, 1, dpsUnscheduledMovementOutId, 2, dpsUnscheduledMovementInId)
+        mappingApi.stubGetTapPrisonerMappingIds(prisonerNumber, 12345L, 1, dpsAuthorisationId, 1, dpsOccurrenceId, 3, dpsScheduledMovementOutId, 4, dpsScheduledMovementInId, 1, dpsUnscheduledMovementOutId, 2, dpsUnscheduledMovementInId)
         externalMovementsNomisApi.stubGetAllOffenderTaps(prisonerNumber)
         dpsApi.stubResyncPrisonerTaps(
           personIdentifier = prisonerNumber,
@@ -151,12 +150,12 @@ class TapMigrationIntTest(
     @Test
     fun `will create mappings`() {
       mappingApi.verify(
-        putRequestedFor(urlEqualTo("/mapping/temporary-absence/migrate"))
+        putRequestedFor(urlEqualTo("/mapping/taps/migrate"))
           .withRequestBodyJsonPath("prisonerNumber", "A0001KT")
           .withRequestBodyJsonPath("migrationId", migrationId),
       )
       mappingApi.verify(
-        putRequestedFor(urlEqualTo("/mapping/temporary-absence/migrate"))
+        putRequestedFor(urlEqualTo("/mapping/taps/migrate"))
           .withRequestBodyJsonPath("prisonerNumber", "A0002KT")
           .withRequestBodyJsonPath("migrationId", migrationId),
       )
@@ -338,14 +337,14 @@ class TapMigrationIntTest(
 
     @Test
     fun `will populate correct mapping details`() {
-      ExternalMovementsMappingApiMockServer.getRequestBody<TemporaryAbsencesPrisonerMappingDto>(
-        putRequestedFor(urlEqualTo("/mapping/temporary-absence/migrate")),
+      TapMappingApiMockServer.getRequestBody<TapPrisonerMappingsDto>(
+        putRequestedFor(urlEqualTo("/mapping/taps/migrate")),
       )
         .apply {
           assertThat(bookings[0].bookingId).isEqualTo(12345)
 
-          assertThat(bookings[0].applications[0].nomisMovementApplicationId).isEqualTo(1)
-          assertThat(bookings[0].applications[0].dpsMovementApplicationId).isEqualTo(dpsAuthorisationId)
+          assertThat(bookings[0].applications[0].nomisApplicationId).isEqualTo(1)
+          assertThat(bookings[0].applications[0].dpsAuthorisationId).isEqualTo(dpsAuthorisationId)
 
           with(bookings[0].applications[0].schedules[0]) {
             assertThat(nomisEventId).isEqualTo(1)
@@ -435,15 +434,15 @@ class TapMigrationIntTest(
         pageSize = 10,
         firstOffenderNo = prisonerNumber,
       )
-      mappingApi.stubCreateTemporaryAbsenceMapping()
-      mappingApi.stubGetTemporaryAbsenceMappingIds(
+      mappingApi.stubCreateTapPrisonerMappings()
+      mappingApi.stubGetTapPrisonerMappingIds(
         prisonerNumber,
-        idMappings = TemporaryAbsencesPrisonerMappingIdsDto(prisonerNumber, listOf(), listOf(), listOf()),
+        idMappings = TapPrisonerMappingIdsDto(prisonerNumber, listOf(), listOf(), listOf()),
       )
       // The prison on the application and schedules is LEI
       externalMovementsNomisApi.stubGetAllOffenderTaps(
         prisonerNumber,
-        response = temporaryAbsencesResponse(movementPrison = movementPrison),
+        response = offenderTapsResponse(movementPrison = movementPrison),
       )
       dpsApi.stubResyncPrisonerTaps(
         personIdentifier = prisonerNumber,
@@ -497,15 +496,15 @@ class TapMigrationIntTest(
         pageSize = 10,
         firstOffenderNo = prisonerNumber,
       )
-      mappingApi.stubCreateTemporaryAbsenceMapping()
-      mappingApi.stubGetTemporaryAbsenceMappingIds(
+      mappingApi.stubCreateTapPrisonerMappings()
+      mappingApi.stubGetTapPrisonerMappingIds(
         prisonerNumber,
-        idMappings = TemporaryAbsencesPrisonerMappingIdsDto(prisonerNumber, listOf(), listOf(), listOf()),
+        idMappings = TapPrisonerMappingIdsDto(prisonerNumber, listOf(), listOf(), listOf()),
       )
       // The application is approved, on an inactive booking, and is not active
       externalMovementsNomisApi.stubGetAllOffenderTaps(
         prisonerNumber,
-        response = temporaryAbsencesResponse(
+        response = offenderTapsResponse(
           activeBooking = true,
           latestBooking = false,
           tapApplications = listOf(
@@ -578,7 +577,7 @@ class TapMigrationIntTest(
       setupMigrationTest()
 
       stubMigrationDependencies(1)
-      mappingApi.stubCreateTemporaryAbsenceMappingFailureFollowedBySuccess()
+      mappingApi.stubCreateTapPrisonerMappingsFailureFollowedBySuccess()
       migrationId = performMigration()
     }
 
@@ -591,7 +590,7 @@ class TapMigrationIntTest(
     fun `will create mappings twice before succeeding`() {
       mappingApi.verify(
         2,
-        putRequestedFor(urlEqualTo("/mapping/temporary-absence/migrate"))
+        putRequestedFor(urlEqualTo("/mapping/taps/migrate"))
           .withRequestBodyJsonPath("prisonerNumber", "A0001KT")
           .withRequestBodyJsonPath("migrationId", migrationId),
       )
@@ -622,9 +621,9 @@ class TapMigrationIntTest(
         pageSize = 10,
         firstOffenderNo = "A0001KT",
       )
-      mappingApi.stubGetTemporaryAbsenceMappingIds(
+      mappingApi.stubGetTapPrisonerMappingIds(
         "A0001KT",
-        idMappings = TemporaryAbsencesPrisonerMappingIdsDto("A0001KT", listOf(), listOf(), listOf()),
+        idMappings = TapPrisonerMappingIdsDto("A0001KT", listOf(), listOf(), listOf()),
       )
       externalMovementsNomisApi.stubGetAllOffenderTaps(
         "A0001KT",
@@ -681,7 +680,7 @@ class TapMigrationIntTest(
       @Test
       fun `will create mappings`() {
         mappingApi.verify(
-          putRequestedFor(urlEqualTo("/mapping/temporary-absence/migrate"))
+          putRequestedFor(urlEqualTo("/mapping/taps/migrate"))
             .withRequestBodyJsonPath("prisonerNumber", "A0001KT"),
         )
       }
@@ -765,7 +764,7 @@ class TapMigrationIntTest(
       @Test
       fun `will update mappings`() {
         mappingApi.verify(
-          putRequestedFor(urlEqualTo("/mapping/temporary-absence/migrate"))
+          putRequestedFor(urlEqualTo("/mapping/taps/migrate"))
             .withRequestBodyJsonPath("prisonerNumber", "A0001KT")
             .withRequestBodyJsonPath("bookings.length()", 0),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMigrationTest.kt
@@ -4,19 +4,19 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.application
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.temporaryAbsencesResponse
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsencesPrisonerMappingIdsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.offenderTapsResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapPrisonerMappingIdsDto
 import java.time.LocalDate
 
 class TapMigrationTest {
 
-  private val someMappingIds = TemporaryAbsencesPrisonerMappingIdsDto("any", listOf(), listOf(), listOf())
+  private val someMappingIds = TapPrisonerMappingIdsDto("any", listOf(), listOf(), listOf())
 
   @Nested
   inner class ApplicationStatus {
     @Test
     fun `should set expired if approved scheduled, old booking not ended yet`() {
-      val nomisResponse = temporaryAbsencesResponse(
+      val nomisResponse = offenderTapsResponse(
         activeBooking = true,
         latestBooking = false,
         tapApplications = listOf(
@@ -35,7 +35,7 @@ class TapMigrationTest {
 
     @Test
     fun `should set expired if approved unscheduled, old booking not ended yet`() {
-      val nomisResponse = temporaryAbsencesResponse(
+      val nomisResponse = offenderTapsResponse(
         activeBooking = true,
         latestBooking = false,
         tapApplications = listOf(
@@ -54,7 +54,7 @@ class TapMigrationTest {
 
     @Test
     fun `should NOT set expired if active booking is true`() {
-      val nomisResponse = temporaryAbsencesResponse(
+      val nomisResponse = offenderTapsResponse(
         activeBooking = true,
         tapApplications = listOf(
           application(
@@ -72,7 +72,7 @@ class TapMigrationTest {
 
     @Test
     fun `should NOT set expired if application ended`() {
-      val nomisResponse = temporaryAbsencesResponse(
+      val nomisResponse = offenderTapsResponse(
         activeBooking = false,
         tapApplications = listOf(
           application(
@@ -90,7 +90,7 @@ class TapMigrationTest {
 
     @Test
     fun `should NOT set expired if application not approved`() {
-      val nomisResponse = temporaryAbsencesResponse(
+      val nomisResponse = offenderTapsResponse(
         activeBooking = false,
         tapApplications = listOf(
           application(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMoveBookingIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMoveBookingIntTest.kt
@@ -22,23 +22,22 @@ import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helper.bookingMovedDomainEvent
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.sendMessage
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiMockServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.MoveTemporaryAbsencesRequest
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapDpsApiExtension.Companion.dpsExtMovementsServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapDpsApiMockServer.Companion.getRequestBody
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.application
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.offenderTapsResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.tapMovementIn
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.tapMovementOut
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.taps
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.temporaryAbsencesResponse
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceApplicationIdMapping
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceMoveBookingMappingDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TemporaryAbsenceMovementIdMapping
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapApplicationIdMapping
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapMoveBookingMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.TapMovementIdMapping
 import uk.gov.justice.hmpps.sqs.countAllMessagesOnQueue
 import java.util.*
 
 class TapMoveBookingIntTest(
-  @Autowired private val mappingApi: ExternalMovementsMappingApiMockServer,
+  @Autowired private val mappingApi: TapMappingApiMockServer,
   @Autowired private val externalMovementsNomisApi: TapNomisApiMockServer,
 ) : SqsIntegrationTestBase() {
 
@@ -59,20 +58,20 @@ class TapMoveBookingIntTest(
     private val scheduledMovementId1 = UUID.randomUUID()
     private val scheduledMovementId2 = UUID.randomUUID()
 
-    private val moveBookingMappings = TemporaryAbsenceMoveBookingMappingDto(
+    private val moveBookingMappings = TapMoveBookingMappingDto(
       applicationIds = listOf(
-        TemporaryAbsenceApplicationIdMapping(applicationId1, authorisationId1),
-        TemporaryAbsenceApplicationIdMapping(applicationId2, authorisationId2),
+        TapApplicationIdMapping(applicationId1, authorisationId1),
+        TapApplicationIdMapping(applicationId2, authorisationId2),
       ),
       movementIds = listOf(
-        TemporaryAbsenceMovementIdMapping(movementSeq1, movementId1),
-        TemporaryAbsenceMovementIdMapping(movementSeq2, movementId2),
-        TemporaryAbsenceMovementIdMapping(scheduledMovementSeq1, scheduledMovementId1),
-        TemporaryAbsenceMovementIdMapping(scheduledMovementSeq2, scheduledMovementId2),
+        TapMovementIdMapping(movementSeq1, movementId1),
+        TapMovementIdMapping(movementSeq2, movementId2),
+        TapMovementIdMapping(scheduledMovementSeq1, scheduledMovementId1),
+        TapMovementIdMapping(scheduledMovementSeq2, scheduledMovementId2),
       ),
     )
 
-    private val nomisData = temporaryAbsencesResponse(
+    private val nomisData = offenderTapsResponse(
       bookingId = 1234567L,
       tapApplications = listOf(
         application(
@@ -120,7 +119,7 @@ class TapMoveBookingIntTest(
 
     @Test
     fun `should get move booking mappings`() {
-      mappingApi.verify(getRequestedFor(urlEqualTo("/mapping/temporary-absence/move-booking/1234567")))
+      mappingApi.verify(getRequestedFor(urlEqualTo("/mapping/taps/move-booking/1234567")))
     }
 
     @Test
@@ -137,7 +136,7 @@ class TapMoveBookingIntTest(
 
     @Test
     fun `should move mappings to the new offender no`() {
-      mappingApi.verify(putRequestedFor(urlEqualTo("/mapping/temporary-absence/move-booking/1234567/from/A1000KT/to/A1234KT")))
+      mappingApi.verify(putRequestedFor(urlEqualTo("/mapping/taps/move-booking/1234567/from/A1000KT/to/A1234KT")))
     }
 
     @Test
@@ -222,12 +221,12 @@ class TapMoveBookingIntTest(
 
   @Nested
   inner class NoMappingsExist {
-    private val moveBookingMappings = TemporaryAbsenceMoveBookingMappingDto(
+    private val moveBookingMappings = TapMoveBookingMappingDto(
       applicationIds = listOf(),
       movementIds = listOf(),
     )
 
-    private val nomisData = temporaryAbsencesResponse(
+    private val nomisData = offenderTapsResponse(
       bookingId = 1234567L,
       tapApplications = listOf(),
       unscheduledTapMovementOuts = listOf(),
@@ -258,7 +257,7 @@ class TapMoveBookingIntTest(
     fun `should NOT move mappings to the new offender no`() {
       mappingApi.verify(
         0,
-        putRequestedFor(urlEqualTo("/mapping/temporary-absence/move-booking/1234567/from/A1000KT/to/A1234KT")),
+        putRequestedFor(urlEqualTo("/mapping/taps/move-booking/1234567/from/A1000KT/to/A1234KT")),
       )
     }
 
@@ -281,12 +280,12 @@ class TapMoveBookingIntTest(
   inner class NomisMovementNotFoundInMappings {
     private val movementSeq1 = 1
 
-    private val moveBookingMappings = TemporaryAbsenceMoveBookingMappingDto(
+    private val moveBookingMappings = TapMoveBookingMappingDto(
       applicationIds = listOf(),
       movementIds = listOf(),
     )
 
-    private val nomisData = temporaryAbsencesResponse(
+    private val nomisData = offenderTapsResponse(
       bookingId = 1234567L,
       tapApplications = listOf(),
       unscheduledTapMovementOuts = listOf(tapMovementOut(seq = movementSeq1)),
@@ -317,7 +316,7 @@ class TapMoveBookingIntTest(
     fun `should NOT move mappings to the new offender no`() {
       mappingApi.verify(
         0,
-        putRequestedFor(urlEqualTo("/mapping/temporary-absence/move-booking/1234567/from/A1000KT/to/A1234KT")),
+        putRequestedFor(urlEqualTo("/mapping/taps/move-booking/1234567/from/A1000KT/to/A1234KT")),
       )
     }
 
@@ -343,12 +342,12 @@ class TapMoveBookingIntTest(
   inner class NomisApplicationNotFoundInMappings {
     private val applicationId1 = 1234L
 
-    private val moveBookingMappings = TemporaryAbsenceMoveBookingMappingDto(
+    private val moveBookingMappings = TapMoveBookingMappingDto(
       applicationIds = listOf(),
       movementIds = listOf(),
     )
 
-    private val nomisData = temporaryAbsencesResponse(
+    private val nomisData = offenderTapsResponse(
       bookingId = 1234567L,
       tapApplications = listOf(application(id = applicationId1)),
       unscheduledTapMovementOuts = listOf(),
@@ -379,7 +378,7 @@ class TapMoveBookingIntTest(
     fun `should NOT move mappings to the new offender no`() {
       mappingApi.verify(
         0,
-        putRequestedFor(urlEqualTo("/mapping/temporary-absence/move-booking/1234567/from/A1000KT/to/A1234KT")),
+        putRequestedFor(urlEqualTo("/mapping/taps/move-booking/1234567/from/A1000KT/to/A1234KT")),
       )
     }
 
@@ -405,14 +404,14 @@ class TapMoveBookingIntTest(
     private val applicationId1 = 1234L
     private val authorisationId1 = UUID.randomUUID()
 
-    private val moveBookingMappings = TemporaryAbsenceMoveBookingMappingDto(
+    private val moveBookingMappings = TapMoveBookingMappingDto(
       applicationIds = listOf(
-        TemporaryAbsenceApplicationIdMapping(applicationId1, authorisationId1),
+        TapApplicationIdMapping(applicationId1, authorisationId1),
       ),
       movementIds = listOf(),
     )
 
-    private val nomisData = temporaryAbsencesResponse(
+    private val nomisData = offenderTapsResponse(
       bookingId = 1234567L,
       tapApplications = listOf(
         application(
@@ -470,14 +469,14 @@ class TapMoveBookingIntTest(
     private val applicationId1 = 1234L
     private val authorisationId1 = UUID.randomUUID()
 
-    private val moveBookingMappings = TemporaryAbsenceMoveBookingMappingDto(
+    private val moveBookingMappings = TapMoveBookingMappingDto(
       applicationIds = listOf(
-        TemporaryAbsenceApplicationIdMapping(applicationId1, authorisationId1),
+        TapApplicationIdMapping(applicationId1, authorisationId1),
       ),
       movementIds = listOf(),
     )
 
-    private val nomisData = temporaryAbsencesResponse(
+    private val nomisData = offenderTapsResponse(
       bookingId = 1234567L,
       tapApplications = listOf(
         application(
@@ -518,7 +517,7 @@ class TapMoveBookingIntTest(
     fun `should move mappings to the new offender twice`() {
       mappingApi.verify(
         2,
-        putRequestedFor(urlEqualTo("/mapping/temporary-absence/move-booking/1234567/from/A1000KT/to/A1234KT")),
+        putRequestedFor(urlEqualTo("/mapping/taps/move-booking/1234567/from/A1000KT/to/A1234KT")),
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMovementIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapMovementIntTest.kt
@@ -22,7 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus.NOT_FOUND
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.sendMessage
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiMockServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncWriteTapMovement
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapDpsApiExtension.Companion.dpsExtMovementsServer
@@ -35,14 +34,14 @@ import java.util.*
 
 class TapMovementIntTest(
   @Autowired private val nomisApi: TapNomisApiMockServer,
-  @Autowired private val mappingApi: ExternalMovementsMappingApiMockServer,
+  @Autowired private val mappingApi: TapMappingApiMockServer,
 ) : SqsIntegrationTestBase() {
 
   private val dpsApi = dpsExtMovementsServer
 
   @Nested
   @DisplayName("EXTERNAL_MOVEMENT-CHANGED (inserted, scheduled)")
-  inner class TemporaryAbsenceScheduledExternalMovementCreated {
+  inner class TapOccurrenceCreated {
     private val dpsMovementId = UUID.randomUUID()
     private val dpsOccurrenceId = UUID.randomUUID()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapNomisApiMockServer.kt
@@ -32,7 +32,7 @@ class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
 
   fun stubGetAllOffenderTaps(
     offenderNo: String = "A1234BC",
-    response: OffenderTapsResponse = temporaryAbsencesResponse(),
+    response: OffenderTapsResponse = offenderTapsResponse(),
   ) {
     nomisApi.stubFor(
       get(urlPathEqualTo("/movements/$offenderNo/taps")).willReturn(
@@ -100,7 +100,7 @@ class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
     eventStatus: String = "COMP",
     toAddress: String = "to full address",
     toAddressId: Long = 321,
-    response: TapScheduleOut = scheduledTemporaryAbsenceResponse(
+    response: TapScheduleOut = tapScheduleOutResponse(
       startTime = eventTime,
       applicationId = applicationId,
       eventId = eventId,
@@ -204,7 +204,7 @@ class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
     private val yesterday = now.minusDays(1)
     private val tomorrow = now.plusDays(1)
 
-    fun scheduledTemporaryAbsenceResponse(
+    fun tapScheduleOutResponse(
       startTime: LocalDateTime = now,
       applicationId: Long = 111,
       eventId: Long = 1,
@@ -244,7 +244,7 @@ class TapNomisApiMockServer(private val jsonMapper: JsonMapper) {
       ),
     )
 
-    fun temporaryAbsencesResponse(
+    fun offenderTapsResponse(
       movementPrison: String = "LEI",
       bookingId: Long = 12345L,
       activeBooking: Boolean = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapNomisApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapNomisApiServiceTest.kt
@@ -57,7 +57,7 @@ class TapNomisApiServiceTest {
     }
 
     @Test
-    fun `will return temporary absences`() = runTest {
+    fun `will return offender taps`() = runTest {
       tapNomisApiMockServer.stubGetAllOffenderTaps(offenderNo = "A1234BC")
 
       val result = apiService.getAllOffenderTapsOrNull(offenderNo = "A1234BC")!!
@@ -91,7 +91,7 @@ class TapNomisApiServiceTest {
   }
 
   @Nested
-  inner class GetTemporaryAbsenceApplication {
+  inner class GetTapApplication {
     @Test
     internal fun `will pass oath2 token to service`() = runTest {
       tapNomisApiMockServer.stubGetTapApplication(offenderNo = "A1234BC", applicationId = 111)
@@ -115,7 +115,7 @@ class TapNomisApiServiceTest {
     }
 
     @Test
-    fun `will return temporary absence application`() = runTest {
+    fun `will return tap application`() = runTest {
       tapNomisApiMockServer.stubGetTapApplication(offenderNo = "A1234BC", applicationId = 111)
 
       apiService.getTapApplication(offenderNo = "A1234BC", applicationId = 111)
@@ -150,7 +150,7 @@ class TapNomisApiServiceTest {
   }
 
   @Nested
-  inner class GetTemporaryAbsenceScheduledMovement {
+  inner class GetTapSchedule {
     @Test
     internal fun `will pass oath2 token to service`() = runTest {
       tapNomisApiMockServer.stubGetTapScheduleOut(offenderNo = "A1234BC", eventId = 1)
@@ -174,7 +174,7 @@ class TapNomisApiServiceTest {
     }
 
     @Test
-    fun `will return scheduled temporary absence`() = runTest {
+    fun `will return tap schedule out`() = runTest {
       tapNomisApiMockServer.stubGetTapScheduleOut(offenderNo = "A1234BC", eventId = 1)
 
       apiService.getTapScheduleOut(offenderNo = "A1234BC", eventId = 1)
@@ -211,7 +211,7 @@ class TapNomisApiServiceTest {
   }
 
   @Nested
-  inner class GetTemporaryAbsenceMovement {
+  inner class GetTapMovement {
     @Test
     internal fun `will pass oath2 token to service`() = runTest {
       tapNomisApiMockServer.stubGetTapMovementOut(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
@@ -235,7 +235,7 @@ class TapNomisApiServiceTest {
     }
 
     @Test
-    fun `will return temporary absence`() = runTest {
+    fun `will return tap movement out`() = runTest {
       tapNomisApiMockServer.stubGetTapMovementOut(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
 
       apiService.getTapMovementOut(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
@@ -262,7 +262,7 @@ class TapNomisApiServiceTest {
     }
 
     @Test
-    fun `will return unscheduled temporary absence`() = runTest {
+    fun `will return unscheduled tap movement out`() = runTest {
       tapNomisApiMockServer.stubGetTapMovementOut(
         offenderNo = "A1234BC",
         bookingId = 12345,
@@ -300,7 +300,7 @@ class TapNomisApiServiceTest {
   }
 
   @Nested
-  inner class TemporaryAbsenceReturnMovementTest {
+  inner class TapMovementInTest {
     @Test
     fun `will call the correct endpoint`() = runTest {
       tapNomisApiMockServer.stubGetTapMovementIn(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
@@ -313,7 +313,7 @@ class TapNomisApiServiceTest {
     }
 
     @Test
-    fun `will return temporary absence return`() = runTest {
+    fun `will return tap movement in`() = runTest {
       tapNomisApiMockServer.stubGetTapMovementIn(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
 
       apiService.getTapMovementIn(offenderNo = "A1234BC", bookingId = 12345, movementSeq = 1)
@@ -337,7 +337,7 @@ class TapNomisApiServiceTest {
     }
 
     @Test
-    fun `will return unscheduled temporary absence return`() = runTest {
+    fun `will return unscheduled tap movement in`() = runTest {
       tapNomisApiMockServer.stubGetTapMovementIn(
         offenderNo = "A1234BC",
         bookingId = 12345,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapScheduleIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapScheduleIntTest.kt
@@ -27,7 +27,6 @@ import org.springframework.boot.test.system.CapturedOutput
 import org.springframework.http.HttpStatus.NOT_FOUND
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.sendMessage
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.ExternalMovementsMappingApiMockServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.SyncWriteTapOccurrence
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapDpsApiExtension.Companion.dpsExtMovementsServer
@@ -42,7 +41,7 @@ import java.util.*
 
 class TapScheduleIntTest(
   @Autowired private val nomisApi: TapNomisApiMockServer,
-  @Autowired private val mappingApi: ExternalMovementsMappingApiMockServer,
+  @Autowired private val mappingApi: TapMappingApiMockServer,
 ) : SqsIntegrationTestBase() {
 
   private val dpsApi = dpsExtMovementsServer

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/taps/TapScheduleServiceTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.model.Location
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.scheduledTemporaryAbsenceResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapNomisApiMockServer.Companion.tapScheduleOutResponse
 
 class TapScheduleServiceTest {
 
@@ -15,7 +15,7 @@ class TapScheduleServiceTest {
 
     @Test
     fun `should default escort code if null`() {
-      val nomis = scheduledTemporaryAbsenceResponse().copy(
+      val nomis = tapScheduleOutResponse().copy(
         escort = null,
       )
 
@@ -26,7 +26,7 @@ class TapScheduleServiceTest {
 
     @Test
     fun `should default transport type code if null`() {
-      val nomis = scheduledTemporaryAbsenceResponse().copy(
+      val nomis = tapScheduleOutResponse().copy(
         transportType = null,
       )
 
@@ -38,7 +38,7 @@ class TapScheduleServiceTest {
 
   @Test
   fun `should send cancelled flag`() {
-    val nomis = scheduledTemporaryAbsenceResponse().copy(
+    val nomis = tapScheduleOutResponse().copy(
       eventStatus = "CANC",
     )
 
@@ -53,7 +53,7 @@ class TapScheduleServiceTest {
 
     @Test
     fun `should send cancelled flag`() {
-      val nomis = scheduledTemporaryAbsenceResponse().copy(
+      val nomis = tapScheduleOutResponse().copy(
         eventStatus = "CANC",
       )
 


### PR DESCRIPTION
Refactor to switch to the new TAP mapping API and model. There should be no functional changes.