### PR TITLE
SDIT-3731 We don't need a spy bean and it causes problems testing locally

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/SqsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/integration/SqsIntegrationTestBase.kt
@@ -24,6 +24,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.context.bean.override.mockito.MockReset
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import org.springframework.test.web.reactive.server.WebTestClient
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
@@ -245,7 +246,7 @@ class SqsIntegrationTestBase : TestBase() {
   @Autowired
   protected lateinit var jwtAuthHelper: JwtAuthorisationHelper
 
-  @MockitoSpyBean(reset = MockReset.NONE)
+  @MockitoBean(reset = MockReset.NONE)
   protected lateinit var telemetryClient: TelemetryClient
 
   @MockitoSpyBean


### PR DESCRIPTION
Since we moved back to v2 of the app insights library some team members have started experiencing 5 second delays on the first test running locally. The test times out and we can't test locally. This appears to be caused by the VPN blocking the telemetry client while the test is running. A working theory is that the real telemetry client tries to call out for some reason, but the vpn injects this 5 second delay.

The simple fix is to stop using a telemetry client spy bean for integration tests, and use a mock bean instead - we don't need a spy bean as we'd never have need to call the real bean anyway.