### PR TITLE
SDIT-3671 Prep work for breach hearing sync

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingEventListener.kt
@@ -12,20 +12,23 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.SQSMess
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.asCompletableFuture
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.SentenceId
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.sentencing.SentencingAdjustmentsSynchronisationService
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.CASE_BOOKING_RESYNCHRONISATION
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.CASE_RESYNCHRONISATION
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RECALL_BREACH_COURT_EVENT_CHARGE_INSERTED
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RECALL_SENTENCE_ADJUSTMENTS_SYNCHRONISATION
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RETRY_COURT_APPEARANCE_SYNCHRONISATION_MAPPING
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RETRY_COURT_CASE_BOOKING_CLONE_SYNCHRONISATION_MAPPING
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RETRY_COURT_CASE_SYNCHRONISATION_MAPPING
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RETRY_COURT_CHARGE_SYNCHRONISATION_MAPPING
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RETRY_PRISONER_MERGE_COURT_CASE_SYNCHRONISATION_MAPPING
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RETRY_SENTENCE_SYNCHRONISATION_MAPPING
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RETRY_SENTENCE_TERM_SYNCHRONISATION_MAPPING
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.SENTENCE_RESYNCHRONISATION
 import java.time.LocalDateTime
 import java.util.concurrent.CompletableFuture
