### PR TITLE
SDIT-3671 Move breach hearing sync to message handler

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationService.kt
@@ -156,7 +156,7 @@ class CourtSentencingSynchronisationService(
                 "court-appearance-synchronisation-created-success",
                 telemetry,
               )
-              // this is a breach court event created by DPS so all charges events will be ignored
+              // this is a breach court event created by DPS, so all charges events will be ignored
               // so add them now via an event
               if (event.originatesInDps) {
                 nomisCourtAppearance.courtEventCharges.forEach {
@@ -573,13 +573,13 @@ class CourtSentencingSynchronisationService(
       )
     if (isAppearancePartOfACourtCase(event)) {
       if (!event.triggeredByFlushSchedules) {
-        if (event.originatesInDps && !event.isBreachHearing) {
+        if (event.originatesInDps) {
           telemetryClient.trackEvent("court-appearance-synchronisation-updated-skipped", telemetry)
         } else {
           val mapping = mappingApiService.getCourtAppearanceOrNullByNomisId(event.eventId)
           if (mapping == null) {
             if (ignoreMissingCourtAppearances) {
-              // require temporarily in preprod since batch will trigger updates on court events overnight that may not have been migrated
+              // require temporarily in preprod since batch will trigger updates on court events overnight that may not have been migrated,
               // so no point in sending to DLQ and causing confusion
               telemetryClient.trackEvent(
                 "court-appearance-synchronisation-updated-skipped",
@@ -662,9 +662,25 @@ class CourtSentencingSynchronisationService(
     // TODO - implementation
     telemetryClient.trackEvent("recall-breach-court-appearance-synchronisation-success", mapOf("offenderNo" to message.offenderNo, "nomisCourtAppearanceId" to message.courtAppearanceId.toString()))
   }
-  suspend fun nomisRecallBeachCourtAppearanceUpdated(message: SyncRecallBreachCourtAppearanceEvent) {
-    // TODO - implementation
-    telemetryClient.trackEvent("recall-breach-court-appearance-resynchronisation-success", mapOf("offenderNo" to message.offenderNo, "nomisCourtAppearanceId" to message.courtAppearanceId.toString()))
+
+  suspend fun nomisRecallBeachCourtAppearanceUpdated(event: SyncRecallBreachCourtAppearanceEvent) {
+    val telemetry = mutableMapOf<String, Any>("offenderNo" to event.offenderNo, "nomisCourtAppearanceId" to event.courtAppearanceId)
+
+    track(name = "recall-breach-court-appearance-resynchronisation", telemetry = telemetry) {
+      val nomisCourtAppearance = nomisApiService.getCourtAppearance(offenderNo = event.offenderNo, courtAppearanceId = event.courtAppearanceId).also {
+        telemetry["nomisCourtCaseId"] = it.caseId!!
+      }
+      val courtAppearanceMapping = mappingApiService.getCourtAppearanceByNomisId(event.courtAppearanceId).also {
+        telemetry["dpsCourtAppearanceId"] = it.dpsCourtAppearanceId
+      }
+      val courtCaseMapping = mappingApiService.getCourtCaseByNomisId(nomisCourtAppearance.caseId!!).also {
+        telemetry["dpsCourtCaseId"] = it.dpsCourtCaseId
+      }
+      dpsApiService.updateCourtAppearance(
+        courtAppearanceId = courtAppearanceMapping.dpsCourtAppearanceId,
+        courtAppearance = nomisCourtAppearance.toDpsCourtAppearance(dpsCaseId = courtCaseMapping.dpsCourtCaseId),
+      )
+    }
   }
 
   suspend fun nomisCourtChargeInserted(event: CourtEventChargeEvent) = nomisCourtChargeInserted(
@@ -676,7 +692,7 @@ class CourtSentencingSynchronisationService(
   )
 
   // New Court event charge.
-  // is it a new underlying offender charge? 2 DPS endpoints - create charge or apply new version to appearance
+  // is it a new underlying offender charge? 2 DPS endpoints - create charge or apply a new version to appearance
   suspend fun nomisCourtChargeInserted(
     eventId: Long,
     chargeId: Long,
@@ -749,7 +765,7 @@ class CourtSentencingSynchronisationService(
           "court-charge-synchronisation-created-failed",
           telemetry + ("reason" to "court appearance is not mapped"),
         )
-        // after migration has run this should not happen so make sure this message goes in DLQ
+        // after migration has run, this should not happen, so make sure this message goes in DLQ
         throw ParentEntityNotFoundRetry("Received COURT_EVENT_CHARGES-INSERTED for court appearance $eventId that has never been created")
       }
     }
@@ -1343,7 +1359,7 @@ class CourtSentencingSynchronisationService(
     }
   }
 
-  // there is an edge case where a sentence charge is created after the sentence is created - without causing a sentence update event
+  // there is an edge case where a sentence charge is created after the sentence is created - without causing a sentence update event,
   // this handles that scenario by updating the sentence in DPS to ensure all charges are included
   suspend fun nomisSentenceChargeInserted(event: OffenderSentenceChargeEvent) {
     val bookingId = event.bookingId
@@ -1533,7 +1549,7 @@ class CourtSentencingSynchronisationService(
       }
     }
 
-    // no scenario this can reasonably be empty except when testing
+    // there is no scenario this can reasonably be empty except when testing
     if (event.caseIds.isNotEmpty()) {
       val nomisCourtCases =
         nomisApiService.getCourtCases(offenderNo = event.offenderNo, courtCaseIds = event.caseIds)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationIntTest.kt
@@ -32,6 +32,8 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.NOT_FOUND
 import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtsentencing.CourtSentencingDpsApiExtension.Companion.dpsCourtSentencingServer
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtsentencing.CourtSentencingDpsApiExtension.Companion.getRequestBody
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtsentencing.model.LegacyCreateCourtAppearance
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtsentencing.model.LegacyCreateSentence
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtsentencing.model.MergeCreateChargeResponse
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtsentencing.model.MergeCreateCourtAppearanceResponse
@@ -2468,87 +2470,6 @@ class CourtSentencingSynchronisationIntTest : SqsIntegrationTestBase() {
         }
       }
     }
-
-    @Nested
-    @DisplayName("When breach recall court appearance was updated in DPS")
-    inner class DpsUpdatedRecallBreachHearing {
-
-      @BeforeEach
-      fun setUp() {
-        courtSentencingNomisApiMockServer.stubGetCourtAppearance(
-          courtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
-          offenderNo = OFFENDER_ID_DISPLAY,
-          courtCaseId = NOMIS_COURT_CASE_ID,
-          eventDateTime = LocalDateTime.parse("2020-01-02T09:00:00"),
-        )
-      }
-
-      @Nested
-      @DisplayName("When happy path")
-      inner class HappyPath {
-        @BeforeEach
-        fun setUp() {
-          courtSentencingMappingApiMockServer.stubGetCourtAppearanceByNomisId(
-            nomisCourtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
-            dpsCourtAppearanceId = DPS_COURT_APPEARANCE_ID,
-          )
-
-          courtSentencingMappingApiMockServer.stubGetByNomisId(
-            nomisCourtCaseId = NOMIS_COURT_CASE_ID,
-          )
-
-          dpsCourtSentencingServer.stubPutCourtAppearanceForUpdate(
-            courtAppearanceId = UUID.fromString(
-              DPS_COURT_APPEARANCE_ID,
-            ),
-          )
-          courtSentencingOffenderEventsQueue.sendMessage(
-            courtAppearanceEvent(
-              eventType = "COURT_EVENTS-UPDATED",
-              auditModule = "DPS_SYNCHRONISATION",
-              isBreachHearing = true,
-            ),
-          ).also {
-            waitForAnyProcessingToComplete()
-          }
-        }
-
-        @Test
-        fun `will update DPS with the changes`() {
-          dpsCourtSentencingServer.verify(
-            1,
-            putRequestedFor(urlPathEqualTo("/legacy/court-appearance/$DPS_COURT_APPEARANCE_ID"))
-              .withRequestBody(
-                matchingJsonPath(
-                  "legacyData.nomisAppearanceTypeCode",
-                  equalTo("CRT"),
-                ),
-              )
-              .withRequestBody(
-                matchingJsonPath(
-                  "legacyData.appearanceTime",
-                  equalTo("09:00"),
-                ),
-              ),
-          )
-        }
-
-        @Test
-        fun `will track a telemetry event for success`() {
-          verify(telemetryClient).trackEvent(
-            eq("court-appearance-synchronisation-updated-success"),
-            check {
-              assertThat(it["offenderNo"]).isEqualTo(OFFENDER_ID_DISPLAY)
-              assertThat(it["isBreachHearing"]).isEqualTo("true")
-              assertThat(it["nomisBookingId"]).isEqualTo(NOMIS_BOOKING_ID.toString())
-              assertThat(it["nomisCourtAppearanceId"]).isEqualTo(NOMIS_COURT_APPEARANCE_ID.toString())
-              assertThat(it["dpsCourtAppearanceId"]).isEqualTo(DPS_COURT_APPEARANCE_ID)
-            },
-            isNull(),
-          )
-        }
-      }
-    }
   }
 
   @Nested
@@ -2683,6 +2604,29 @@ class CourtSentencingSynchronisationIntTest : SqsIntegrationTestBase() {
   inner class RecallBreachCourtAppearanceUpdateResynchronisation {
     @BeforeEach
     fun setUp() {
+      courtSentencingNomisApiMockServer.stubGetCourtAppearance(
+        courtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
+        offenderNo = OFFENDER_ID_DISPLAY,
+        courtCaseId = NOMIS_COURT_CASE_ID,
+        eventDateTime = LocalDateTime.parse("2020-01-02T09:00:00"),
+      )
+
+      courtSentencingMappingApiMockServer.stubGetCourtAppearanceByNomisId(
+        nomisCourtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
+        dpsCourtAppearanceId = DPS_COURT_APPEARANCE_ID,
+      )
+
+      courtSentencingMappingApiMockServer.stubGetByNomisId(
+        nomisCourtCaseId = NOMIS_COURT_CASE_ID,
+        dpsCourtCaseId = DPS_COURT_CASE_ID,
+      )
+
+      dpsCourtSentencingServer.stubPutCourtAppearanceForUpdate(
+        courtAppearanceId = UUID.fromString(
+          DPS_COURT_APPEARANCE_ID,
+        ),
+      )
+
       courtSentencingOffenderEventsQueue.sendMessage(
         SQSMessage(
           Type = "courtsentencing.resync.breach-court-appearance.updated",
@@ -2695,12 +2639,21 @@ class CourtSentencingSynchronisationIntTest : SqsIntegrationTestBase() {
     }
 
     @Test
+    fun `will update DPS with the changes`() {
+      val dpsUpdateRequest: LegacyCreateCourtAppearance = getRequestBody(putRequestedFor(urlPathEqualTo("/legacy/court-appearance/$DPS_COURT_APPEARANCE_ID")))
+      assertThat(dpsUpdateRequest.appearanceDate).isEqualTo(LocalDate.parse("2020-01-02"))
+    }
+
+    @Test
     fun `will track telemetry for the create synchronisation`() {
       verify(telemetryClient).trackEvent(
         eq("recall-breach-court-appearance-resynchronisation-success"),
         check {
           assertThat(it["offenderNo"]).isEqualTo(OFFENDER_ID_DISPLAY)
+          assertThat(it["nomisCourtCaseId"]).isEqualTo("$NOMIS_COURT_CASE_ID")
+          assertThat(it["dpsCourtCaseId"]).isEqualTo(DPS_COURT_CASE_ID)
           assertThat(it["nomisCourtAppearanceId"]).isEqualTo("$NOMIS_COURT_APPEARANCE_ID")
+          assertThat(it["dpsCourtAppearanceId"]).isEqualTo(DPS_COURT_APPEARANCE_ID)
         },
         isNull(),
       )


### PR DESCRIPTION
Rather than relying on the breach hearing flag (which itself is simply using audit data), use the explicit re-sync SQS message received from the to-nomis sync service

A few minor grammar changes to satisfy IntelliJ warnings.