### PR TITLE
SDIT-3844 Implement move booking happy path

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerEventListener.kt
@@ -21,6 +21,7 @@ class CourtSchedulerEventListener(
   private val eventFeatureSwitch: EventFeatureSwitch,
   private val courtScheduleService: CourtSchedulerSyncScheduleService,
   private val courtMovementService: CourtSchedulerSyncMovementService,
+  private val moveBookingService: CourtSchedulerMoveBookingService,
 ) {
 
   private companion object {
@@ -42,6 +43,7 @@ class CourtSchedulerEventListener(
               "COURT_EVENTS-UPDATED" -> courtScheduleService.courtScheduleUpdated(sqsMessage.Message.fromJson())
               "COURT_EVENTS-DELETED" -> courtScheduleService.courtScheduleDeleted(sqsMessage.Message.fromJson())
               "EXTERNAL_MOVEMENT-CHANGED" -> courtMovementService.courtMovementChanged(sqsMessage.Message.fromJson())
+              "prison-offender-events.prisoner.booking.moved" -> moveBookingService.moveBooking(sqsMessage.Message.fromJson())
               else -> log.info("Received a message I wasn't expecting {}", eventType)
             }
           } else {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMoveBookingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMoveBookingService.kt
@@ -1,0 +1,77 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.MoveCourtEventRequest
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.data.PrisonerBookingMovedDomainEvent
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.TelemetryEnabled
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtMovementIdMapping
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtScheduleIdMapping
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingCourtMovements
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.SynchronisationQueueService
+
+@Service
+class CourtSchedulerMoveBookingService(
+  private val dpsApi: CourtSchedulerDpsApiService,
+  private val nomisApi: CourtSchedulerNomisApiService,
+  private val mappingApi: CourtSchedulerMappingApiService,
+  private val queueService: SynchronisationQueueService,
+  private val migrationService: CourtSchedulerMigrationService,
+  override val telemetryClient: TelemetryClient,
+) : TelemetryEnabled {
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  suspend fun moveBooking(request: PrisonerBookingMovedDomainEvent) {
+    val (toOffender, fromOffender, bookingId) = request.additionalInformation
+    val telemetry = mutableMapOf<String, String>(
+      "fromOffenderNo" to fromOffender,
+      "toOffenderNo" to toOffender,
+      "bookingId" to bookingId.toString(),
+    )
+
+    val booking = nomisApi.getBookingCourtMovementsOrNull(bookingId)!!
+    val mappings = mappingApi.getCourtSchedulerMoveBookingMappings(bookingId)
+
+    val dpsCourtAppearanceIds = booking.findDpsScheduleIds(mappings.scheduleIds)
+    val dpsUnscheduleMovementIds = booking.findDpsMovementIds(mappings.movementIds)
+    dpsApi.moveBooking(
+      MoveCourtEventRequest(
+        fromPersonIdentifier = fromOffender,
+        toPersonIdentifier = toOffender,
+        scheduleIds = dpsCourtAppearanceIds.toSet(),
+        unscheduledMovementIds = dpsUnscheduleMovementIds.toSet(),
+      ),
+    )
+    mappingApi.moveCourtSchedulerBookingMappings(bookingId, fromOffender, toOffender)
+
+    migrationService.resyncPrisonerCourtMovements(fromOffender)
+    migrationService.resyncPrisonerCourtMovements(toOffender)
+
+    telemetryClient.trackEvent(
+      "court-scheduler-move-booking-success",
+      telemetry,
+      null,
+    )
+  }
+
+  private fun BookingCourtMovements.findDpsScheduleIds(
+    mappings: List<CourtScheduleIdMapping>,
+  ) = courtSchedules
+    .map { it.eventId }
+    .mapNotNull { nomisEventId ->
+      mappings.find { it.nomisEventId == nomisEventId }
+        ?.dpsCourtAppearanceId
+    }
+
+  private fun BookingCourtMovements.findDpsMovementIds(
+    mappings: List<CourtMovementIdMapping>,
+  ) = (unscheduledCourtMovementOuts.map { it.sequence } + unscheduledCourtMovementIns.map { it.sequence })
+    .mapNotNull { nomisMovementSeq ->
+      mappings.find { it.nomisMovementSeq == nomisMovementSeq }
+        ?.dpsCourtMovementId
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerIntegrationTestBase.kt
@@ -1,10 +1,9 @@
 package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court
 
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.kotlin.times
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.SqsIntegrationTestBase
-import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerDpsApiExtension
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.COURTSCHEDULER_SYNC_QUEUE_ID
 import uk.gov.justice.hmpps.sqs.HmppsQueue
 
@@ -20,4 +19,7 @@ abstract class CourtSchedulerIntegrationTestBase : SqsIntegrationTestBase() {
   internal val courtMovementsQueueOffenderEventsDlqUrl by lazy { courtMovementsOffenderEventsQueue.dlqUrl as String }
 
   override fun getQueues(): List<HmppsQueue> = listOf(courtMovementsOffenderEventsQueue)
+
+  @MockitoSpyBean
+  protected lateinit var courtSchedulerMigrationService: CourtSchedulerMigrationService
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMoveBookingIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMoveBookingIntTest.kt
@@ -1,0 +1,131 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court
+
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.MoveCourtEventRequest
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helper.bookingMovedDomainEvent
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.integration.sendMessage
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerDpsApiExtension.Companion.dpsCourtSchedulerServer
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerDpsApiMockServer.Companion.getRequestBody
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerNomisApiMockServer.Companion.bookingCourtMovementIn
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerNomisApiMockServer.Companion.bookingCourtMovementOut
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court.CourtSchedulerNomisApiMockServer.Companion.bookingCourtSchedule
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtMovementIdMapping
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtScheduleIdMapping
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.CourtSchedulerMoveBookingMappingDto
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomisprisoner.model.BookingCourtMovements
+import java.util.*
+
+class CourtSchedulerMoveBookingIntTest(
+  @Autowired private val mappingApi: CourtSchedulerMappingApiMockServer,
+  @Autowired private val courtSchedulerNomisApi: CourtSchedulerNomisApiMockServer,
+) : CourtSchedulerIntegrationTestBase() {
+
+  private val dpsApi = dpsCourtSchedulerServer
+
+  @Nested
+  inner class HappyPath {
+    private val eventId1 = 1234L
+    private val dpsScheduleId1 = UUID.randomUUID()
+    private val movementSeq1 = 1
+    private val movementSeq2 = 2
+    private val scheduledMovementSeq1 = 3
+    private val scheduledMovementSeq2 = 4
+    private val dpsMovementId1 = UUID.randomUUID()
+    private val dpsMovementId2 = UUID.randomUUID()
+    private val dpsScheduledMovementId1 = UUID.randomUUID()
+    private val dpsScheduledMovementId2 = UUID.randomUUID()
+
+    private val moveBookingMappings = CourtSchedulerMoveBookingMappingDto(
+      scheduleIds = listOf(
+        CourtScheduleIdMapping(eventId1, dpsScheduleId1),
+      ),
+      movementIds = listOf(
+        CourtMovementIdMapping(movementSeq1, dpsMovementId1),
+        CourtMovementIdMapping(movementSeq2, dpsMovementId2),
+        CourtMovementIdMapping(scheduledMovementSeq1, dpsScheduledMovementId1),
+        CourtMovementIdMapping(scheduledMovementSeq2, dpsScheduledMovementId2),
+      ),
+    )
+
+    private val nomisData = BookingCourtMovements(
+      bookingId = 12345L,
+      activeBooking = true,
+      latestBooking = true,
+      courtSchedules = listOf(
+        bookingCourtSchedule(eventId = eventId1, movementOutSeq = scheduledMovementSeq1, movementInSeq = scheduledMovementSeq2),
+      ),
+      unscheduledCourtMovementOuts = listOf(bookingCourtMovementOut(seq = movementSeq1)),
+      unscheduledCourtMovementIns = listOf(bookingCourtMovementIn(seq = movementSeq2)),
+    )
+
+    @BeforeEach
+    fun setUp() = runTest {
+      courtSchedulerNomisApi.stubGetBookingCourtMovements(12345L, nomisData)
+      mappingApi.stubGetMoveBookingMappings(12345L, moveBookingMappings)
+      dpsApi.stubMoveBooking()
+      mappingApi.stubMoveBookingMappings(bookingId = 12345L, fromOffenderNo = "A1000KT", toOffenderNo = "A1234KT")
+
+      // Also need stubs for the calls to resync the prisoner. This bypasses the resync process because stubbing all of the various API calls makes the test data setup even more unreadable.
+      doNothing().whenever(courtSchedulerMigrationService).resyncPrisonerCourtMovements(any())
+
+      sendMessage(
+        bookingMovedDomainEvent(
+          bookingId = 12345,
+          movedToNomsNumber = "A1234KT",
+          movedFromNomsNumber = "A1000KT",
+        ),
+      )
+        .also { waitForAnyProcessingToComplete() }
+    }
+
+    @Test
+    fun `should get all movements from NOMIS`() {
+      courtSchedulerNomisApi.verifyGetBookingCourtMovements(bookingId = 12345L)
+    }
+
+    @Test
+    fun `should get move booking mappings`() {
+      mappingApi.verify(getRequestedFor(urlEqualTo("/mapping/court-scheduler/move-booking/12345")))
+    }
+
+    @Test
+    fun `should move DPS IDs for applications and unscheduled movements`() {
+      getRequestBody<MoveCourtEventRequest>(
+        putRequestedFor(urlEqualTo("/move/court-appearances")),
+      ).apply {
+        assertThat(fromPersonIdentifier).isEqualTo("A1000KT")
+        assertThat(toPersonIdentifier).isEqualTo("A1234KT")
+        assertThat(scheduleIds).containsExactlyInAnyOrder(dpsScheduleId1)
+        assertThat(unscheduledMovementIds).containsExactlyInAnyOrder(dpsMovementId1, dpsMovementId2)
+      }
+    }
+
+    @Test
+    fun `should move mappings to the new offender no`() {
+      mappingApi.verify(putRequestedFor(urlEqualTo("/mapping/court-scheduler/move-booking/12345/from/A1000KT/to/A1234KT")))
+    }
+
+    @Test
+    fun `should resync each offender`() = runTest {
+      verify(courtSchedulerMigrationService).resyncPrisonerCourtMovements("A1000KT")
+      verify(courtSchedulerMigrationService).resyncPrisonerCourtMovements("A1234KT")
+    }
+  }
+
+  private fun sendMessage(event: String) = awsSqsCourtMovementsOffenderEventsClient.sendMessage(
+    courtMovementsQueueOffenderEventsUrl,
+    event,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerNomisApiMockServer.kt
@@ -7,6 +7,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
 import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.OK
 import org.springframework.stereotype.Component
 import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.nomismappings.model.ErrorResponse
@@ -40,7 +41,7 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
       get(urlPathEqualTo("/movements/$offenderNo/court/schedule/out/$eventId")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
-          .withStatus(HttpStatus.OK.value())
+          .withStatus(OK.value())
           .withBody(jsonMapper.writeValueAsString(response)),
       ),
     )
@@ -73,7 +74,7 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
       get(urlPathEqualTo("/movements/$offenderNo/court/movement/out/$bookingId/$movementSeq")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
-          .withStatus(HttpStatus.OK.value())
+          .withStatus(OK.value())
           .withBody(jsonMapper.writeValueAsString(response)),
       ),
     )
@@ -106,7 +107,7 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
       get(urlPathEqualTo("/movements/$offenderNo/court/movement/in/$bookingId/$movementSeq")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
-          .withStatus(HttpStatus.OK.value())
+          .withStatus(OK.value())
           .withBody(jsonMapper.writeValueAsString(response)),
       ),
     )
@@ -131,7 +132,7 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
       get(urlPathEqualTo("/movements/$offenderNo/court")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
-          .withStatus(HttpStatus.OK.value())
+          .withStatus(OK.value())
           .withBody(jsonMapper.writeValueAsString(response)),
       ),
     )
@@ -159,7 +160,7 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
       get(urlPathEqualTo("/movements/booking/$bookingId/court")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
-          .withStatus(HttpStatus.OK.value())
+          .withStatus(OK.value())
           .withBody(jsonMapper.writeValueAsString(response)),
       ),
     )
@@ -275,8 +276,12 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
       ),
     )
 
-    fun bookingCourtSchedule() = BookingCourtScheduleOut(
-      eventId = 1,
+    fun bookingCourtSchedule(
+      eventId: Long = 1,
+      movementOutSeq: Int = 3,
+      movementInSeq: Int = 4,
+    ) = BookingCourtScheduleOut(
+      eventId = eventId,
       eventDate = yesterday.toLocalDate(),
       startTime = yesterday,
       eventType = "CRT",
@@ -287,8 +292,8 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
         createDatetime = yesterday,
         createUsername = "USER",
       ),
-      courtMovementOut = bookingCourtMovementOut(seq = 3),
-      courtMovementIn = bookingCourtMovementIn(seq = 4),
+      courtMovementOut = bookingCourtMovementOut(seq = movementOutSeq),
+      courtMovementIn = bookingCourtMovementIn(seq = movementInSeq),
       comment = "Some schedule comment",
       courtCaseId = 87878L,
     )


### PR DESCRIPTION
Adds the basic happy path for court scheduler move booking.

Outstanding scenarios TODO:

* more details in telemetry
* ignore if nothing to move or missing mappings
* fail if single mapping not found
* error if DPS update fails
* retry if mapping updates fails