### PR TITLE
SDIT-3731 Add court migration message handling

### DIFF
--- a/helm_deploy/hmpps-prisoner-from-nomis-migration/values.yaml
+++ b/helm_deploy/hmpps-prisoner-from-nomis-migration/values.yaml
@@ -121,6 +121,10 @@ generic-service:
      HMPPS_SQS_QUEUES_MIGRATIONPRISONERBALANCE_QUEUE_NAME: "sqs_name"
     sqs-migration-prisonerbalance-dlq:
       HMPPS_SQS_QUEUES_MIGRATIONPRISONERBALANCE_DLQ_NAME: "sqs_name"
+    sqs-migration-courtmovements-queue:
+      HMPPS_SQS_QUEUES_MIGRATIONCOURTMOVEMENTS_QUEUE_NAME: "sqs_name"
+    sqs-migration-courtmovements-dlq:
+      HMPPS_SQS_QUEUES_MIGRATIONCOURTMOVEMENTS_DLQ_NAME: "sqs_name"
     sqs-migration-externalmovements-queue:
       HMPPS_SQS_QUEUES_MIGRATIONEXTERNALMOVEMENTS_QUEUE_NAME: "sqs_name"
     sqs-migration-externalmovements-dlq:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMappingApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMappingApiService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.awaitBody
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.awaitSuccessOrDuplicate
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.CreateMappingResult
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.DuplicateErrorResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.history.MigrationMapping
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.api.CourtMovementResourceApi
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.api.CourtScheduleResourceApi
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.api.CourtSchedulerMigrationResourceApi
@@ -22,14 +23,14 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.mod
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtSchedulerPrisonerMappingsDto
 
 @Service