+
+const val RETRY_COURT_CASE_SYNCHRONISATION_MAPPING = "court_case_synchronisation_retry"
+const val RETRY_COURT_APPEARANCE_SYNCHRONISATION_MAPPING = "court_appearance_synchronisation_retry"
+const val RETRY_COURT_CHARGE_SYNCHRONISATION_MAPPING = "court_charge_synchronisation_retry"
+const val RETRY_SENTENCE_SYNCHRONISATION_MAPPING = "sentence_synchronisation_retry"
+const val RETRY_SENTENCE_TERM_SYNCHRONISATION_MAPPING = "sentence_term_synchronisation_retry"
+const val RETRY_PRISONER_MERGE_COURT_CASE_SYNCHRONISATION_MAPPING = "prisoner_merge_court_case_synchronisation_retry"
+const val RETRY_COURT_CASE_BOOKING_CLONE_SYNCHRONISATION_MAPPING = "court_case_booking_clone_synchronisation_retry"
+const val RECALL_BREACH_COURT_EVENT_CHARGE_INSERTED = "recall_breach_court_event_charge_inserted"
+const val RECALL_BREACH_COURT_APPEARANCE_SYNCHRONISATION_CREATED = "courtsentencing.resync.breach-court-appearance.inserted"
+const val RECALL_BREACH_COURT_APPEARANCE_SYNCHRONISATION_UPDATED = "courtsentencing.resync.breach-court-appearance.updated"
+const val RECALL_SENTENCE_ADJUSTMENTS_SYNCHRONISATION = "courtsentencing.resync.sentence-adjustments"
+const val SENTENCE_RESYNCHRONISATION = "courtsentencing.resync.sentence"
+const val CASE_RESYNCHRONISATION = "courtsentencing.resync.case"
+const val CASE_BOOKING_RESYNCHRONISATION = "courtsentencing.resync.case.booking"
 
 @Service
 class CourtSentencingEventListener(
@@ -50,34 +53,58 @@ class CourtSentencingEventListener(
           if (eventFeatureSwitch.isEnabled(eventType, "courtsentencing")) {
             when (eventType) {
               "OFFENDER_CASES-INSERTED" -> courtSentencingSynchronisationService.nomisCourtCaseInserted(sqsMessage.Message.fromJson())
+
               "OFFENDER_CASES-UPDATED" -> courtSentencingSynchronisationService.nomisCourtCaseUpdated(sqsMessage.Message.fromJson())
+
               "OFFENDER_CASES-DELETED" -> courtSentencingSynchronisationService.nomisCourtCaseDeleted(sqsMessage.Message.fromJson())
+
               "OFFENDER_CASES-LINKED" -> courtSentencingSynchronisationService.nomisCourtCaseLinked(sqsMessage.Message.fromJson())
+
               "OFFENDER_CASES-UNLINKED" -> courtSentencingSynchronisationService.nomisCourtCaseUnlinked(sqsMessage.Message.fromJson())
+
               "COURT_EVENTS-INSERTED" -> courtSentencingSynchronisationService.nomisCourtAppearanceInserted(sqsMessage.Message.fromJson())
+
               "COURT_EVENTS-UPDATED" -> courtSentencingSynchronisationService.nomisCourtAppearanceUpdated(sqsMessage.Message.fromJson())
+
               "COURT_EVENTS-DELETED" -> courtSentencingSynchronisationService.nomisCourtAppearanceDeleted(sqsMessage.Message.fromJson())
+
               "COURT_EVENT_CHARGES-INSERTED" -> courtSentencingSynchronisationService.nomisCourtChargeInserted(sqsMessage.Message.fromJson())
+
               "COURT_EVENT_CHARGES-DELETED" -> courtSentencingSynchronisationService.nomisCourtChargeDeleted(sqsMessage.Message.fromJson())
+
               "COURT_EVENT_CHARGES-UPDATED" -> courtSentencingSynchronisationService.nomisCourtChargeUpdated(sqsMessage.Message.fromJson())
+
               "COURT_EVENT_CHARGES-LINKED" -> courtSentencingSynchronisationService.nomisCourtChargeLinked(sqsMessage.Message.fromJson())
+
               "OFFENDER_CHARGES-UPDATED" -> courtSentencingSynchronisationService.nomisOffenderChargeUpdated(sqsMessage.Message.fromJson())
+
               "OFFENDER_SENTENCES-INSERTED" -> courtSentencingSynchronisationService.nomisSentenceInserted(sqsMessage.Message.fromJson())
+
               "OFFENDER_SENTENCES-DELETED" -> courtSentencingSynchronisationService.nomisSentenceDeleted(sqsMessage.Message.fromJson())
+
               "OFFENDER_SENTENCES-UPDATED" -> courtSentencingSynchronisationService.nomisSentenceUpdated(sqsMessage.Message.fromJson())
+
               "OFFENDER_SENTENCE_TERMS-INSERTED" -> courtSentencingSynchronisationService.nomisSentenceTermInserted(sqsMessage.Message.fromJson())
+
               "OFFENDER_SENTENCE_TERMS-DELETED" -> courtSentencingSynchronisationService.nomisSentenceTermDeleted(sqsMessage.Message.fromJson())
+
               "OFFENDER_SENTENCE_TERMS-UPDATED" -> courtSentencingSynchronisationService.nomisSentenceTermUpdated(sqsMessage.Message.fromJson())
+
               "OFFENDER_SENTENCE_CHARGES-DELETED" -> courtSentencingSynchronisationService.nomisSentenceChargeDeleted(sqsMessage.Message.fromJson())
+
               "OFFENDER_SENTENCE_CHARGES-INSERTED" -> courtSentencingSynchronisationService.nomisSentenceChargeInserted(
                 sqsMessage.Message.fromJson(),
               )
+
               "OFFENDER_CASE_IDENTIFIERS-DELETED",
               "OFFENDER_CASE_IDENTIFIERS-INSERTED",
               "OFFENDER_CASE_IDENTIFIERS-UPDATED",
               -> courtSentencingSynchronisationService.nomisCaseIdentifiersUpdated(eventType, sqsMessage.Message.fromJson())
+
               "prison-offender-events.prisoner.merged" -> courtSentencingSynchronisationService.prisonerMerged(sqsMessage.Message.fromJson())
+
               "OFFENDER_FIXED_TERM_RECALLS-UPDATED" -> courtSentencingSynchronisationService.nomisRecallReturnToCustodyDataChanged(sqsMessage.Message.fromJson())
+
               else -> log.info("Received a message I wasn't expecting {}", eventType)
             }
           } else {
@@ -119,6 +146,14 @@ class CourtSentencingEventListener(
           sqsMessage.Message.fromJson(),
         )
 
+        RECALL_BREACH_COURT_APPEARANCE_SYNCHRONISATION_CREATED -> courtSentencingSynchronisationService.nomisRecallBeachCourtAppearanceInserted(
+          sqsMessage.Message.fromJson(),
+        )
+
+        RECALL_BREACH_COURT_APPEARANCE_SYNCHRONISATION_UPDATED -> courtSentencingSynchronisationService.nomisRecallBeachCourtAppearanceUpdated(
+          sqsMessage.Message.fromJson(),
+        )
+
         RECALL_SENTENCE_ADJUSTMENTS_SYNCHRONISATION -> sentencingAdjustmentsSynchronisationService.nomisSentenceAdjustmentsUpdate(
           sqsMessage.Message.fromJson(),
         )
@@ -130,6 +165,7 @@ class CourtSentencingEventListener(
         CASE_RESYNCHRONISATION -> courtSentencingSynchronisationService.nomisCaseResynchronisation(
           sqsMessage.Message.fromJson(),
         )
+
         CASE_BOOKING_RESYNCHRONISATION ->
           courtSentencingSynchronisationService.nomisCaseBookingMoveResynchronisation(sqsMessage.Message.fromJson())
 
@@ -283,4 +319,9 @@ data class SentenceIdAndAdjustmentType(
 data class SyncSentenceAdjustment(
   val offenderNo: String,
   val sentences: List<SentenceIdAndAdjustmentType>,
+)
+
+data class SyncRecallBreachCourtAppearanceEvent(
+  val offenderNo: String,
+  val courtAppearanceId: Long,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationService.kt
@@ -49,17 +49,9 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.mod
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.OffenderChargeResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.SentenceResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.InternalMessage
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RECALL_BREACH_COURT_EVENT_CHARGE_INSERTED
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RETRY_COURT_APPEARANCE_SYNCHRONISATION_MAPPING
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RETRY_COURT_CASE_BOOKING_CLONE_SYNCHRONISATION_MAPPING
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RETRY_COURT_CASE_SYNCHRONISATION_MAPPING
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RETRY_COURT_CHARGE_SYNCHRONISATION_MAPPING
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RETRY_PRISONER_MERGE_COURT_CASE_SYNCHRONISATION_MAPPING
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RETRY_SENTENCE_SYNCHRONISATION_MAPPING
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.RETRY_SENTENCE_TERM_SYNCHRONISATION_MAPPING
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.SynchronisationQueueService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.SynchronisationType
-import java.util.UUID
+import java.util.*
 
 @Service
 class CourtSentencingSynchronisationService(
@@ -68,7 +60,7 @@ class CourtSentencingSynchronisationService(
   private val dpsApiService: CourtSentencingDpsApiService,
   private val queueService: SynchronisationQueueService,
   override val telemetryClient: TelemetryClient,
-  @Value("\${contact-sentencing.court-event-update.ignore-missing:false}") private val ignoreMissingCourtAppearances: Boolean,
+  @Value($$"${contact-sentencing.court-event-update.ignore-missing:false}") private val ignoreMissingCourtAppearances: Boolean,
   private val courtSentencingMappingApiService: CourtSentencingMappingApiService,
 ) : TelemetryEnabled {
   private companion object {
@@ -666,6 +658,15 @@ class CourtSentencingSynchronisationService(
     bookingId = message.body.bookingId,
   )
 
+  suspend fun nomisRecallBeachCourtAppearanceInserted(message: SyncRecallBreachCourtAppearanceEvent) {
+    // TODO - implementation
+    telemetryClient.trackEvent("recall-breach-court-appearance-synchronisation-success", mapOf("offenderNo" to message.offenderNo, "nomisCourtAppearanceId" to message.courtAppearanceId.toString()))
+  }
+  suspend fun nomisRecallBeachCourtAppearanceUpdated(message: SyncRecallBreachCourtAppearanceEvent) {
+    // TODO - implementation
+    telemetryClient.trackEvent("recall-breach-court-appearance-resynchronisation-success", mapOf("offenderNo" to message.offenderNo, "nomisCourtAppearanceId" to message.courtAppearanceId.toString()))
+  }
+
   suspend fun nomisCourtChargeInserted(event: CourtEventChargeEvent) = nomisCourtChargeInserted(
     eventId = event.eventId,
     chargeId = event.chargeId,
@@ -793,7 +794,7 @@ class CourtSentencingSynchronisationService(
   }
 
   suspend fun nomisCourtChargeUpdated(event: CourtEventChargeEvent) {
-    var telemetry = mapOf(
+    val telemetry = mapOf(
       "nomisBookingId" to event.bookingId.toString(),
       "nomisOffenderChargeId" to event.chargeId.toString(),
       "nomisCourtAppearanceId" to event.eventId.toString(),
@@ -942,23 +943,6 @@ class CourtSentencingSynchronisationService(
     )
     log.error("Unable to find mapping for nomis offender charges in the context of sentence: bookingId= ${nomisSentence.bookingId} sentenceSequence= ${nomisSentence.sentenceSeq}}\nPossible causes: events out of order or offender charge has not been migrated")
     throw ParentEntityNotFoundRetry("Unable to find mapping for nomis offender charges in the context of sentence: bookingId= ${nomisSentence.bookingId} sentenceSequence= ${nomisSentence.sentenceSeq}")
-  }
-
-  private suspend fun tryToDeleteCourtChargeMapping(mapping: CourtChargeMappingDto) = runCatching {
-    mappingApiService.deleteCourtChargeMappingByNomisId(mapping.nomisCourtChargeId)
-    telemetryClient.trackEvent(
-      "court-charge-mapping-deleted-success",
-      mapOf("nomisOffenderCharge" to mapping.nomisCourtChargeId, "dpsCourtChargeId" to mapping.dpsCourtChargeId),
-    )
-  }.onFailure { e ->
-    telemetryClient.trackEvent(
-      "court-charge-mapping-deleted-failed",
-      mapOf("nomisOffenderCharge" to mapping.nomisCourtChargeId, "dpsCourtChargeId" to mapping.dpsCourtChargeId),
-    )
-    log.warn(
-      "Unable to delete mapping for court charge with nomis id: ${mapping.nomisCourtChargeId}. Please delete manually",
-      e,
-    )
   }
 
   suspend fun retryCreateCourtCaseMapping(retryMessage: InternalMessage<CourtCaseAllMappingDto>) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/SynchronisationQueueService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/service/SynchronisationQueueService.kt
@@ -10,19 +10,6 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.listeners.SQSMess
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.eventTypeMessageAttributes
 
-const val RETRY_COURT_CASE_SYNCHRONISATION_MAPPING = "court_case_synchronisation_retry"
-const val RETRY_COURT_APPEARANCE_SYNCHRONISATION_MAPPING = "court_appearance_synchronisation_retry"
-const val RETRY_COURT_CHARGE_SYNCHRONISATION_MAPPING = "court_charge_synchronisation_retry"
-const val RETRY_SENTENCE_SYNCHRONISATION_MAPPING = "sentence_synchronisation_retry"
-const val RETRY_SENTENCE_TERM_SYNCHRONISATION_MAPPING = "sentence_term_synchronisation_retry"
-const val RETRY_PRISONER_MERGE_COURT_CASE_SYNCHRONISATION_MAPPING = "prisoner_merge_court_case_synchronisation_retry"
-const val RETRY_COURT_CASE_BOOKING_CLONE_SYNCHRONISATION_MAPPING = "court_case_booking_clone_synchronisation_retry"
-const val RECALL_BREACH_COURT_EVENT_CHARGE_INSERTED = "recall_breach_court_event_charge_inserted"
-const val RECALL_SENTENCE_ADJUSTMENTS_SYNCHRONISATION = "courtsentencing.resync.sentence-adjustments"
-const val SENTENCE_RESYNCHRONISATION = "courtsentencing.resync.sentence"
-const val CASE_RESYNCHRONISATION = "courtsentencing.resync.case"
-const val CASE_BOOKING_RESYNCHRONISATION = "courtsentencing.resync.case.booking"
-
 @Service
 class SynchronisationQueueService(
   private val hmppsQueueService: HmppsQueueService,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationIntTest.kt
@@ -2650,6 +2650,64 @@ class CourtSentencingSynchronisationIntTest : SqsIntegrationTestBase() {
   }
 
   @Nested
+  @DisplayName("courtsentencing.resync.breach-court-appearance.inserted")
+  inner class RecallBreachCourtAppearanceInsertedSynchronisation {
+    @BeforeEach
+    fun setUp() {
+      courtSentencingOffenderEventsQueue.sendMessage(
+        SQSMessage(
+          Type = "courtsentencing.resync.breach-court-appearance.inserted",
+          Message = SyncRecallBreachCourtAppearanceEvent(
+            offenderNo = OFFENDER_ID_DISPLAY,
+            courtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
+          ).toJson(),
+        ).toJson(),
+      ).also { waitForAnyProcessingToComplete("recall-breach-court-appearance-synchronisation-success") }
+    }
+
+    @Test
+    fun `will track telemetry for the create synchronisation`() {
+      verify(telemetryClient).trackEvent(
+        eq("recall-breach-court-appearance-synchronisation-success"),
+        check {
+          assertThat(it["offenderNo"]).isEqualTo(OFFENDER_ID_DISPLAY)
+          assertThat(it["nomisCourtAppearanceId"]).isEqualTo("$NOMIS_COURT_APPEARANCE_ID")
+        },
+        isNull(),
+      )
+    }
+  }
+
+  @Nested
+  @DisplayName("courtsentencing.resync.breach-court-appearance.updated")
+  inner class RecallBreachCourtAppearanceUpdateResynchronisation {
+    @BeforeEach
+    fun setUp() {
+      courtSentencingOffenderEventsQueue.sendMessage(
+        SQSMessage(
+          Type = "courtsentencing.resync.breach-court-appearance.updated",
+          Message = SyncRecallBreachCourtAppearanceEvent(
+            offenderNo = OFFENDER_ID_DISPLAY,
+            courtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
+          ).toJson(),
+        ).toJson(),
+      ).also { waitForAnyProcessingToComplete("recall-breach-court-appearance-resynchronisation-success") }
+    }
+
+    @Test
+    fun `will track telemetry for the create synchronisation`() {
+      verify(telemetryClient).trackEvent(
+        eq("recall-breach-court-appearance-resynchronisation-success"),
+        check {
+          assertThat(it["offenderNo"]).isEqualTo(OFFENDER_ID_DISPLAY)
+          assertThat(it["nomisCourtAppearanceId"]).isEqualTo("$NOMIS_COURT_APPEARANCE_ID")
+        },
+        isNull(),
+      )
+    }
+  }
+
+  @Nested
   @DisplayName("COURT_EVENT_CHARGES-INSERTED")
   inner class CourtEventChargeInserted {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/SentencingSynchronisationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/SentencingSynchronisationIntTest.kt
@@ -456,17 +456,17 @@ class SentencingSynchronisationIntTest : SqsIntegrationTestBase() {
             )
             // will not create a sentence in DPS
             dpsCourtSentencingServer.verify(0, postRequestedFor(anyUrl()))
+          }
+        }
 
-            @Test
-            fun `the event is placed on dead letter queue`() {
-              await untilAsserted {
-                assertThat(
-                  awsSqsCourtSentencingOffenderEventDlqClient.countAllMessagesOnQueue(
-                    courtSentencingQueueOffenderEventsDlqUrl,
-                  ).get(),
-                ).isEqualTo(1)
-              }
-            }
+        @Test
+        fun `the event is placed on dead letter queue`() {
+          await untilAsserted {
+            assertThat(
+              awsSqsCourtSentencingOffenderEventDlqClient.countAllMessagesOnQueue(
+                courtSentencingQueueOffenderEventsDlqUrl,
+              ).get(),
+            ).isEqualTo(1)
           }
         }
       }


### PR DESCRIPTION
Small step to add two new events so this service syncs court appearances created by a DPS Recall to be synchronized back to DPS

Move constants, fixed a few warnings and added the new events