### PR TITLE
SDIT-3995 Reject a resync if there is a court case but no RaS ID

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/config/ExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/config/ExceptionHandler.kt
@@ -90,6 +90,19 @@ class HmppsPrisonerFromNomisMigrationExceptionHandler {
       ),
   ).also { log.info("Bad request returned from downstream service: {}", e.message) }
 
+  @ExceptionHandler(ConflictException::class)
+  fun handleConflict(e: ConflictException): Mono<ResponseEntity<ErrorResponse>> = Mono.just(
+    ResponseEntity
+      .status(HttpStatus.CONFLICT.value())
+      .body(
+        ErrorResponse(
+          status = HttpStatus.CONFLICT.value(),
+          userMessage = "Conflict: ${e.message}",
+          developerMessage = e.message,
+        ),
+      ),
+  ).also { log.info("Conflict: {}", e.message) }
+
   @ExceptionHandler(MoveActivityStartDatesException::class)
   fun handleBadRequest(e: MoveActivityStartDatesException): Mono<ResponseEntity<ErrorResponse>> = Mono.just(
     ResponseEntity
@@ -126,3 +139,4 @@ data class ErrorResponse(
 }
 
 class BadRequestException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
+class ConflictException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationService.kt
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import tools.jackson.databind.json.JsonMapper
 import tools.jackson.module.kotlin.readValue
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.config.ConflictException
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.config.trackEvent
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.AtAndBy
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.CourtEvent
@@ -213,9 +214,14 @@ fun OffenderCourtMovementsResponse.toDpsRequest(
           eventId = schedule.eventId,
           commentText = schedule.comment,
           currentTerm = booking.latestBooking,
-          externalReferenceUrn = sentencingMappings.find { it.nomisCourtAppearanceId == schedule.eventId }
-            ?.dpsCourtAppearanceId
-            ?.let { "$EXTERNAL_REF_PREFIX$it" },
+          externalReferenceUrn = if (schedule.courtCaseId != null) {
+            sentencingMappings.find { it.nomisCourtAppearanceId == schedule.eventId }
+              ?.dpsCourtAppearanceId
+              ?.let { "$EXTERNAL_REF_PREFIX$it" }
+              ?: throw ConflictException("Could not find a sentencing mapping for eventId=${schedule.eventId} but there is a court case so we expect one")
+          } else {
+            null
+          },
         ),
         created = AtAndBy(schedule.audit.createDatetime, schedule.audit.createUsername.toDpsUser()),
         modified = schedule.audit.modifyDatetime?.let { AtAndBy(it, schedule.audit.modifyUserId!!.toDpsUser()) },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationIntTest.kt
@@ -580,6 +580,78 @@ class CourtSchedulerMigrationIntTest(
     }
 
     @Nested
+    inner class ErrorIfExternalReferenceDoesNotExist {
+      @BeforeEach
+      fun setUp() = runTest {
+        mappingApi.stubGetCourtSchedulerPrisonerMappingIds(prisonerNumber, 12345L, 1, dpsCourtScheduleId, 3, dpsScheduledMovementOutId, 4, dpsScheduledMovementInId, 1, dpsUnscheduledMovementOutId, 2, dpsUnscheduledMovementInId)
+        nomisApi.stubGetOffenderCourtMovements(prisonerNumber)
+        // The NOMIS response has a court case but there is no court sentencing mapping
+        sentencingMappingApi.stubGetAllCourtAppearanceByNomisIds(mappings = listOf())
+      }
+
+      @Test
+      fun `should return conflict`() {
+        repairPrisoner(prisonerNumber)
+          .expectStatus().isEqualTo(409)
+      }
+
+      @Test
+      fun `should check for existing mappings`() {
+        repairPrisoner(prisonerNumber)
+
+        mappingApi.verify(getRequestedFor(urlPathEqualTo("/mapping/court-scheduler/A0001KT/ids")))
+      }
+
+      @Test
+      fun `should get NOMIS court movement details`() {
+        repairPrisoner(prisonerNumber)
+
+        nomisApi.verify(getRequestedFor(urlPathEqualTo("/movements/A0001KT/court")))
+      }
+
+      @Test
+      fun `should get RaS court sentencing mappings`() {
+        repairPrisoner(prisonerNumber)
+
+        sentencingMappingApi.verify(
+          postRequestedFor(urlPathEqualTo("/mapping/court-sentencing/court-appearances/nomis-court-appearance-ids/get-list")),
+        )
+      }
+
+      @Test
+      fun `should NOT call DPS resync API`() {
+        repairPrisoner(prisonerNumber)
+
+        dpsApi.verify(0, putRequestedFor(urlPathEqualTo("/resync/court-appearances/A0001KT")))
+      }
+
+      @Test
+      fun `should NOT update mappings`() {
+        repairPrisoner(prisonerNumber)
+
+        mappingApi.verify(
+          count = 0,
+          putRequestedFor(urlPathEqualTo("/mapping/court-scheduler/migrate"))
+            .withRequestBodyJsonPath("offenderNo", "A0001KT"),
+        )
+      }
+
+      @Test
+      fun `will publish telemetry`() {
+        repairPrisoner(prisonerNumber)
+
+        verify(telemetryClient).trackEvent(
+          eq("court-scheduler-migration-entity-failed"),
+          check {
+            assertThat(it["offenderNo"]).isEqualTo("A0001KT")
+            assertThat(it["reason"]).isEqualTo("Could not find a sentencing mapping for eventId=1 but there is a court case so we expect one")
+          },
+          isNull(),
+        )
+      }
+    }
+
+    @Nested
     inner class Security {
 
       @Test


### PR DESCRIPTION
After a merge DPS CAS call our resync endpoint to get up to date info from NOMIS and tell us about the new mappings. However, RaS are also in the middle of handling the merge - so the RaS mapping might not exist yet, in which case we cannot tell CAS the RaS ID. 

Therefore if we have a court case but can't find the RaS mapping we reject the resync request - it's then up to CAS to retry the resync later, and at some point RaS will have finished and their mappings will exist. (in real life this is probably after the first retry, it's a race condition)