### PR TITLE
SDIT-4035 Add feature switch to ignore court case linked appearance inserts and updates

### DIFF
--- a/helm_deploy/hmpps-prisoner-from-nomis-migration/values.yaml
+++ b/helm_deploy/hmpps-prisoner-from-nomis-migration/values.yaml
@@ -37,6 +37,7 @@ generic-service:
     FEATURE_EVENT_COREPERSON_OFFENDER_BELIEFS-INSERTED: false
     FEATURE_EVENT_COREPERSON_OFFENDER_BELIEFS-UPDATED: false
     FEATURE_EVENT_COREPERSON_OFFENDER_BELIEFS-DELETED: false
+    FEATURE_COURT-SCHEDULER_IGNORE-ALL-SENTENCING-EVENTS: false
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/HmppsPrisonerFromNomisMigration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/HmppsPrisonerFromNomisMigration.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.prisonerfromnomismigration
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 class HmppsPrisonerFromNomisMigration
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerFeatureSwitches.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerFeatureSwitches.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.prisonerfromnomismigration.movements.court
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "feature.court-scheduler")
+class CourtSchedulerFeatureSwitches(
+  val ignoreAllSentencingEvents: Boolean = false,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerSyncScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerSyncScheduleService.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.InternalM
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.SynchronisationQueueService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.SynchronisationType
 import java.util.*
+import kotlin.collections.set
 
 private const val TELEMETRY_PREFIX: String = "${CRT_TELEMETRY_PREFIX}-schedule"
 
@@ -36,6 +37,7 @@ class CourtSchedulerSyncScheduleService(
   private val nomisApi: CourtSchedulerNomisApiService,
   private val dpsApi: CourtSchedulerDpsApiService,
   private val nomisSyncApi: CourtSchedulerNomisSyncApiService,
+  private val features: CourtSchedulerFeatureSwitches,
 ) : TelemetryEnabled {
 
   companion object {
@@ -48,15 +50,17 @@ class CourtSchedulerSyncScheduleService(
   }
 
   suspend fun syncCourtScheduleOutInserted(event: CourtScheduleEvent) {
-    val (eventId, bookingId, prisonerNumber, _, directionCode) = event
+    val (eventId, bookingId, prisonerNumber, caseId, directionCode) = event
     val telemetry = mutableMapOf<String, Any>(
       "offenderNo" to prisonerNumber,
       "bookingId" to bookingId,
       "nomisEventId" to eventId,
       "directionCode" to directionCode,
-    )
+    ).apply {
+      if (caseId != null) this["caseId"] = caseId
+    }
 
-    if (event.auditExactMatchOrHasMissingAudit(COURT_SCHEDULER_SYNC_AUDIT_MODULE)) {
+    if (event.auditExactMatchOrHasMissingAudit(COURT_SCHEDULER_SYNC_AUDIT_MODULE) || (caseId != null && features.ignoreAllSentencingEvents)) {
       telemetryClient.trackEvent("${TELEMETRY_PREFIX}-inserted-ignored", telemetry)
       return
     }
@@ -123,15 +127,17 @@ class CourtSchedulerSyncScheduleService(
   }
 
   suspend fun syncCourtScheduleOutUpdated(event: CourtScheduleEvent) {
-    val (eventId, bookingId, prisonerNumber, _, directionCode) = event
+    val (eventId, bookingId, prisonerNumber, caseId, directionCode) = event
     val telemetry = mutableMapOf<String, Any>(
       "offenderNo" to prisonerNumber,
       "bookingId" to bookingId,
       "nomisEventId" to eventId,
       "directionCode" to directionCode,
-    )
+    ).apply {
+      if (caseId != null) this["caseId"] = caseId
+    }
 
-    if (event.auditExactMatchOrHasMissingAudit(COURT_SCHEDULER_SYNC_AUDIT_MODULE)) {
+    if (event.auditExactMatchOrHasMissingAudit(COURT_SCHEDULER_SYNC_AUDIT_MODULE) || (caseId != null && features.ignoreAllSentencingEvents)) {
       telemetryClient.trackEvent("${TELEMETRY_PREFIX}-updated-ignored", telemetry)
       return
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerIntegrationTestBase.kt
@@ -27,4 +27,7 @@ abstract class CourtSchedulerIntegrationTestBase : SqsIntegrationTestBase() {
 
   @MockitoSpyBean(reset = MockReset.NONE)
   protected lateinit var queueService: SynchronisationQueueService
+
+  @MockitoSpyBean(reset = MockReset.NONE)
+  protected lateinit var courtSchedulerFeature: CourtSchedulerFeatureSwitches
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerSyncScheduleIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerSyncScheduleIntTest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.TestInstance
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.kotlin.any
 import org.mockito.kotlin.check
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
@@ -71,6 +72,7 @@ class CourtSchedulerSyncScheduleIntTest(
 
     reset(telemetryClient)
     reset(queueService)
+    reset(courtSchedulerFeature)
   }
 
   @Nested
@@ -205,6 +207,51 @@ class CourtSchedulerSyncScheduleIntTest(
           eq("court-scheduler-sync-schedule-inserted-success"),
           check {
             assertThat(it["dpsSentencingCourtAppearanceId"]).isEqualTo("$dpsSentencingCourtAppearanceId")
+          },
+          isNull(),
+        )
+      }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class LinkedToCourtCaseAndRasFeatureSwitchedOff {
+
+      @BeforeAll
+      fun setUp() {
+        setUpTestClass()
+        // Mock the feature switch as being turned on
+        doReturn(true).whenever(courtSchedulerFeature).ignoreAllSentencingEvents
+
+        sendMessage(courtScheduleEvent("COURT_EVENTS-INSERTED", caseId = 1314L))
+          .also { waitForAnyProcessingToComplete() }
+      }
+
+      @Test
+      fun `should NOT check mapping`() {
+        mappingApi.verify(
+          count = 0,
+          pattern = getRequestedFor(urlPathEqualTo("/mapping/court-scheduler/schedule/nomis-id/123")),
+        )
+      }
+
+      @Test
+      fun `should NOT create DPS scheduled movement`() {
+        dpsApi.verify(
+          0,
+          putRequestedFor(urlPathEqualTo("/sync/court-appearances/A1234BC")),
+        )
+      }
+
+      @Test
+      fun `should create telemetry`() {
+        verify(telemetryClient).trackEvent(
+          eq("court-scheduler-sync-schedule-inserted-ignored"),
+          check {
+            assertThat(it["offenderNo"]).isEqualTo("A1234BC")
+            assertThat(it["bookingId"]).isEqualTo("12345")
+            assertThat(it["nomisEventId"]).isEqualTo("123")
+            assertThat(it["caseId"]).isEqualTo("1314")
           },
           isNull(),
         )
@@ -762,6 +809,51 @@ class CourtSchedulerSyncScheduleIntTest(
           eq("court-scheduler-sync-schedule-updated-success"),
           check {
             assertThat(it["dpsSentencingCourtAppearanceId"]).isEqualTo("$dpsSentencingCourtAppearanceId")
+          },
+          isNull(),
+        )
+      }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class LinkedToCourtCaseAndRasFeatureSwitchedOff {
+
+      @BeforeAll
+      fun setUp() {
+        setUpTestClass()
+        // Mock the feature switch as being turned on
+        doReturn(true).whenever(courtSchedulerFeature).ignoreAllSentencingEvents
+
+        sendMessage(courtScheduleEvent("COURT_EVENTS-UPDATED", caseId = 1314L))
+          .also { waitForAnyProcessingToComplete() }
+      }
+
+      @Test
+      fun `should NOT check mapping`() {
+        mappingApi.verify(
+          count = 0,
+          pattern = getRequestedFor(urlPathEqualTo("/mapping/court-scheduler/schedule/nomis-id/123")),
+        )
+      }
+
+      @Test
+      fun `should NOT create DPS scheduled movement`() {
+        dpsApi.verify(
+          0,
+          putRequestedFor(urlPathEqualTo("/sync/court-appearances/A1234BC")),
+        )
+      }
+
+      @Test
+      fun `should publish telemetry`() {
+        verify(telemetryClient).trackEvent(
+          eq("court-scheduler-sync-schedule-updated-ignored"),
+          check {
+            assertThat(it["offenderNo"]).isEqualTo("A1234BC")
+            assertThat(it["bookingId"]).isEqualTo("12345")
+            assertThat(it["nomisEventId"]).isEqualTo("123")
+            assertThat(it["caseId"]).isEqualTo("1314")
           },
           isNull(),
         )
@@ -1367,12 +1459,13 @@ class CourtSchedulerSyncScheduleIntTest(
     nomisEventType: String = eventType.replace("COURT_EVENTS", "COURT_EVENT"),
     directionCode: String? = "OUT",
     eventId: Long = 123,
+    caseId: Long? = 1314,
   ) = // language=JSON
     """{
          "Type" : "Notification",
          "MessageId" : "57126174-e2d7-518f-914e-0056a63363b0",
          "TopicArn" : "arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-f221e27fcfcf78f6ab4f4c3cc165eee7",
-         "Message" : "{\"eventType\":\"$eventType\",\"eventDatetime\":\"2026-05-05T09:39:57\",\"nomisEventType\":\"$nomisEventType\",\"bookingId\":12345,\"offenderIdDisplay\":\"A1234BC\",\"auditModuleName\":\"$auditModuleName\",\"eventId\":$eventId,\"caseId\":101112,\"isBreachHearing\":false${directionCode?.let { """,\"directionCode\":\"$directionCode\"""" } ?: ""}}",
+         "Message" : "{\"eventType\":\"$eventType\",\"eventDatetime\":\"2026-05-05T09:39:57\",\"nomisEventType\":\"$nomisEventType\",\"bookingId\":12345,\"offenderIdDisplay\":\"A1234BC\",\"auditModuleName\":\"$auditModuleName\",\"eventId\":$eventId,\"caseId\":$caseId,\"isBreachHearing\":false${directionCode?.let { """,\"directionCode\":\"$directionCode\"""" } ?: ""}}",
          "Timestamp" : "2025-09-02T09:19:03.998Z",
          "SignatureVersion" : "1",
          "Signature" : "eePe/HtUdMyeFriH6GJe4FAJjYhQFjohJOu0+t8qULvpaw+qsGBfolKYa83fARpGDZJf9ceKd6kYGwF+OVeNViXluqPeUyoWbJ/lOjCs1tvlUuceCLy/7+eGGxkNASKJ1sWdwhO5J5I8WKUq5vfyYgL/Mygae6U71Bc0H9I2uVkw7tUYg0ZQBMSkA8HpuLLAN06qR5ahJnNDDxxoV07KY6E2dy8TheEo2Dhxq8hicl272LxWKMifM9VfR+D1i1eZNXDGsvvHmMCjumpxxYAJmrU+aqUzAU2KnhoZJTfeZT+RV+ZazjPLqX52zwA47ZFcqzCBnmrU6XwuHT4gKJcj1Q==",


### PR DESCRIPTION
When court scheduler and remand and sentencing sync court case linked court appearances between themselves, we'll need to stop listening for court appearances with court cases in the to-CAS sync. In the meantime we will put this behind a feature switch to support testing.