### PR TITLE
SDIT-3671 Move breach hearing sync to message handler

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingEventListener.kt
@@ -200,7 +200,6 @@ data class CourtAppearanceEvent(
   val caseId: Long?,
   val offenderIdDisplay: String,
   val bookingId: Long,
-  val isBreachHearing: Boolean,
   override val auditModuleName: String?,
 ) : EventAudited
 
@@ -216,7 +215,6 @@ data class RecallBreachCourtEventCharge(
   val eventId: Long,
   val chargeId: Long,
   val offenderIdDisplay: String,
-  val bookingId: Long,
 )
 
 data class CourtEventChargeLinkingEvent(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationService.kt
@@ -114,10 +114,9 @@ class CourtSentencingSynchronisationService(
         "nomisCourtAppearanceId" to event.eventId.toString(),
         "offenderNo" to event.offenderIdDisplay,
         "nomisBookingId" to event.bookingId.toString(),
-        "isBreachHearing" to event.isBreachHearing.toString(),
       )
     if (isAppearancePartOfACourtCase(event)) {
-      if (event.originatesInDps && !event.isBreachHearing) {
+      if (event.originatesInDps) {
         telemetryClient.trackEvent("court-appearance-synchronisation-created-skipped", telemetry)
       } else {
         val nomisCourtAppearance =
@@ -126,60 +125,39 @@ class CourtSentencingSynchronisationService(
             courtAppearanceId = event.eventId,
           )
 
-        if (nomisCourtAppearance.isClone && event.isBreachHearing) {
-          telemetryClient.trackEvent("court-appearance-synchronisation-created-skipped", telemetry + ("reason" to "appearance is a clone of a breach hearing"))
-        } else {
-          mappingApiService.getCourtAppearanceOrNullByNomisId(event.eventId)?.let { mapping ->
+        mappingApiService.getCourtAppearanceOrNullByNomisId(event.eventId)?.let { mapping ->
+          telemetryClient.trackEvent(
+            "court-appearance-synchronisation-created-ignored",
+            telemetry + ("dpsCourtAppearanceId" to mapping.dpsCourtAppearanceId) + ("reason" to "appearance already mapped"),
+          )
+        } ?: let {
+          mappingApiService.getCourtCaseOrNullByNomisId(nomisCourtAppearance.caseId!!)?.let { courtCaseMapping ->
+            telemetry["nomisCourtCaseId"] = courtCaseMapping.nomisCourtCaseId.toString()
+            telemetry["dpsCourtCaseId"] = courtCaseMapping.dpsCourtCaseId
+            trackIfFailure(name = "court-appearance-synchronisation-created", telemetry = telemetry.toMutableMap()) {
+              dpsApiService.createCourtAppearance(
+                nomisCourtAppearance.toDpsCourtAppearance(dpsCaseId = courtCaseMapping.dpsCourtCaseId),
+              )
+            }.run {
+              telemetry["dpsCourtAppearanceId"] = this.lifetimeUuid.toString()
+              tryToCreateCourtAppearanceMapping(
+                nomisCourtAppearance = nomisCourtAppearance,
+                dpsCourtAppearanceResponse = this,
+                telemetry,
+              ).also { mappingCreateResult ->
+                if (mappingCreateResult == MappingResponse.MAPPING_FAILED) telemetry["mapping"] = "initial-failure"
+              }
+            }
             telemetryClient.trackEvent(
-              "court-appearance-synchronisation-created-ignored",
-              telemetry + ("dpsCourtAppearanceId" to mapping.dpsCourtAppearanceId) + ("reason" to "appearance already mapped"),
+              "court-appearance-synchronisation-created-success",
+              telemetry,
             )
           } ?: let {
-            mappingApiService.getCourtCaseOrNullByNomisId(nomisCourtAppearance.caseId!!)?.let { courtCaseMapping ->
-              telemetry["nomisCourtCaseId"] = courtCaseMapping.nomisCourtCaseId.toString()
-              telemetry["dpsCourtCaseId"] = courtCaseMapping.dpsCourtCaseId
-              trackIfFailure(name = "court-appearance-synchronisation-created", telemetry = telemetry.toMutableMap()) {
-                dpsApiService.createCourtAppearance(
-                  nomisCourtAppearance.toDpsCourtAppearance(dpsCaseId = courtCaseMapping.dpsCourtCaseId),
-                )
-              }.run {
-                telemetry["dpsCourtAppearanceId"] = this.lifetimeUuid.toString()
-                tryToCreateCourtAppearanceMapping(
-                  nomisCourtAppearance = nomisCourtAppearance,
-                  dpsCourtAppearanceResponse = this,
-                  telemetry,
-                ).also { mappingCreateResult ->
-                  if (mappingCreateResult == MappingResponse.MAPPING_FAILED) telemetry["mapping"] = "initial-failure"
-                }
-              }
-              telemetryClient.trackEvent(
-                "court-appearance-synchronisation-created-success",
-                telemetry,
-              )
-              // this is a breach court event created by DPS, so all charges events will be ignored
-              // so add them now via an event
-              if (event.originatesInDps) {
-                nomisCourtAppearance.courtEventCharges.forEach {
-                  queueService.sendMessage(
-                    messageType = RECALL_BREACH_COURT_EVENT_CHARGE_INSERTED,
-                    synchronisationType = SynchronisationType.COURT_SENTENCING,
-                    message = RecallBreachCourtEventCharge(
-                      eventId = event.eventId,
-                      chargeId = it.offenderCharge.id,
-                      offenderIdDisplay = event.offenderIdDisplay,
-                      bookingId = event.bookingId,
-                    ),
-                    telemetryAttributes = emptyMap(),
-                  )
-                }
-              }
-            } ?: let {
-              telemetryClient.trackEvent(
-                "court-appearance-synchronisation-created-failed",
-                telemetry + ("nomisCourtCaseId" to nomisCourtAppearance.caseId.toString()) + ("reason" to "associated court case is not mapped"),
-              )
-              throw ParentEntityNotFoundRetry("Received COURT_EVENTS_INSERTED for court case ${nomisCourtAppearance.caseId} that has never been created/mapped")
-            }
+            telemetryClient.trackEvent(
+              "court-appearance-synchronisation-created-failed",
+              telemetry + ("nomisCourtCaseId" to nomisCourtAppearance.caseId.toString()) + ("reason" to "associated court case is not mapped"),
+            )
+            throw ParentEntityNotFoundRetry("Received COURT_EVENTS_INSERTED for court case ${nomisCourtAppearance.caseId} that has never been created/mapped")
           }
         }
       }
@@ -569,7 +547,6 @@ class CourtSentencingSynchronisationService(
         "nomisBookingId" to event.bookingId.toString(),
         "nomisCourtAppearanceId" to event.eventId.toString(),
         "offenderNo" to event.offenderIdDisplay,
-        "isBreachHearing" to event.isBreachHearing,
       )
     if (isAppearancePartOfACourtCase(event)) {
       if (!event.triggeredByFlushSchedules) {
@@ -655,12 +632,45 @@ class CourtSentencingSynchronisationService(
     eventId = message.body.eventId,
     chargeId = message.body.chargeId,
     offenderNo = message.body.offenderIdDisplay,
-    bookingId = message.body.bookingId,
   )
 
-  suspend fun nomisRecallBeachCourtAppearanceInserted(message: SyncRecallBreachCourtAppearanceEvent) {
-    // TODO - implementation
-    telemetryClient.trackEvent("recall-breach-court-appearance-synchronisation-success", mapOf("offenderNo" to message.offenderNo, "nomisCourtAppearanceId" to message.courtAppearanceId.toString()))
+  suspend fun nomisRecallBeachCourtAppearanceInserted(event: SyncRecallBreachCourtAppearanceEvent) {
+    val telemetry = mutableMapOf<String, Any>("nomisCourtAppearanceId" to event.courtAppearanceId, "offenderNo" to event.offenderNo)
+
+    track("recall-breach-court-appearance-synchronisation", telemetry) {
+      val nomisCourtAppearance = nomisApiService.getCourtAppearance(offenderNo = event.offenderNo, courtAppearanceId = event.courtAppearanceId).also {
+        telemetry["nomisCourtCaseId"] = it.caseId!!.toString()
+      }
+
+      val courtCaseMapping = mappingApiService.getCourtCaseByNomisId(nomisCourtAppearance.caseId!!).also {
+        telemetry["dpsCourtCaseId"] = it.dpsCourtCaseId
+      }
+
+      val dpsCourtAppearance = dpsApiService.createCourtAppearance(nomisCourtAppearance.toDpsCourtAppearance(dpsCaseId = courtCaseMapping.dpsCourtCaseId)).also {
+        telemetry["dpsCourtAppearanceId"] = it.lifetimeUuid.toString()
+      }
+
+      tryToCreateCourtAppearanceMapping(
+        nomisCourtAppearance = nomisCourtAppearance,
+        dpsCourtAppearanceResponse = dpsCourtAppearance,
+        telemetry,
+      ).also { mappingCreateResult ->
+        if (mappingCreateResult == MappingResponse.MAPPING_FAILED) telemetry["mapping"] = "initial-failure"
+      }
+
+      nomisCourtAppearance.courtEventCharges.forEach {
+        queueService.sendMessage(
+          messageType = RECALL_BREACH_COURT_EVENT_CHARGE_INSERTED,
+          synchronisationType = SynchronisationType.COURT_SENTENCING,
+          message = RecallBreachCourtEventCharge(
+            eventId = event.courtAppearanceId,
+            chargeId = it.offenderCharge.id,
+            offenderIdDisplay = event.offenderNo,
+          ),
+          telemetryAttributes = telemetry.valuesAsStrings(),
+        )
+      }
+    }
   }
 
   suspend fun nomisRecallBeachCourtAppearanceUpdated(event: SyncRecallBreachCourtAppearanceEvent) {
@@ -697,7 +707,7 @@ class CourtSentencingSynchronisationService(
     eventId: Long,
     chargeId: Long,
     offenderNo: String,
-    bookingId: Long,
+    bookingId: Long? = null,
     skipSynchronisation: Boolean = false,
   ) {
     val telemetry =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/courtsentencing/CourtSentencingSynchronisationIntTest.kt
@@ -1903,246 +1903,6 @@ class CourtSentencingSynchronisationIntTest : SqsIntegrationTestBase() {
     }
 
     @Nested
-    @DisplayName("When court appearance was created in DPS for a recall")
-    inner class DpsCreatedRecallBreachHearing {
-      @Nested
-      @DisplayName("When happy path")
-      inner class HappyPath {
-        val chargeIds =
-          listOf((101L to "e94eea10-dfd1-43c2-b43c-56e8650f8ae7"), (102L to "e94eea10-dfd1-43c2-b43c-56e8650f8ae7"))
-
-        @BeforeEach
-        fun setUp() {
-          courtSentencingNomisApiMockServer.stubGetCourtAppearance(
-            courtCaseId = NOMIS_COURT_CASE_ID,
-            offenderNo = OFFENDER_ID_DISPLAY,
-            courtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
-            eventDateTime = LocalDateTime.parse("2020-01-02T09:00:00"),
-            courtId = "MDI",
-            courtEventCharges = listOf(
-              courtEventChargeResponse(
-                eventId = NOMIS_COURT_APPEARANCE_ID,
-                offenderChargeId = chargeIds[0].first,
-              ),
-              courtEventChargeResponse(
-                eventId = NOMIS_COURT_APPEARANCE_ID,
-                offenderChargeId = chargeIds[1].first,
-              ),
-            ),
-          )
-
-          courtSentencingMappingApiMockServer.stubGetCourtAppearanceByNomisIdNotFoundFollowedBySuccess(
-            nomisCourtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
-            dpsCourtAppearanceId = DPS_COURT_APPEARANCE_ID,
-          )
-          courtSentencingMappingApiMockServer.stubGetByNomisId(
-            nomisCourtCaseId = NOMIS_COURT_CASE_ID,
-            dpsCourtCaseId = DPS_COURT_CASE_ID,
-          )
-          dpsCourtSentencingServer.stubPostCourtAppearanceForCreate(
-            courtAppearanceId = UUID.fromString(
-              DPS_COURT_APPEARANCE_ID,
-            ),
-            courtCaseId = DPS_COURT_CASE_ID,
-          )
-          courtSentencingMappingApiMockServer.stubPostCourtAppearanceMapping()
-
-          // court event charge mocking
-          chargeIds.forEach {
-            courtSentencingNomisApiMockServer.stubGetCourtEventCharge(
-              offenderNo = OFFENDER_ID_DISPLAY,
-              offenderChargeId = it.first,
-              courtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
-            )
-
-            dpsCourtSentencingServer.stubPostCourtChargeForCreate(
-              courtChargeId = it.second,
-              courtCaseId = DPS_COURT_CASE_ID,
-              offenderNo = OFFENDER_ID_DISPLAY,
-            )
-          }
-          courtSentencingMappingApiMockServer.stubGetCourtChargeByNomisId(status = NOT_FOUND)
-          courtSentencingMappingApiMockServer.stubPostCourtChargeMapping()
-
-          courtSentencingOffenderEventsQueue.sendMessage(
-
-            courtAppearanceEvent(
-              eventType = "COURT_EVENTS-INSERTED",
-              auditModule = "DPS_SYNCHRONISATION",
-              courtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
-              isBreachHearing = true,
-            ),
-          ).also { waitForAnyProcessingToComplete(name = "court-charge-synchronisation-created-success", times = 2) }
-        }
-
-        @Test
-        fun `will create a court appearance in DPS`() {
-          dpsCourtSentencingServer.verify(
-            postRequestedFor(urlPathEqualTo("/legacy/court-appearance"))
-              .withRequestBody(matchingJsonPath("legacyData.nomisOutcomeCode", equalTo("4506")))
-              .withRequestBody(matchingJsonPath("legacyData.outcomeConvictionFlag", equalTo("false")))
-              .withRequestBody(matchingJsonPath("legacyData.outcomeDispositionCode", equalTo("I")))
-              .withRequestBody(matchingJsonPath("legacyData.outcomeDescription", equalTo("Adjournment")))
-              .withRequestBody(matchingJsonPath("legacyData.nomisAppearanceTypeCode", equalTo("CRT")))
-              .withRequestBody(matchingJsonPath("legacyData.postedDate", not(WireMock.absent())))
-              .withRequestBody(matchingJsonPath("legacyData.appearanceTime", equalTo("09:00")))
-              .withRequestBody(matchingJsonPath("courtCode", equalTo("MDI")))
-              .withRequestBody(matchingJsonPath("courtCaseUuid", equalTo(DPS_COURT_CASE_ID)))
-              .withRequestBody(matchingJsonPath("appearanceDate", equalTo("2020-01-02"))),
-          )
-        }
-
-        @Test
-        fun `will create a court charges and associate with an appearance in DPS`() {
-          dpsCourtSentencingServer.verify(
-            2,
-            postRequestedFor(urlPathEqualTo("/legacy/charge"))
-              .withRequestBody(matchingJsonPath("appearanceLifetimeUuid", equalTo(DPS_COURT_APPEARANCE_ID))),
-          )
-        }
-
-        @Test
-        fun `will create mapping between DPS and NOMIS court charge ids`() {
-          chargeIds.forEach {
-            courtSentencingMappingApiMockServer.verify(
-              postRequestedFor(urlPathEqualTo("/mapping/court-sentencing/court-charges"))
-                .withRequestBody(matchingJsonPath("dpsCourtChargeId", equalTo(it.second)))
-                .withRequestBody(
-                  matchingJsonPath(
-                    "nomisCourtChargeId",
-                    equalTo(it.first.toString()),
-                  ),
-                ),
-            )
-          }
-        }
-
-        @Test
-        fun `will create mapping between DPS and NOMIS appearance ids`() {
-          courtSentencingMappingApiMockServer.verify(
-            postRequestedFor(urlPathEqualTo("/mapping/court-sentencing/court-appearances"))
-              .withRequestBody(matchingJsonPath("dpsCourtAppearanceId", equalTo(DPS_COURT_APPEARANCE_ID)))
-              .withRequestBody(
-                matchingJsonPath(
-                  "nomisCourtAppearanceId",
-                  equalTo(NOMIS_COURT_APPEARANCE_ID.toString()),
-                ),
-              )
-              .withRequestBody(matchingJsonPath("mappingType", equalTo("NOMIS_CREATED"))),
-          )
-        }
-
-        @Test
-        fun `will track a telemetry event for court appearance success`() {
-          verify(telemetryClient).trackEvent(
-            eq("court-appearance-synchronisation-created-success"),
-            check {
-              assertThat(it["offenderNo"]).isEqualTo(OFFENDER_ID_DISPLAY)
-              assertThat(it["isBreachHearing"]).isEqualTo("true")
-              assertThat(it["nomisBookingId"]).isEqualTo(NOMIS_BOOKING_ID.toString())
-              assertThat(it["nomisCourtCaseId"]).isEqualTo(NOMIS_COURT_CASE_ID.toString())
-              assertThat(it["nomisCourtAppearanceId"]).isEqualTo(NOMIS_COURT_APPEARANCE_ID.toString())
-              assertThat(it["dpsCourtCaseId"]).isEqualTo(DPS_COURT_CASE_ID)
-              assertThat(it["dpsCourtAppearanceId"]).isEqualTo(DPS_COURT_APPEARANCE_ID)
-              assertThat(it).doesNotContain(SimpleEntry("mapping", "initial-failure"))
-            },
-            isNull(),
-          )
-        }
-
-        @Test
-        fun `will track a telemetry event for court charge events success`() {
-          chargeIds.forEach { ids ->
-            verify(telemetryClient).trackEvent(
-              eq("court-charge-synchronisation-created-success"),
-              check {
-                assertThat(it["offenderNo"]).isEqualTo(OFFENDER_ID_DISPLAY)
-                assertThat(it["nomisBookingId"]).isEqualTo(NOMIS_BOOKING_ID.toString())
-                assertThat(it["nomisOffenderChargeId"]).isEqualTo(ids.first.toString())
-                assertThat(it["nomisCourtAppearanceId"]).isEqualTo(NOMIS_COURT_APPEARANCE_ID.toString())
-                assertThat(it["dpsChargeId"]).isEqualTo(ids.second)
-                assertThat(it["dpsCourtAppearanceId"]).isEqualTo(DPS_COURT_APPEARANCE_ID)
-                assertThat(it["existingDpsCharge"]).isEqualTo("false")
-                assertThat(it).doesNotContain(SimpleEntry("mapping", "initial-failure"))
-              },
-              isNull(),
-            )
-          }
-        }
-      }
-    }
-
-    @Nested
-    @DisplayName("When court appearance was cloned by DPS for a previous recall")
-    inner class DpsClonedRecallBreachHearing {
-      @Nested
-      @DisplayName("When happy path")
-      inner class HappyPath {
-        val chargeIds =
-          listOf((101L to "e94eea10-dfd1-43c2-b43c-56e8650f8ae7"), (102L to "e94eea10-dfd1-43c2-b43c-56e8650f8ae7"))
-
-        @BeforeEach
-        fun setUp() {
-          courtSentencingNomisApiMockServer.stubGetCourtAppearance(
-            courtCaseId = NOMIS_COURT_CASE_ID,
-            offenderNo = OFFENDER_ID_DISPLAY,
-            courtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
-            eventDateTime = LocalDateTime.parse("2020-01-02T09:00:00"),
-            courtId = "MDI",
-            isClone = true,
-            courtEventCharges = listOf(
-              courtEventChargeResponse(
-                eventId = NOMIS_COURT_APPEARANCE_ID,
-                offenderChargeId = chargeIds[0].first,
-              ),
-              courtEventChargeResponse(
-                eventId = NOMIS_COURT_APPEARANCE_ID,
-                offenderChargeId = chargeIds[1].first,
-              ),
-            ),
-          )
-
-          courtSentencingMappingApiMockServer.stubGetCourtAppearanceByNomisIdNotFoundFollowedBySuccess(
-            nomisCourtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
-            dpsCourtAppearanceId = DPS_COURT_APPEARANCE_ID,
-          )
-          courtSentencingOffenderEventsQueue.sendMessage(
-
-            courtAppearanceEvent(
-              eventType = "COURT_EVENTS-INSERTED",
-              auditModule = "DPS_SYNCHRONISATION",
-              courtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
-              isBreachHearing = true,
-            ),
-          ).also { waitForAnyProcessingToComplete(name = "court-appearance-synchronisation-created-skipped") }
-        }
-
-        @Test
-        fun `will not create a court appearance in DPS`() {
-          dpsCourtSentencingServer.verify(
-            0,
-            postRequestedFor(urlPathEqualTo("/legacy/court-appearance")),
-          )
-        }
-
-        @Test
-        fun `will track a telemetry event for court appearance skipped`() {
-          verify(telemetryClient).trackEvent(
-            eq("court-appearance-synchronisation-created-skipped"),
-            check {
-              assertThat(it["offenderNo"]).isEqualTo(OFFENDER_ID_DISPLAY)
-              assertThat(it["isBreachHearing"]).isEqualTo("true")
-              assertThat(it["nomisBookingId"]).isEqualTo(NOMIS_BOOKING_ID.toString())
-              assertThat(it["nomisCourtAppearanceId"]).isEqualTo(NOMIS_COURT_APPEARANCE_ID.toString())
-              assertThat(it["reason"]).isEqualTo("appearance is a clone of a breach hearing")
-            },
-            isNull(),
-          )
-        }
-      }
-    }
-
-    @Nested
     @DisplayName("duplicate mapping - two messages received at the same time")
     inner class WhenDuplicate {
 
@@ -2573,8 +2333,64 @@ class CourtSentencingSynchronisationIntTest : SqsIntegrationTestBase() {
   @Nested
   @DisplayName("courtsentencing.resync.breach-court-appearance.inserted")
   inner class RecallBreachCourtAppearanceInsertedSynchronisation {
+    val chargeIds =
+      listOf((101L to "e94eea10-dfd1-43c2-b43c-56e8650f8ae7"), (102L to "e94eea10-dfd1-43c2-b43c-56e8650f8ae7"))
+
     @BeforeEach
     fun setUp() {
+      courtSentencingNomisApiMockServer.stubGetCourtAppearance(
+        courtCaseId = NOMIS_COURT_CASE_ID,
+        offenderNo = OFFENDER_ID_DISPLAY,
+        courtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
+        eventDateTime = LocalDateTime.parse("2020-01-02T09:00:00"),
+        courtId = "MDI",
+        courtEventCharges = listOf(
+          courtEventChargeResponse(
+            eventId = NOMIS_COURT_APPEARANCE_ID,
+            offenderChargeId = chargeIds[0].first,
+          ),
+          courtEventChargeResponse(
+            eventId = NOMIS_COURT_APPEARANCE_ID,
+            offenderChargeId = chargeIds[1].first,
+          ),
+        ),
+      )
+
+      courtSentencingMappingApiMockServer.stubGetByNomisId(
+        nomisCourtCaseId = NOMIS_COURT_CASE_ID,
+        dpsCourtCaseId = DPS_COURT_CASE_ID,
+      )
+
+      courtSentencingMappingApiMockServer.stubPostCourtAppearanceMapping()
+
+      dpsCourtSentencingServer.stubPostCourtAppearanceForCreate(
+        courtAppearanceId = UUID.fromString(
+          DPS_COURT_APPEARANCE_ID,
+        ),
+      )
+
+      // called after appearance has been created for the charge processing
+      courtSentencingMappingApiMockServer.stubGetCourtAppearanceByNomisId(
+        nomisCourtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
+        dpsCourtAppearanceId = DPS_COURT_APPEARANCE_ID,
+      )
+      // court event charge mocking
+      chargeIds.forEach {
+        courtSentencingNomisApiMockServer.stubGetCourtEventCharge(
+          offenderNo = OFFENDER_ID_DISPLAY,
+          offenderChargeId = it.first,
+          courtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
+        )
+
+        dpsCourtSentencingServer.stubPostCourtChargeForCreate(
+          courtChargeId = it.second,
+          courtCaseId = DPS_COURT_CASE_ID,
+          offenderNo = OFFENDER_ID_DISPLAY,
+        )
+      }
+      courtSentencingMappingApiMockServer.stubGetCourtChargeByNomisId(status = NOT_FOUND)
+      courtSentencingMappingApiMockServer.stubPostCourtChargeMapping()
+
       courtSentencingOffenderEventsQueue.sendMessage(
         SQSMessage(
           Type = "courtsentencing.resync.breach-court-appearance.inserted",
@@ -2583,7 +2399,64 @@ class CourtSentencingSynchronisationIntTest : SqsIntegrationTestBase() {
             courtAppearanceId = NOMIS_COURT_APPEARANCE_ID,
           ).toJson(),
         ).toJson(),
-      ).also { waitForAnyProcessingToComplete("recall-breach-court-appearance-synchronisation-success") }
+      ).also { waitForAnyProcessingToComplete(name = "court-charge-synchronisation-created-success", times = 2) }
+    }
+
+    @Test
+    fun `will create a court appearance in DPS`() {
+      dpsCourtSentencingServer.verify(
+        postRequestedFor(urlPathEqualTo("/legacy/court-appearance"))
+          .withRequestBody(matchingJsonPath("legacyData.nomisOutcomeCode", equalTo("4506")))
+          .withRequestBody(matchingJsonPath("legacyData.outcomeConvictionFlag", equalTo("false")))
+          .withRequestBody(matchingJsonPath("legacyData.outcomeDispositionCode", equalTo("I")))
+          .withRequestBody(matchingJsonPath("legacyData.outcomeDescription", equalTo("Adjournment")))
+          .withRequestBody(matchingJsonPath("legacyData.nomisAppearanceTypeCode", equalTo("CRT")))
+          .withRequestBody(matchingJsonPath("legacyData.postedDate", not(WireMock.absent())))
+          .withRequestBody(matchingJsonPath("legacyData.appearanceTime", equalTo("09:00")))
+          .withRequestBody(matchingJsonPath("courtCode", equalTo("MDI")))
+          .withRequestBody(matchingJsonPath("courtCaseUuid", equalTo(DPS_COURT_CASE_ID)))
+          .withRequestBody(matchingJsonPath("appearanceDate", equalTo("2020-01-02"))),
+      )
+    }
+
+    @Test
+    fun `will create a court charges and associate with an appearance in DPS`() {
+      dpsCourtSentencingServer.verify(
+        2,
+        postRequestedFor(urlPathEqualTo("/legacy/charge"))
+          .withRequestBody(matchingJsonPath("appearanceLifetimeUuid", equalTo(DPS_COURT_APPEARANCE_ID))),
+      )
+    }
+
+    @Test
+    fun `will create mapping between DPS and NOMIS court charge ids`() {
+      chargeIds.forEach {
+        courtSentencingMappingApiMockServer.verify(
+          postRequestedFor(urlPathEqualTo("/mapping/court-sentencing/court-charges"))
+            .withRequestBody(matchingJsonPath("dpsCourtChargeId", equalTo(it.second)))
+            .withRequestBody(
+              matchingJsonPath(
+                "nomisCourtChargeId",
+                equalTo(it.first.toString()),
+              ),
+            ),
+        )
+      }
+    }
+
+    @Test
+    fun `will create mapping between DPS and NOMIS appearance ids`() {
+      courtSentencingMappingApiMockServer.verify(
+        postRequestedFor(urlPathEqualTo("/mapping/court-sentencing/court-appearances"))
+          .withRequestBody(matchingJsonPath("dpsCourtAppearanceId", equalTo(DPS_COURT_APPEARANCE_ID)))
+          .withRequestBody(
+            matchingJsonPath(
+              "nomisCourtAppearanceId",
+              equalTo(NOMIS_COURT_APPEARANCE_ID.toString()),
+            ),
+          )
+          .withRequestBody(matchingJsonPath("mappingType", equalTo("NOMIS_CREATED"))),
+      )
     }
 
     @Test
@@ -2592,7 +2465,10 @@ class CourtSentencingSynchronisationIntTest : SqsIntegrationTestBase() {
         eq("recall-breach-court-appearance-synchronisation-success"),
         check {
           assertThat(it["offenderNo"]).isEqualTo(OFFENDER_ID_DISPLAY)
+          assertThat(it["nomisCourtCaseId"]).isEqualTo("$NOMIS_COURT_CASE_ID")
+          assertThat(it["dpsCourtCaseId"]).isEqualTo(DPS_COURT_CASE_ID)
           assertThat(it["nomisCourtAppearanceId"]).isEqualTo("$NOMIS_COURT_APPEARANCE_ID")
+          assertThat(it["dpsCourtAppearanceId"]).isEqualTo(DPS_COURT_APPEARANCE_ID)
         },
         isNull(),
       )


### PR DESCRIPTION
Rather than relying on the breach hearing flag (which itself is simply using audit data), use the explicit re-sync SQS message received from the to-nomis sync service. This simplifies the "normal" court appearance handler and also breach hearing handling since we don't need all the "does this case exist yet checks?"