### PR TITLE
SDIT-3731 Implement happy path for migrating court movements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingMappingApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingMappingApiService.kt
@@ -116,6 +116,14 @@ class CourtSentencingMappingApiService(
     .retrieve()
     .awaitBody()
 
+  suspend fun getAllCourtAppearancesByNomisIds(courtAppearanceIds: List<Long>): List<CourtAppearanceMappingDto> = webClient.post()
+    .uri(
+      "/mapping/court-sentencing/court-appearances/nomis-court-appearance-ids/get-list",
+    )
+    .bodyValue(courtAppearanceIds)
+    .retrieve()
+    .awaitBody()
+
   suspend fun createCourtAppearanceMapping(
     mapping: CourtAppearanceMappingDto,
   ): CreateMappingResult<CourtAppearanceMappingDto> = webClient.post()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerHelpers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerHelpers.kt
@@ -1,3 +1,5 @@
 package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court
 
 const val CRT_TELEMETRY_PREFIX: String = "court-scheduler-sync"
+const val EXTERNAL_REF_PREFIX = "urn:remand-and-sentencing:court-appearance:"
+const val MISSING_COURT: String = "NULL"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationService.kt
@@ -1,0 +1,237 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.config.trackEvent
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.AtAndBy
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.CourtEvent
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.CourtEventMovement
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.ResyncCourtEvent
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.ResyncCourtEventMovement
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.ResyncCourtEvents
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.ResyncResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtsentencing.CourtSentencingMappingApiService
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.data.MigrationContext
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.DuplicateErrorResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.BookingCourtMovementMappingsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.BookingCourtScheduleMappingsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtAppearanceMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtSchedulerBookingMappingsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtSchedulerPrisonerMappingIdsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtSchedulerPrisonerMappingsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingCourtMovementIn
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingCourtMovementOut
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.OffenderCourtMovementsResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.PrisonerId
+
+@Service
+class CourtSchedulerMigrationService(
+  private val nomisApi: CourtSchedulerNomisApiService,
+  private val mappingApi: CourtSchedulerMappingApiService,
+  private val sentencingMappingApi: CourtSentencingMappingApiService,
+  private val dpsApi: CourtSchedulerDpsApiService,
+  private val telemetryClient: TelemetryClient,
+) {
+
+  suspend fun migrateNomisEntity(context: MigrationContext<PrisonerId>) {
+    val offenderNo = context.body.offenderNo
+    val migrationId = context.migrationId
+    val telemetry = mutableMapOf(
+      "offenderNo" to offenderNo,
+      "migrationId" to migrationId,
+    )
+
+    val offenderCourtMovements = nomisApi.getOffenderCourtMovementsOrNull(offenderNo)
+      ?: OffenderCourtMovementsResponse(bookings = listOf())
+    val oldMappingIds = mappingApi.getCourtSchedulerPrisonMappingIds(offenderNo)
+    val courtSentencingMappings = offenderCourtMovements.findCourtAppearanceIds()
+      .let { courtAppearanceIds -> sentencingMappingApi.getAllCourtAppearancesByNomisIds(courtAppearanceIds) }
+    val dpsResponse = dpsApi.resyncPrisoner(offenderNo, offenderCourtMovements.toDpsRequest(oldMappingIds, courtSentencingMappings))
+      ?: ResyncResponse(listOf(), listOf())
+    val mappings = offenderCourtMovements.buildMappings(offenderNo, migrationId, dpsResponse)
+
+    createMappingOrOnFailureDo(mappings) {}
+  }
+
+  private suspend fun createMappingOrOnFailureDo(
+    mapping: CourtSchedulerPrisonerMappingsDto,
+    failureHandler: suspend (error: Throwable) -> Unit,
+  ) {
+    runCatching {
+      createMapping(mapping)
+    }.onSuccess {
+      publishTelemetry(
+        if (it.isError) "duplicate" else "migrated",
+        mapOf(
+          "offenderNo" to mapping.offenderNo,
+          "migrationId" to mapping.migrationId,
+        ),
+      )
+    }.onFailure {
+      failureHandler(it)
+    }
+  }
+
+  private suspend fun createMapping(mapping: CourtSchedulerPrisonerMappingsDto) = mappingApi.createMapping(
+    mapping,
+    object :
+      ParameterizedTypeReference<DuplicateErrorResponse<CourtSchedulerPrisonerMappingsDto>>() {},
+  )
+
+  private fun publishTelemetry(type: String, telemetry: Map<String, String>) {
+    telemetryClient.trackEvent(
+      "temporary-absences-migration-entity-$type",
+      telemetry,
+    )
+  }
+}
+
+private fun OffenderCourtMovementsResponse.findCourtAppearanceIds(): List<Long> = bookings
+  .flatMap { booking ->
+    booking.courtSchedules
+      .filter { schedule -> schedule.courtCaseId != null }
+      .map { schedule -> schedule.eventId }
+  }
+
+fun OffenderCourtMovementsResponse.toDpsRequest(
+  oldMappingIds: CourtSchedulerPrisonerMappingIdsDto,
+  sentencingMappings: List<CourtAppearanceMappingDto>,
+) = ResyncCourtEvents(
+  courtEvents = bookings.flatMap { booking ->
+    booking.courtSchedules.map { schedule ->
+      ResyncCourtEvent(
+        courtEvent = CourtEvent(
+          dpsId = oldMappingIds.schedules.find { it.nomisEventId == schedule.eventId }?.dpsCourtAppearanceId,
+          prisonCodeAtTimeOfScheduling = schedule.prison,
+          agyLocId = schedule.court,
+          eventDate = schedule.eventDate,
+          startTime = "${schedule.startTime}",
+          courtEventType = schedule.eventType,
+          eventStatus = schedule.eventStatus,
+          eventId = schedule.eventId,
+          commentText = schedule.comment,
+          externalReferenceUrn = sentencingMappings.find { it.nomisCourtAppearanceId == schedule.eventId }
+            ?.dpsCourtAppearanceId
+            ?.let { "$EXTERNAL_REF_PREFIX$it" },
+        ),
+        created = AtAndBy(schedule.audit.createDatetime, schedule.audit.createUsername),
+        modified = schedule.audit.modifyDatetime?.let { AtAndBy(schedule.audit.modifyDatetime, schedule.audit.modifyUserId!!) },
+        movements = listOfNotNull(
+          schedule.courtMovementOut?.toDpsRequest(oldMappingIds, booking.bookingId, schedule.eventId),
+          schedule.courtMovementIn?.toDpsRequest(oldMappingIds, booking.bookingId, schedule.eventId),
+        ),
+      )
+    }
+  },
+  unscheduledMovements = bookings.flatMap { booking ->
+    booking.unscheduledCourtMovementOuts.map { movementOut ->
+      movementOut.toDpsRequest(oldMappingIds, booking.bookingId, null)
+    } +
+      booking.unscheduledCourtMovementIns.map { movementIn ->
+        movementIn.toDpsRequest(oldMappingIds, booking.bookingId, null)
+      }
+  },
+)
+
+private fun BookingCourtMovementOut.toDpsRequest(
+  oldMappingIds: CourtSchedulerPrisonerMappingIdsDto,
+  bookingId: Long,
+  eventId: Long?,
+): ResyncCourtEventMovement = ResyncCourtEventMovement(
+  movement = CourtEventMovement(
+    dpsId = oldMappingIds.movements.find { it.nomisBookingId == bookingId && it.nomisMovementSeq == sequence }?.dpsCourtMovementId,
+    movementDate = movementDate,
+    movementTime = "$movementTime",
+    movementReasonCode = movementReason,
+    directionCode = "OUT",
+    fromAgencyId = fromPrison,
+    toAgencyId = toCourt ?: MISSING_COURT,
+    dpsCourtAppearanceScheduleId = oldMappingIds.schedules.find { it.nomisEventId == eventId }?.dpsCourtAppearanceId,
+    offenderBookId = bookingId,
+    movementSeq = sequence,
+    commentText = commentText,
+  ),
+  created = AtAndBy(audit.createDatetime, audit.createUsername),
+  modified = audit.modifyDatetime?.let {
+    AtAndBy(
+      audit.modifyDatetime,
+      audit.modifyUserId!!,
+    )
+  },
+)
+
+private fun BookingCourtMovementIn.toDpsRequest(
+  oldMappingIds: CourtSchedulerPrisonerMappingIdsDto,
+  bookingId: Long,
+  eventId: Long?,
+): ResyncCourtEventMovement = ResyncCourtEventMovement(
+  movement = CourtEventMovement(
+    dpsId = oldMappingIds.movements.find { it.nomisBookingId == bookingId && it.nomisMovementSeq == sequence }?.dpsCourtMovementId,
+    movementDate = movementDate,
+    movementTime = "$movementTime",
+    movementReasonCode = movementReason,
+    directionCode = "IN",
+    fromAgencyId = fromCourt ?: MISSING_COURT,
+    toAgencyId = toPrison,
+    dpsCourtAppearanceScheduleId = oldMappingIds.schedules.find { it.nomisEventId == eventId }?.dpsCourtAppearanceId,
+    offenderBookId = bookingId,
+    movementSeq = sequence,
+    commentText = commentText,
+  ),
+  created = AtAndBy(audit.createDatetime, audit.createUsername),
+  modified = audit.modifyDatetime?.let {
+    AtAndBy(
+      audit.modifyDatetime,
+      audit.modifyUserId!!,
+    )
+  },
+)
+
+private fun OffenderCourtMovementsResponse.buildMappings(offenderNo: String, migrationId: String, dpsResponse: ResyncResponse) = CourtSchedulerPrisonerMappingsDto(
+  offenderNo = offenderNo,
+  migrationId = migrationId,
+  bookings = bookings.map { booking ->
+    CourtSchedulerBookingMappingsDto(
+      bookingId = booking.bookingId,
+      courtSchedules = booking.courtSchedules.map { schedule ->
+        BookingCourtScheduleMappingsDto(
+          nomisEventId = schedule.eventId,
+          dpsCourtAppearanceId = dpsResponse.findDpsId(schedule.eventId),
+          movements = listOfNotNull(
+            schedule.courtMovementOut?.buildMapping(booking.bookingId, dpsResponse),
+            schedule.courtMovementIn?.buildMapping(booking.bookingId, dpsResponse),
+          ),
+        )
+      },
+      unscheduledMovements = booking.unscheduledCourtMovementOuts.map { it.buildUnscheduleMapping(booking.bookingId, dpsResponse) } +
+        booking.unscheduledCourtMovementIns.map { it.buildUnscheduledMapping(booking.bookingId, dpsResponse) },
+    )
+  },
+)
+
+private fun BookingCourtMovementOut.buildMapping(bookingId: Long, dpsResponse: ResyncResponse) = BookingCourtMovementMappingsDto(
+  nomisMovementSeq = sequence,
+  dpsCourtMovementId = dpsResponse.findScheduleMovementDpsId(bookingId, sequence),
+)
+
+private fun BookingCourtMovementIn.buildMapping(bookingId: Long, dpsResponse: ResyncResponse) = BookingCourtMovementMappingsDto(
+  nomisMovementSeq = sequence,
+  dpsCourtMovementId = dpsResponse.findScheduleMovementDpsId(bookingId, sequence),
+)
+
+private fun BookingCourtMovementOut.buildUnscheduleMapping(bookingId: Long, dpsResponse: ResyncResponse) = BookingCourtMovementMappingsDto(
+  nomisMovementSeq = sequence,
+  dpsCourtMovementId = dpsResponse.findUnscheduleMovementDpsId(bookingId, sequence),
+)
+
+private fun BookingCourtMovementIn.buildUnscheduledMapping(bookingId: Long, dpsResponse: ResyncResponse) = BookingCourtMovementMappingsDto(
+  nomisMovementSeq = sequence,
+  dpsCourtMovementId = dpsResponse.findUnscheduleMovementDpsId(bookingId, sequence),
+)
+
+private fun ResyncResponse.findDpsId(eventId: Long) = courtEvents.first { mapping -> mapping.eventId == eventId }.dpsId
+
+private fun ResyncResponse.findScheduleMovementDpsId(bookingId: Long, movementSeq: Int) = courtEvents.flatMap { it.movements }.first { mapping -> mapping.offenderBookId == bookingId && mapping.movementSeq == movementSeq }.dpsId
+
+private fun ResyncResponse.findUnscheduleMovementDpsId(bookingId: Long, movementSeq: Int) = unscheduledMovements.first { mapping -> mapping.offenderBookId == bookingId && mapping.movementSeq == movementSeq }.dpsId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerSyncMovementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerSyncMovementService.kt
@@ -28,7 +28,6 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.Synchroni
 import java.util.*
 
 private const val TELEMETRY_PREFIX: String = "${CRT_TELEMETRY_PREFIX}-movement"
-private const val MISSING_COURT: String = "NULL"
 
 @Service
 class CourtSchedulerSyncMovementService(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingMappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingMappingApiMockServer.kt
@@ -314,6 +314,46 @@ class CourtSentencingMappingApiMockServer(private val jsonMapper: JsonMapper) {
     )
   }
 
+  fun stubGetAllCourtAppearanceByNomisIds(
+    nomisCourtAppearanceIds: List<Long> = listOf(123, 456),
+    dpsCourtAppearanceIds: List<String> = listOf(UUID.randomUUID().toString(), UUID.randomUUID().toString()),
+    mappings: List<CourtAppearanceMappingDto> = listOf(
+      CourtAppearanceMappingDto(
+        nomisCourtAppearanceId = nomisCourtAppearanceIds[0],
+        dpsCourtAppearanceId = dpsCourtAppearanceIds[0],
+        mappingType = CourtAppearanceMappingDto.MappingType.MIGRATED,
+      ),
+      CourtAppearanceMappingDto(
+        nomisCourtAppearanceId = nomisCourtAppearanceIds[1],
+        dpsCourtAppearanceId = dpsCourtAppearanceIds[1],
+        mappingType = CourtAppearanceMappingDto.MappingType.MIGRATED,
+      ),
+    ),
+  ) {
+    mappingApi.stubFor(
+      post(urlEqualTo("/mapping/court-sentencing/court-appearances/nomis-court-appearance-ids/get-list")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(HttpStatus.OK.value())
+          .withBody(jsonMapper.writeValueAsString(mappings)),
+      ),
+    )
+  }
+
+  fun stubGetAllCourtAppearanceByNomisIds(
+    status: HttpStatus,
+    error: ErrorResponse = ErrorResponse(status = status.value()),
+  ) {
+    mappingApi.stubFor(
+      post(urlPathMatching("/mapping/court-sentencing/court-appearances/nomis-court-appearance-ids/get-list")).willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withStatus(status.value())
+          .withBody(jsonMapper.writeValueAsString(error)),
+      ),
+    )
+  }
+
   fun stubPostCourtAppearanceMapping() {
     mappingApi.stubFor(
       post("/mapping/court-sentencing/court-appearances").willReturn(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingMappingApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingMappingApiServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtsentencing
 
 import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
@@ -23,6 +24,7 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.histo
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtCaseAllMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtCaseBatchMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtCaseMappingDto
+import java.util.*
 
 private const val NOMIS_COURT_CASE_ID = 1234L
 private const val DPS_COURT_CASE_ID = "cc1"
@@ -186,6 +188,56 @@ class CourtSentencingMappingApiServiceTest {
         putRequestedFor(urlPathEqualTo("/mapping/court-sentencing/court-cases/replace"))
           .withRequestBody(matchingJsonPath("mappingType", equalTo("DPS_CREATED"))),
       )
+    }
+  }
+
+  @Nested
+  inner class GetAllCourtAppearancesByNomisIds {
+    @Test
+    internal fun `will pass oath2 token to service`() = runTest {
+      courtSentencingMappingApiMockServer.stubGetAllCourtAppearanceByNomisIds()
+
+      apiService.getAllCourtAppearancesByNomisIds(listOf(123, 456))
+
+      courtSentencingMappingApiMockServer.verify(
+        postRequestedFor(anyUrl()).withHeader("Authorization", equalTo("Bearer ABCDE")),
+      )
+    }
+
+    @Test
+    internal fun `will pass requested IDs to service`() = runTest {
+      courtSentencingMappingApiMockServer.stubGetAllCourtAppearanceByNomisIds()
+
+      apiService.getAllCourtAppearancesByNomisIds(listOf(123, 456))
+
+      courtSentencingMappingApiMockServer.verify(
+        postRequestedFor(urlPathEqualTo("/mapping/court-sentencing/court-appearances/nomis-court-appearance-ids/get-list")).withHeader("Authorization", equalTo("Bearer ABCDE"))
+          .withRequestBody(equalToJson("[123, 456]")),
+      )
+    }
+
+    @Test
+    internal fun `will parse response`() = runTest {
+      val dpsId1 = UUID.randomUUID().toString()
+      val dpsId2 = UUID.randomUUID().toString()
+      courtSentencingMappingApiMockServer.stubGetAllCourtAppearanceByNomisIds(
+        dpsCourtAppearanceIds = listOf(dpsId1, dpsId2),
+      )
+
+      with(apiService.getAllCourtAppearancesByNomisIds(listOf(123, 456))) {
+        assertThat(this).hasSize(2)
+        assertThat(this[0].dpsCourtAppearanceId).isEqualTo(dpsId1)
+        assertThat(this[1].dpsCourtAppearanceId).isEqualTo(dpsId2)
+      }
+    }
+
+    @Test
+    internal fun `will throw if error`() = runTest {
+      courtSentencingMappingApiMockServer.stubGetAllCourtAppearanceByNomisIds(status = INTERNAL_SERVER_ERROR)
+
+      assertThrows<WebClientResponseException.InternalServerError> {
+        apiService.getAllCourtAppearancesByNomisIds(listOf(123, 456))
+      }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/MigrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/MigrationTestBase.kt
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.coreperson.CorePersonCprApiExtension
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.csra.CsraApiExtension
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.finance.FinanceApiExtension
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerDpsApiExtension
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapDpsApiExtension
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.officialvisits.OfficialVisitsDpsApiExtension
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.persistence.repository.MigrationHistoryRepository
@@ -28,6 +29,7 @@ class MigrationTestBase : SqsIntegrationTestBase() {
     OfficialVisitsDpsApiExtension.resetAndDisableResetBeforeEach()
     CsraApiExtension.resetAndDisableResetBeforeEach()
     TapDpsApiExtension.resetAndDisableResetBeforeEach()
+    CourtSchedulerDpsApiExtension.resetAndDisableResetBeforeEach()
 
     reset(telemetryClient)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationIntTest.kt
@@ -1,0 +1,200 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court
+
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.mockito.kotlin.reset
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.ResyncCourtEvents
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtsentencing.CourtSentencingMappingApiMockServer
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.data.MigrationContext
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.data.generateBatchId
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.MigrationTestBase
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerDpsApiExtension.Companion.dpsCourtSchedulerServer
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerDpsApiMockServer.Companion.resyncResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtAppearanceMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtSchedulerPrisonerMappingsDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.PrisonerId
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationType
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.NomisApiExtension
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+import java.util.*
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CourtSchedulerMigrationIntTest(
+  @Autowired private val nomisApi: CourtSchedulerNomisApiMockServer,
+  @Autowired private val mappingApi: CourtSchedulerMappingApiMockServer,
+  @Autowired private val sentencingMappingApi: CourtSentencingMappingApiMockServer,
+  @Autowired private val migrationService: CourtSchedulerMigrationService,
+) : MigrationTestBase() {
+
+  private val dpsApi = dpsCourtSchedulerServer
+
+  private val dpsCourtScheduleId = UUID.randomUUID()
+  private val dpsScheduledMovementOutId = UUID.randomUUID()
+  private val dpsScheduledMovementInId = UUID.randomUUID()
+  private val dpsUnscheduledMovementOutId = UUID.randomUUID()
+  private val dpsUnscheduledMovementInId = UUID.randomUUID()
+  private val dpsSentencingCourtAppearanceId = UUID.randomUUID()
+
+  @AfterAll
+  fun tearDownTelemetryClient() = reset(telemetryClient)
+
+  private fun stubMigrationDependencies(entities: Int = 2) {
+    NomisApiExtension.nomisApi.stubGetPrisonerIds(totalElements = entities.toLong(), pageSize = 10, firstOffenderNo = "A0001KT")
+    mappingApi.stubCreateCourtSchedulerPrisonerMappings()
+    (1..entities)
+      .map { index -> "A%04dKT".format(index) }
+      .forEach { prisonerNumber ->
+        mappingApi.stubGetCourtSchedulerPrisonerMappingIds(prisonerNumber, 12345L, 1, dpsCourtScheduleId, 3, dpsScheduledMovementOutId, 4, dpsScheduledMovementInId, 1, dpsUnscheduledMovementOutId, 2, dpsUnscheduledMovementInId)
+        nomisApi.stubGetOffenderCourtMovements(prisonerNumber)
+        sentencingMappingApi.stubGetAllCourtAppearanceByNomisIds(
+          mappings = listOf(CourtAppearanceMappingDto(1, dpsSentencingCourtAppearanceId.toString(), "any", CourtAppearanceMappingDto.MappingType.MIGRATED)),
+        )
+        dpsApi.stubResyncPrisonerCourtAppearances(
+          personIdentifier = prisonerNumber,
+          response = resyncResponse(dpsCourtScheduleId, dpsScheduledMovementOutId, dpsScheduledMovementInId, dpsUnscheduledMovementOutId, dpsUnscheduledMovementInId),
+        )
+      }
+  }
+
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  inner class MigrateEntity {
+    @BeforeAll
+    fun setUp() = runTest {
+      setupMigrationTest()
+
+      stubMigrationDependencies(entities = 1)
+      // TODO expand this to process messages - just implementing the basic migration service for now
+      migrationService.migrateNomisEntity(
+        MigrationContext(
+          MigrationType.EXTERNAL_MOVEMENTS,
+          generateBatchId(),
+          1,
+          PrisonerId("A0001KT"),
+          mutableMapOf(),
+        ),
+      )
+    }
+
+    @Test
+    fun `should check for existing mappings`() {
+      mappingApi.verify(getRequestedFor(urlPathEqualTo("/mapping/court/A0001KT/ids")))
+    }
+
+    @Test
+    fun `should get NOMIS court movement details`() {
+      nomisApi.verify(getRequestedFor(urlPathEqualTo("/movements/A0001KT/court")))
+    }
+
+    @Test
+    fun `should get RaS court sentencing mappings`() {
+      sentencingMappingApi.verify(
+        postRequestedFor(urlPathEqualTo("/mapping/court-sentencing/court-appearances/nomis-court-appearance-ids/get-list")),
+      )
+    }
+
+    @Test
+    fun `should call DPS resync API`() {
+      dpsApi.verify(putRequestedFor(urlPathEqualTo("/resync/court-appearances/A0001KT")))
+    }
+
+    @Test
+    fun `should populate DPS court appearance`() {
+      CourtSchedulerDpsApiMockServer.getRequestBody<ResyncCourtEvents>(
+        putRequestedFor(urlPathEqualTo("/resync/court-appearances/A0001KT")),
+      ).apply {
+        with(courtEvents[0].courtEvent) {
+          assertThat(dpsId).isEqualTo(dpsCourtScheduleId)
+          assertThat(eventId).isEqualTo(1)
+          assertThat(prisonCodeAtTimeOfScheduling).isEqualTo("BXI")
+          assertThat(eventDate).isEqualTo(LocalDate.now().minusDays(1))
+          assertThat(LocalDateTime.parse(startTime)).isCloseTo(LocalDateTime.now().minusDays(1), within(5, ChronoUnit.MINUTES))
+          assertThat(courtEventType).isEqualTo("CRT")
+          assertThat(eventStatus).isEqualTo("COMP")
+          assertThat(commentText).isEqualTo("Some schedule comment")
+          assertThat(externalReferenceUrn).isEqualTo("$EXTERNAL_REF_PREFIX$dpsSentencingCourtAppearanceId")
+        }
+        with(courtEvents[0].created) {
+          assertThat(by).isEqualTo("USER")
+          assertThat(at).isCloseTo(LocalDateTime.now().minusDays(1), within(5, ChronoUnit.MINUTES))
+        }
+        assertThat(courtEvents[0].modified).isNull()
+      }
+    }
+
+    @Test
+    fun `should populate DPS court movement`() {
+      CourtSchedulerDpsApiMockServer.getRequestBody<ResyncCourtEvents>(
+        putRequestedFor(urlPathEqualTo("/resync/court-appearances/A0001KT")),
+      ).apply {
+        with(courtEvents[0].movements[0].movement) {
+          assertThat(dpsId).isEqualTo(dpsScheduledMovementOutId)
+          assertThat(offenderBookId).isEqualTo(12345)
+          assertThat(movementSeq).isEqualTo(3)
+          assertThat(movementDate).isEqualTo(LocalDate.now().minusDays(1))
+          assertThat(LocalDateTime.parse(movementTime)).isCloseTo(LocalDateTime.now().minusDays(1), within(5, ChronoUnit.MINUTES))
+          assertThat(movementReasonCode).isEqualTo("CRT")
+          assertThat(fromAgencyId).isEqualTo("BXI")
+          assertThat(toAgencyId).isEqualTo("LEEDMC")
+          assertThat(commentText).isEqualTo("Some movement out comment")
+        }
+        with(courtEvents[0].movements[0].created) {
+          assertThat(by).isEqualTo("USER")
+          assertThat(at).isCloseTo(LocalDateTime.now().minusDays(1), within(5, ChronoUnit.MINUTES))
+        }
+        assertThat(courtEvents[0].movements[0].modified).isNull()
+      }
+    }
+
+    @Test
+    fun `should send all movements`() {
+      CourtSchedulerDpsApiMockServer.getRequestBody<ResyncCourtEvents>(
+        putRequestedFor(urlPathEqualTo("/resync/court-appearances/A0001KT")),
+      ).apply {
+        assertThat(courtEvents[0].movements.size).isEqualTo(2)
+        assertThat(courtEvents[0].movements[0].movement.movementSeq).isEqualTo(3)
+        assertThat(courtEvents[0].movements[1].movement.movementSeq).isEqualTo(4)
+        assertThat(unscheduledMovements.size).isEqualTo(2)
+        assertThat(unscheduledMovements[0].movement.movementSeq).isEqualTo(1)
+        assertThat(unscheduledMovements[1].movement.movementSeq).isEqualTo(2)
+      }
+    }
+
+    @Test
+    fun `should update mappings`() {
+      CourtSchedulerMappingApiMockServer.getRequestBody<CourtSchedulerPrisonerMappingsDto>(
+        putRequestedFor(urlPathEqualTo("/mapping/court/migrate")),
+      ).apply {
+        assertThat(offenderNo).isEqualTo("A0001KT")
+        with(bookings[0]) {
+          assertThat(bookingId).isEqualTo(12345)
+          with(courtSchedules[0]) {
+            assertThat(nomisEventId).isEqualTo(1)
+            assertThat(dpsCourtAppearanceId).isEqualTo(dpsCourtScheduleId)
+            assertThat(movements[0].nomisMovementSeq).isEqualTo(3)
+            assertThat(movements[0].dpsCourtMovementId).isEqualTo(dpsScheduledMovementOutId)
+            assertThat(movements[1].nomisMovementSeq).isEqualTo(4)
+            assertThat(movements[1].dpsCourtMovementId).isEqualTo(dpsScheduledMovementInId)
+          }
+          assertThat(unscheduledMovements[0].nomisMovementSeq).isEqualTo(1)
+          assertThat(unscheduledMovements[0].dpsCourtMovementId).isEqualTo(dpsUnscheduledMovementOutId)
+          assertThat(unscheduledMovements[1].nomisMovementSeq).isEqualTo(2)
+          assertThat(unscheduledMovements[1].dpsCourtMovementId).isEqualTo(dpsUnscheduledMovementInId)
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerNomisApiMockServer.kt
@@ -243,7 +243,7 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
     )
 
     fun bookingCourtSchedule() = BookingCourtScheduleOut(
-      eventId = 67890L,
+      eventId = 1,
       eventDate = yesterday.toLocalDate(),
       startTime = yesterday,
       eventType = "CRT",


### PR DESCRIPTION
This PR builds out the main transformation for migrating a single prisoner's court movements to DPS and saving the mappings. The next steps will be something like:

* add message handling and telemetry
* add error handling and some negative tests
* add an endpoint to migrate a single prisoner