-class CourtSchedulerMappingApiService(@Qualifier("courtSchedulerMappingApiWebClient") webClient: WebClient) {
+class CourtSchedulerMappingApiService(@Qualifier("courtSchedulerMappingApiWebClient") webClient: WebClient) : MigrationMapping<CourtSchedulerPrisonerMappingsDto>(domainUrl = "/mapping/court", webClient) {
 
   private val scheduleApi = CourtScheduleResourceApi(webClient)
   private val movementApi = CourtMovementResourceApi(webClient)
   private val migrationApi = CourtSchedulerMigrationResourceApi(webClient)
   private val prisonerApi = CourtSchedulerPrisonerResourceApi(webClient)
 
-  suspend fun createMapping(
+  override suspend fun createMapping(
     mapping: CourtSchedulerPrisonerMappingsDto,
     errorJavaClass: ParameterizedTypeReference<DuplicateErrorResponse<CourtSchedulerPrisonerMappingsDto>>,
   ): CreateMappingResult<CourtSchedulerPrisonerMappingsDto> = migrationApi.prepare(migrationApi.createPrisonerCourtSchedulerMappingsRequestConfig(mapping))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationFilter.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Filter specifying what should be migrated from NOMIS to DPS")
+class CourtSchedulerMigrationFilter(
+  @Schema(
+    description = "Only migrate a single prisoner - used for testing",
+    example = "A1234BC",
+  )
+  val prisonerNumber: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationMessageListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationMessageListener.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court
+
+import io.awspring.cloud.sqs.annotation.SqsListener
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.services.sqs.model.Message
+import tools.jackson.databind.json.JsonMapper
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.MigrationMessageListener
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.COURT_MOVEMENTS_QUEUE_ID
+import java.util.concurrent.CompletableFuture
+
+@Service
+class CourtSchedulerMigrationMessageListener(
+  jsonMapper: JsonMapper,
+  migrationService: CourtSchedulerMigrationService,
+) : MigrationMessageListener(
+  jsonMapper,
+  migrationService,
+) {
+
+  @SqsListener(
+    COURT_MOVEMENTS_QUEUE_ID,
+    factory = "hmppsQueueContainerFactoryProxy",
+    maxConcurrentMessages = "8",
+    maxMessagesPerPoll = "8",
+  )
+  fun onExternalMovementMessage(message: String, rawMessage: Message): CompletableFuture<Void?> = onMessage(message, rawMessage)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationResource.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements
+
+import com.microsoft.applicationinsights.TelemetryClient
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerMigrationFilter
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerMigrationService
+
+@RestController
+@RequestMapping("/migrate/court", produces = [MediaType.APPLICATION_JSON_VALUE])
+@Tag(name = "Court Movements Migration Resource")
+@PreAuthorize("hasRole('ROLE_PRISONER_FROM_NOMIS__MIGRATION__RW')")
+class CourtSchedulerMigrationResource(
+  private val migrationService: CourtSchedulerMigrationService,
+  private val telemetryClient: TelemetryClient,
+) {
+  @PostMapping
+  @ResponseStatus(value = HttpStatus.ACCEPTED)
+  @Operation(
+    summary = "Starts a court movement migration (or repair)",
+    description = "Starts an asynchronous migration process to migrate (or repair) court movements for all prisoners. Requires role <b>PRISONER_FROM_NOMIS__MIGRATION__RW</b> ot <b>PRISONER_FROM_NOMIS__MIGRATION__RW</b>",
+    responses = [
+      ApiResponse(
+        responseCode = "202",
+        description = "Court movement migration process started",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to start migration",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  suspend fun migrateCourtMovements(
+    @RequestBody @Valid migrationFilter: CourtSchedulerMigrationFilter,
+  ) = migrationService.startMigration(migrationFilter)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationService.kt
@@ -1,8 +1,12 @@
 package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court
 
-import com.microsoft.applicationinsights.TelemetryClient
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.ParameterizedTypeReference
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.readValue
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.config.trackEvent
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.AtAndBy
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.CourtEvent
@@ -24,17 +28,60 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.mod
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingCourtMovementOut
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.OffenderCourtMovementsResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.PrisonerId
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.ByPageNumber
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.ByPageNumberMigrationService
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationMessage
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationPage
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationType
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.NomisApiService
 
 @Service
 class CourtSchedulerMigrationService(
   private val nomisApi: CourtSchedulerNomisApiService,
+  val nomisIdsApi: NomisApiService,
   private val mappingApi: CourtSchedulerMappingApiService,
   private val sentencingMappingApi: CourtSentencingMappingApiService,
   private val dpsApi: CourtSchedulerDpsApiService,
-  private val telemetryClient: TelemetryClient,
+  jsonMapper: JsonMapper,
+  @Value($$"${courtmovements.page.size:1000}") pageSize: Long,
+  @Value($$"${courtmovements.complete-check.delay-seconds}") completeCheckDelaySeconds: Int,
+  @Value($$"${courtmovements.complete-check.retry-seconds:1}") completeCheckRetrySeconds: Int,
+  @Value($$"${courtmovements.complete-check.count}") completeCheckCount: Int,
+  @Value($$"${complete-check.scheduled-retry-seconds:10}") completeCheckScheduledRetrySeconds: Int,
+) : ByPageNumberMigrationService<CourtSchedulerMigrationFilter, PrisonerId, CourtSchedulerPrisonerMappingsDto>(
+  mappingService = mappingApi,
+  migrationType = MigrationType.COURT_MOVEMENTS,
+  pageSize = pageSize,
+  completeCheckDelaySeconds = completeCheckDelaySeconds,
+  completeCheckCount = completeCheckCount,
+  completeCheckRetrySeconds = completeCheckRetrySeconds,
+  completeCheckScheduledRetrySeconds = completeCheckScheduledRetrySeconds,
+  jsonMapper = jsonMapper,
 ) {
 
-  suspend fun migrateNomisEntity(context: MigrationContext<PrisonerId>) {
+  suspend fun getIds(
+    migrationFilter: CourtSchedulerMigrationFilter,
+    pageSize: Long,
+    pageNumber: Long,
+  ): PageImpl<PrisonerId> = if (migrationFilter.prisonerNumber.isNullOrEmpty()) {
+    nomisIdsApi.getPrisonerIds(
+      pageNumber = pageNumber,
+      pageSize = pageSize,
+    )
+  } else {
+    // If a single prisoner migration is requested, then we'll trust the input as we're probably testing. Pretend that we called nomis-prisoner-api which found a single prisoner.
+    PageImpl(mutableListOf(PrisonerId(migrationFilter.prisonerNumber)), Pageable.ofSize(1), 1)
+  }
+
+  override suspend fun getPageOfIds(
+    migrationFilter: CourtSchedulerMigrationFilter,
+    pageSize: Long,
+    pageNumber: Long,
+  ): List<PrisonerId> = getIds(migrationFilter, pageSize, pageNumber).content
+
+  override suspend fun getTotalNumberOfIds(migrationFilter: CourtSchedulerMigrationFilter): Long = getIds(migrationFilter, 1, 0).totalElements
+
+  override suspend fun migrateNomisEntity(context: MigrationContext<PrisonerId>) {
     val offenderNo = context.body.offenderNo
     val migrationId = context.migrationId
     val telemetry = mutableMapOf(
@@ -81,10 +128,18 @@ class CourtSchedulerMigrationService(
 
   private fun publishTelemetry(type: String, telemetry: Map<String, String>) {
     telemetryClient.trackEvent(
-      "temporary-absences-migration-entity-$type",
+      "court-movements-migration-entity-$type",
       telemetry,
     )
   }
+
+  override fun parseContextFilter(json: String): MigrationMessage<*, CourtSchedulerMigrationFilter> = jsonMapper.readValue(json)
+
+  override fun parseContextPageFilter(json: String): MigrationMessage<*, MigrationPage<CourtSchedulerMigrationFilter, ByPageNumber>> = jsonMapper.readValue(json)
+
+  override fun parseContextNomisId(json: String): MigrationMessage<*, PrisonerId> = jsonMapper.readValue(json)
+
+  override fun parseContextMapping(json: String): MigrationMessage<*, CourtSchedulerPrisonerMappingsDto> = jsonMapper.readValue(json)
 }
 
 private fun OffenderCourtMovementsResponse.findCourtAppearanceIds(): List<Long> = bookings

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/GeneralMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/GeneralMappingService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtsentencing.C
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.csra.CsraMappingService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.finance.PrisonBalanceMappingApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.finance.PrisonerBalanceMappingApiService
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerMappingApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapMappingApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.officialvisits.OfficialVisitsMappingService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.officialvisits.VisitSlotsMappingService
@@ -28,12 +29,14 @@ class GeneralMappingService(
   private val tapMappingApiService: TapMappingApiService,
   private val visitSlotsMappingService: VisitSlotsMappingService,
   private val officialVisitsMappingService: OfficialVisitsMappingService,
+  private val courtSchedulerMappingService: CourtSchedulerMappingApiService,
 ) {
   suspend fun getMigrationCount(migrationId: String, migrationType: MigrationType): Long = when (migrationType) {
     MigrationType.ACTIVITIES -> activityMappingService.getMigrationCount(migrationId)
     MigrationType.ALLOCATIONS -> allocationsMappingService.getMigrationCount(migrationId)
     MigrationType.APPOINTMENTS -> appointmentsMappingService.getMigrationCount(migrationId)
     MigrationType.CORE_PERSON_RELIGION -> religionsMappingService.getMigrationCount(migrationId)
+    MigrationType.COURT_MOVEMENTS -> courtSchedulerMappingService.getMigrationCount(migrationId)
     MigrationType.COURT_SENTENCING -> courtSentencingMappingService.getMigrationCount(migrationId)
     MigrationType.CSRA -> csraMappingService.getMigrationCount(migrationId)
     MigrationType.EXTERNAL_MOVEMENTS -> tapMappingApiService.getMigrationCount(migrationId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/Helpers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/Helpers.kt
@@ -21,6 +21,7 @@ const val ALLOCATIONS_QUEUE_ID = "migrationallocations"
 const val APPOINTMENTS_QUEUE_ID = "migrationappointments"
 const val CORE_PERSON_QUEUE_ID = "migrationcoreperson"
 const val CSRA_QUEUE_ID = "migrationcsra"
+const val COURT_MOVEMENTS_QUEUE_ID = "migrationcourtmovements"
 const val COURT_SENTENCING_QUEUE_ID = "migrationcourtsentencing"
 const val EXTERNAL_MOVEMENTS_QUEUE_ID = "migrationexternalmovements"
 const val PRISON_BALANCE_QUEUE_ID = "migrationprisonbalance"
@@ -54,6 +55,7 @@ enum class MigrationType(val queueId: String, val telemetryName: String) {
   APPOINTMENTS(APPOINTMENTS_QUEUE_ID, "appointments"),
   CORE_PERSON_RELIGION(CORE_PERSON_QUEUE_ID, "coreperson-religion"),
   CSRA(CSRA_QUEUE_ID, "csras"),
+  COURT_MOVEMENTS(COURT_MOVEMENTS_QUEUE_ID, "court-movements"),
   COURT_SENTENCING(COURT_SENTENCING_QUEUE_ID, "court-sentencing"),
   EXTERNAL_MOVEMENTS(EXTERNAL_MOVEMENTS_QUEUE_ID, "temporary-absences"),
   PRISON_BALANCE(PRISON_BALANCE_QUEUE_ID, "prisonbalance"),

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -28,6 +28,9 @@ hmpps.sqs:
     migrationprisonerbalance:
       queueName: ${random.uuid}
       dlqName: ${random.uuid}
+    migrationcourtmovements:
+      queueName: ${random.uuid}
+      dlqName: ${random.uuid}
     migrationexternalmovements:
       queueName: ${random.uuid}
       dlqName: ${random.uuid}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -199,6 +199,11 @@ personalrelationships:
     delay-seconds: 180
     count: 9
 
+courtmovements:
+  complete-check:
+    delay-seconds: 180
+    count: 9
+
 externalmovements:
   complete-check:
     delay-seconds: 180
@@ -264,6 +269,9 @@ hmpps.sqs:
       errorVisibilityTimeout: 1, 1, 1, 10
       propagateTracing: false
     migrationprisonerbalance:
+      errorVisibilityTimeout: 1, 1, 1, 10
+      propagateTracing: false
+    migrationcourtmovements:
       errorVisibilityTimeout: 1, 1, 1, 10
       propagateTracing: false
     migrationexternalmovements:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/SqsIntegrationTestBase.kt
@@ -37,8 +37,6 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.csra.CsraApiExten
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.finance.FinanceApiExtension
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.LocalStackContainer.setLocalStackProperties
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerDpsApiExtension
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerSyncMovementService
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerSyncScheduleService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapDpsApiExtension
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapMigrationService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.officialvisits.OfficialVisitsDpsApiExtension
@@ -250,14 +248,6 @@ class SqsIntegrationTestBase : TestBase() {
 
   @MockitoSpyBean
   protected lateinit var externalMovementsMigrationService: TapMigrationService
-
-  // TODO remove when real tests are in place
-  @MockitoSpyBean
-  protected lateinit var courtSchedulerSyncScheduleService: CourtSchedulerSyncScheduleService
-
-  // TODO remove when real tests are in place
-  @MockitoSpyBean
-  protected lateinit var courtSchedulerSyncMovementService: CourtSchedulerSyncMovementService
 
   @BeforeEach
   fun setUp() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationIntTest.kt
@@ -7,25 +7,34 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.within
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.ResyncCourtEvents
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtsentencing.CourtSentencingMappingApiMockServer
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.data.MigrationContext
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.data.generateBatchId
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helper.MigrationResult
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.MigrationTestBase
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerDpsApiExtension.Companion.dpsCourtSchedulerServer
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerDpsApiMockServer.Companion.resyncResponse
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.taps.TapMigrationFilter
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtAppearanceMappingDto
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtSchedulerPrisonerMappingsDto
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.PrisonerId
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.MigrationType
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.wiremock.NomisApiExtension
+import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
@@ -36,7 +45,6 @@ class CourtSchedulerMigrationIntTest(
   @Autowired private val nomisApi: CourtSchedulerNomisApiMockServer,
   @Autowired private val mappingApi: CourtSchedulerMappingApiMockServer,
   @Autowired private val sentencingMappingApi: CourtSentencingMappingApiMockServer,
-  @Autowired private val migrationService: CourtSchedulerMigrationService,
 ) : MigrationTestBase() {
 
   private val dpsApi = dpsCourtSchedulerServer
@@ -47,6 +55,7 @@ class CourtSchedulerMigrationIntTest(
   private val dpsUnscheduledMovementOutId = UUID.randomUUID()
   private val dpsUnscheduledMovementInId = UUID.randomUUID()
   private val dpsSentencingCourtAppearanceId = UUID.randomUUID()
+  private lateinit var migrationId: String
 
   @AfterAll
   fun tearDownTelemetryClient() = reset(telemetryClient)
@@ -77,16 +86,7 @@ class CourtSchedulerMigrationIntTest(
       setupMigrationTest()
 
       stubMigrationDependencies(entities = 1)
-      // TODO expand this to process messages - just implementing the basic migration service for now
-      migrationService.migrateNomisEntity(
-        MigrationContext(
-          MigrationType.EXTERNAL_MOVEMENTS,
-          generateBatchId(),
-          1,
-          PrisonerId("A0001KT"),
-          mutableMapOf(),
-        ),
-      )
+      migrationId = performMigration()
     }
 
     @Test
@@ -196,5 +196,70 @@ class CourtSchedulerMigrationIntTest(
         }
       }
     }
+
+    @Test
+    fun `will publish telemetry`() {
+      verify(telemetryClient).trackEvent(
+        eq("court-movements-migration-entity-migrated"),
+        check {
+          assertThat(it["offenderNo"]).isEqualTo("A0001KT")
+          assertThat(it["migrationId"]).isEqualTo(migrationId)
+        },
+        isNull(),
+      )
+    }
+  }
+
+  @Nested
+  inner class Security {
+    @Test
+    fun `access forbidden when no role`() {
+      webTestClient.post().uri("/migrate/court")
+        .headers(setAuthorisation(roles = listOf()))
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(TapMigrationFilter())
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `access forbidden with wrong role`() {
+      webTestClient.post().uri("/migrate/court")
+        .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(TapMigrationFilter())
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `access unauthorised with no auth token`() {
+      webTestClient.post().uri("/migrate/court")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(TapMigrationFilter())
+        .exchange()
+        .expectStatus().isUnauthorized
+    }
+  }
+
+  private fun performMigration(prisonerNumber: String? = null): String = webTestClient.post()
+    .uri("/migrate/court")
+    .headers(setAuthorisation(roles = listOf("ROLE_PRISONER_FROM_NOMIS__MIGRATION__RW")))
+    .contentType(MediaType.APPLICATION_JSON)
+    .apply { prisonerNumber?.let { bodyValue("""{"prisonerNumber":"$prisonerNumber"}""") } ?: bodyValue("{}") }
+    .exchange()
+    .expectStatus().isAccepted
+    .returnResult<MigrationResult>().responseBody.blockFirst()!!
+    .migrationId
+    .also {
+      waitUntilCompleted()
+    }
+
+  private fun waitUntilCompleted() = await atMost Duration.ofSeconds(60) untilAsserted {
+    verify(telemetryClient).trackEvent(
+      eq("court-movements-migration-completed"),
+      any(),
+      isNull(),
+    )
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -101,6 +101,13 @@ externalmovements:
     count: 1
   page:
     size: 10
+courtmovements:
+  complete-check:
+    delay-seconds: 0
+    retry-seconds: 0
+    count: 1
+  page:
+    size: 10
 visitslots:
   complete-check:
     delay-seconds: 0
@@ -194,6 +201,9 @@ hmpps.sqs:
       errorVisibilityTimeout: 0
     migrationprisonerbalance:
       errorVisibilityTimeout: 0
+    migrationcourtmovements:
+      errorVisibilityTimeout: 0
+      dlqMaxReceiveCount: 1
     migrationexternalmovements:
       errorVisibilityTimeout: 0
       dlqMaxReceiveCount: 1


### PR DESCRIPTION
Convert the current test of a single prisoner to call the /migration endpoint instead of calling the service directly - this exercises the migration queues and handlers.