### PR TITLE
SDIT-4033 Handle RaS linked court movements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerSyncMovementService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerSyncMovementService.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.config.trackEvent
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.CourtEventMovement
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.SyncCourtEventMovement
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtscheduler.model.SyncUser
+import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.courtsentencing.CourtSentencingMappingApiService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.EventAudited.Companion.EDIT_EXTERNAL_MOVEMENTS_AUDIT_MODULE
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.TelemetryEnabled
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.helpers.track
@@ -28,6 +29,7 @@ import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.InternalM
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.SynchronisationQueueService
 import uk.gov.justice.digital.hmpps.prisonerfromnomismigration.service.SynchronisationType
 import java.util.*
+import kotlin.collections.set
 
 private const val TELEMETRY_PREFIX: String = "${CRT_TELEMETRY_PREFIX}-movement"
 
@@ -36,6 +38,7 @@ class CourtSchedulerSyncMovementService(
   override val telemetryClient: TelemetryClient,
   private val queueService: SynchronisationQueueService,
   private val mappingApi: CourtSchedulerMappingApiService,
+  private val sentencingMappingApi: CourtSentencingMappingApiService,
   private val nomisApi: CourtSchedulerNomisApiService,
   private val dpsApi: CourtSchedulerDpsApiService,
   private val migrationService: CourtSchedulerMigrationService,
@@ -102,14 +105,23 @@ class CourtSchedulerSyncMovementService(
     dpsCourtMovementId: UUID? = null,
   ): SyncCourtEventMovement {
     val nomis = nomisApi.getCourtMovementOut(prisonerNumber, bookingId, movementSeq)
-    val dpsCourtAppearanceId = nomis.courtScheduleOutId
+    val (dpsCourtAppearanceId, dpsSentencingCourtAppearanceId) = nomis.courtScheduleOutId
       ?.also { telemetry["nomisEventId"] = it }
-      ?.let {
-        tryFetchParent { mappingApi.getCourtScheduleMappingOrNull(it)?.dpsCourtAppearanceId }
-          .also { telemetry["dpsCourtAppearanceId"] = it }
-      }
+      ?.let { findDpsId(nomis.caseId, nomis.courtScheduleOutId, telemetry) }
+      ?: (null to null)
 
-    return nomis.toDpsRequest(dpsCourtAppearanceScheduleId = dpsCourtAppearanceId, dpsCourtMovementId = dpsCourtMovementId)
+    return nomis.toDpsRequest(dpsCourtMovementId, dpsCourtAppearanceId, dpsSentencingCourtAppearanceId)
+  }
+
+  private suspend fun findDpsId(nomisCaseId: Long?, nomisEventId: Long, telemetry: MutableMap<String, Any>): Pair<UUID?, String?> = if (nomisCaseId == null) {
+    tryFetchParent { mappingApi.getCourtScheduleMappingOrNull(nomisEventId)?.dpsCourtAppearanceId }
+      .also { telemetry["dpsCourtAppearanceId"] = it }
+      .let { it to null }
+  } else {
+    telemetry["nomisCourtCaseId"] = nomisCaseId
+    tryFetchParent { sentencingMappingApi.getCourtAppearanceOrNullByNomisId(nomisEventId)?.dpsCourtAppearanceId }
+      .also { telemetry["dpsSentencingCourtAppearanceId"] = it }
+      .let { null to it }
   }
 
   private suspend fun courtMovementInRequest(
@@ -120,14 +132,12 @@ class CourtSchedulerSyncMovementService(
     dpsCourtMovementId: UUID? = null,
   ): SyncCourtEventMovement {
     val nomis = nomisApi.getCourtMovementIn(prisonerNumber, bookingId, movementSeq)
-    val dpsCourtAppearanceId = nomis.courtScheduleOutId
+    val (dpsCourtAppearanceId, dpsSentencingCourtAppearanceId) = nomis.courtScheduleOutId
       ?.also { telemetry["nomisEventId"] = it }
-      ?.let {
-        tryFetchParent { mappingApi.getCourtScheduleMappingOrNull(it)?.dpsCourtAppearanceId }
-          .also { telemetry["dpsCourtAppearanceId"] = it }
-      }
+      ?.let { findDpsId(nomis.caseId, nomis.courtScheduleOutId, telemetry) }
+      ?: (null to null)
 
-    return nomis.toDpsRequest(dpsCourtAppearanceScheduleId = dpsCourtAppearanceId, dpsCourtMovementId = dpsCourtMovementId)
+    return nomis.toDpsRequest(dpsCourtMovementId, dpsCourtAppearanceId, dpsSentencingCourtAppearanceId)
   }
 
   suspend fun courtMovementUpdated(event: ExternalMovementEvent) {
@@ -227,6 +237,7 @@ class CourtSchedulerSyncMovementService(
 private fun CourtMovementOut.toDpsRequest(
   dpsCourtMovementId: UUID? = null,
   dpsCourtAppearanceScheduleId: UUID? = null,
+  dpsSentencingCourtAppearanceScheduleId: String? = null,
 ) = SyncCourtEventMovement(
   movement = CourtEventMovement(
     directionCode = "OUT",
@@ -239,6 +250,7 @@ private fun CourtMovementOut.toDpsRequest(
     fromAgencyId = fromPrison,
     toAgencyId = toCourt ?: MISSING_COURT,
     commentText = this.commentText,
+    dpsCourtAppearanceExternalReference = "$EXTERNAL_REF_PREFIX$dpsSentencingCourtAppearanceScheduleId",
   ),
   occurredAt = this.audit.modifyDatetime ?: this.audit.createDatetime,
   user = SyncUser(
@@ -250,6 +262,7 @@ private fun CourtMovementOut.toDpsRequest(
 private fun CourtMovementIn.toDpsRequest(
   dpsCourtMovementId: UUID? = null,
   dpsCourtAppearanceScheduleId: UUID? = null,
+  dpsSentencingCourtAppearanceScheduleId: String? = null,
 ) = SyncCourtEventMovement(
   movement = CourtEventMovement(
     directionCode = "IN",
@@ -262,6 +275,7 @@ private fun CourtMovementIn.toDpsRequest(
     fromAgencyId = fromCourt ?: MISSING_COURT,
     toAgencyId = toPrison,
     commentText = this.commentText,
+    dpsCourtAppearanceExternalReference = "$EXTERNAL_REF_PREFIX$dpsSentencingCourtAppearanceScheduleId",
   ),
   occurredAt = this.audit.modifyDatetime ?: this.audit.createDatetime,
   user = SyncUser(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerNomisApiMockServer.kt
@@ -64,10 +64,12 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
     movementSeq: Int = 3,
     movementTime: LocalDateTime = yesterday,
     courtScheduleOutId: Long? = null,
+    courtCaseId: Long? = null,
     response: CourtMovementOut = courtMovementOutResponse(
       movementTime = movementTime,
       movementSeq = movementSeq,
       courtScheduleOutId = courtScheduleOutId,
+      courtCaseId = courtCaseId,
     ),
   ) {
     nomisApi.stubFor(
@@ -97,10 +99,12 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
     movementSeq: Int = 4,
     movementTime: LocalDateTime = yesterday,
     courtScheduleOutId: Long? = null,
+    courtCaseId: Long? = null,
     response: CourtMovementIn = courtMovementInResponse(
       movementSeq = movementSeq,
       movementTime = movementTime,
       courtScheduleOutId = courtScheduleOutId,
+      courtCaseId = courtCaseId,
     ),
   ) {
     nomisApi.stubFor(
@@ -220,6 +224,7 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
       movementSeq: Int = 3,
       movementTime: LocalDateTime = now,
       courtScheduleOutId: Long? = null,
+      courtCaseId: Long? = null,
     ) = CourtMovementOut(
       bookingId = 12345,
       sequence = movementSeq,
@@ -230,6 +235,7 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
       toCourt = "LEEDMC",
       courtScheduleOutId = courtScheduleOutId,
       userActiveCaseloadId = "MDI",
+      caseId = courtCaseId,
       audit = NomisAudit(
         createDatetime = now,
         createUsername = "PRISONER_MANAGER_API",
@@ -240,6 +246,7 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
       movementSeq: Int = 4,
       movementTime: LocalDateTime = now,
       courtScheduleOutId: Long? = null,
+      courtCaseId: Long? = null,
     ) = CourtMovementIn(
       bookingId = 12345,
       sequence = movementSeq,
@@ -250,6 +257,7 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
       fromCourt = "LEEDMC",
       courtScheduleOutId = courtScheduleOutId,
       userActiveCaseloadId = "MDI",
+      caseId = courtCaseId,
       audit = NomisAudit(
         createDatetime = now,
         createUsername = "PRISONER_MANAGER_API",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerSyncMovementIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerSyncMovementIntTest.kt
@@ -244,6 +244,136 @@ class CourtSchedulerSyncMovementIntTest(
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class CourtCaseLinkedMovement {
+      private val dpsSentencingCourtAppearanceId = UUID.randomUUID()
+      private val dpsCourtMovementId: UUID = UUID.randomUUID()
+
+      @BeforeAll
+      fun setUp() {
+        setUpTestClass()
+
+        mappingApi.stubGetCourtMovementMapping(nomisBookingId = 12345L, nomisMovementSeq = 3, status = NOT_FOUND)
+        nomisApi.stubGetCourtMovementOut(
+          offenderNo = "A1234BC",
+          bookingId = 12345L,
+          movementSeq = 3,
+          courtScheduleOutId = 567L,
+          courtCaseId = 1314L,
+        )
+        // There is no mapping for the court schedule OUT because this is linked to a court case
+        mappingApi.stubGetCourtScheduleMapping(nomisEventId = 567L, NOT_FOUND)
+        // So there must be a court sentencing mapping
+        sentencingMappingApi.stubGetCourtAppearanceByNomisId(567L, "$dpsSentencingCourtAppearanceId")
+        dpsApi.stubSyncCourtMovement("A1234BC", referenceId(dpsCourtMovementId))
+        mappingApi.stubCreateCourtMovementMapping()
+
+        sendMessage(courtMovementEvent(direction = "OUT", inserted = true))
+          .also { waitForAnyProcessingToComplete() }
+      }
+
+      @Test
+      fun `should NOT try to get court schedule mapping`() {
+        mappingApi.verify(
+          count = 0,
+          pattern = getRequestedFor(urlPathEqualTo("/mapping/court-scheduler/schedule/nomis-id/567")),
+        )
+      }
+
+      @Test
+      fun `should try to get court sentencing mapping`() {
+        sentencingMappingApi.verify(
+          pattern = getRequestedFor(urlPathEqualTo("/mapping/court-sentencing/court-appearances/nomis-court-appearance-id/567")),
+        )
+      }
+
+      @Test
+      fun `should create DPS court movement`() {
+        CourtSchedulerDpsApiMockServer.getRequestBody<SyncCourtEventMovement>(
+          putRequestedFor(urlPathEqualTo("/sync/court-appearance-movements/A1234BC")),
+        ).apply {
+          assertThat(movement.dpsCourtAppearanceScheduleId).isNull()
+          assertThat(movement.dpsCourtAppearanceExternalReference).isEqualTo("$EXTERNAL_REF_PREFIX$dpsSentencingCourtAppearanceId")
+        }
+      }
+
+      @Test
+      fun `should publish telemetry with DPS sentencing court appearance ID`() {
+        verify(telemetryClient).trackEvent(
+          eq("court-scheduler-sync-movement-inserted-success"),
+          check {
+            assertThat(it["nomisEventId"]).isEqualTo("567")
+            assertThat(it["dpsCourtMovementId"]).isEqualTo("$dpsCourtMovementId")
+            assertThat(it["nomisCourtCaseId"]).isEqualTo("1314")
+            assertThat(it["dpsSentencingCourtAppearanceId"]).isEqualTo("$dpsSentencingCourtAppearanceId")
+          },
+          isNull(),
+        )
+      }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class CourtCaseLinkedMovementWithMissingSchedule {
+
+      @BeforeAll
+      fun setUp() {
+        setUpTestClass()
+
+        mappingApi.stubGetCourtMovementMapping(nomisBookingId = 12345L, nomisMovementSeq = 3, status = NOT_FOUND)
+        nomisApi.stubGetCourtMovementOut(
+          offenderNo = "A1234BC",
+          bookingId = 12345L,
+          movementSeq = 3,
+          courtScheduleOutId = 567L,
+          courtCaseId = 1314L,
+        )
+        // There is no mapping for the court schedule OUT because this is linked to a court case
+        mappingApi.stubGetCourtScheduleMapping(nomisEventId = 567L, NOT_FOUND)
+        // And there is no court sentencing mapping either
+        sentencingMappingApi.stubGetCourtAppearanceByNomisId(status = NOT_FOUND)
+
+        sendMessage(courtMovementEvent(direction = "OUT", inserted = true))
+          .also { waitForAnyProcessingToComplete("court-scheduler-sync-movement-inserted-awaiting-parent") }
+      }
+
+      @Test
+      fun `should NOT try to get court schedule mapping`() {
+        mappingApi.verify(
+          count = 0,
+          pattern = getRequestedFor(urlPathEqualTo("/mapping/court-scheduler/schedule/nomis-id/567")),
+        )
+      }
+
+      @Test
+      fun `should try to get court sentencing mapping`() {
+        sentencingMappingApi.verify(
+          pattern = getRequestedFor(urlPathEqualTo("/mapping/court-sentencing/court-appearances/nomis-court-appearance-id/567")),
+        )
+      }
+
+      @Test
+      fun `should NOT create DPS court movement`() {
+        dpsApi.verify(
+          0,
+          putRequestedFor(urlPathEqualTo("/sync/court-appearance-movements/A1234BC")),
+        )
+      }
+
+      @Test
+      fun `should publish failure telemetry with DPS court appearance ID`() {
+        verify(telemetryClient).trackEvent(
+          eq("court-scheduler-sync-movement-inserted-awaiting-parent"),
+          check {
+            assertThat(it["nomisEventId"]).isEqualTo("567")
+            assertThat(it["nomisCourtCaseId"]).isEqualTo("1314")
+          },
+          isNull(),
+        )
+      }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class WhenCreatedInDps {
 
       @BeforeAll
@@ -609,6 +739,74 @@ class CourtSchedulerSyncMovementIntTest(
             assertThat(it["nomisEventId"]).isEqualTo("567")
             assertThat(it["dpsCourtMovementId"]).isEqualTo("$dpsCourtMovementId")
             assertThat(it["dpsCourtAppearanceId"]).isEqualTo("$dpsCourtAppearanceId")
+          },
+          isNull(),
+        )
+      }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class HappyPathWithCourtCaseLinkedSchedule {
+      private val dpsSentencingCourtAppearanceId: UUID = UUID.randomUUID()
+      private val dpsCourtMovementId: UUID = UUID.randomUUID()
+
+      @BeforeAll
+      fun setUp() {
+        setUpTestClass()
+
+        mappingApi.stubGetCourtMovementMapping(nomisBookingId = 12345L, nomisMovementSeq = 3, dpsCourtMovementId = dpsCourtMovementId)
+        nomisApi.stubGetCourtMovementOut(
+          offenderNo = "A1234BC",
+          bookingId = 12345L,
+          movementSeq = 3,
+          courtScheduleOutId = 567L,
+          courtCaseId = 1314L,
+        )
+        // There is no mapping for the court schedule OUT because this is linked to a court case
+        mappingApi.stubGetCourtScheduleMapping(nomisEventId = 567L, NOT_FOUND)
+        // So there must be a court sentencing mapping
+        sentencingMappingApi.stubGetCourtAppearanceByNomisId(567L, "$dpsSentencingCourtAppearanceId")
+        dpsApi.stubSyncCourtMovement("A1234BC", referenceId(dpsCourtMovementId))
+
+        sendMessage(courtMovementEvent(direction = "OUT", inserted = false))
+          .also { waitForAnyProcessingToComplete() }
+      }
+
+      @Test
+      fun `should NOT try to get court schedule mapping`() {
+        mappingApi.verify(
+          count = 0,
+          pattern = getRequestedFor(urlPathEqualTo("/mapping/court-scheduler/schedule/nomis-id/567")),
+        )
+      }
+
+      @Test
+      fun `should try to get court sentencing mapping`() {
+        sentencingMappingApi.verify(
+          pattern = getRequestedFor(urlPathEqualTo("/mapping/court-sentencing/court-appearances/nomis-court-appearance-id/567")),
+        )
+      }
+
+      @Test
+      fun `should update DPS court appearance movement`() {
+        CourtSchedulerDpsApiMockServer.getRequestBody<SyncCourtEventMovement>(
+          putRequestedFor(urlPathEqualTo("/sync/court-appearance-movements/A1234BC")),
+        ).apply {
+          assertThat(movement.dpsCourtAppearanceScheduleId).isNull()
+          assertThat(movement.dpsCourtAppearanceExternalReference).isEqualTo("$EXTERNAL_REF_PREFIX$dpsSentencingCourtAppearanceId")
+        }
+      }
+
+      @Test
+      fun `should publish success telemetry`() {
+        verify(telemetryClient).trackEvent(
+          eq("court-scheduler-sync-movement-updated-success"),
+          check {
+            assertThat(it["nomisEventId"]).isEqualTo("567")
+            assertThat(it["dpsCourtMovementId"]).isEqualTo("$dpsCourtMovementId")
+            assertThat(it["nomisCourtCaseId"]).isEqualTo("1314")
+            assertThat(it["dpsSentencingCourtAppearanceId"]).isEqualTo("$dpsSentencingCourtAppearanceId")
           },
           isNull(),
         )
@@ -994,6 +1192,136 @@ class CourtSchedulerSyncMovementIntTest(
         )
       }
     }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class CourtCaseLinkedMovement {
+      private val dpsCourtMovementId = UUID.randomUUID()
+      private val dpsSentencingCourtAppearanceId = UUID.randomUUID()
+
+      @BeforeAll
+      fun setUp() {
+        setUpTestClass()
+
+        mappingApi.stubGetCourtMovementMapping(nomisBookingId = 12345L, nomisMovementSeq = 3, status = NOT_FOUND)
+        nomisApi.stubGetCourtMovementIn(
+          offenderNo = "A1234BC",
+          bookingId = 12345L,
+          movementSeq = 3,
+          courtScheduleOutId = 567L,
+          courtCaseId = 1314L,
+        )
+        // There is no mapping for the court schedule OUT because the schedule is linked to a court case
+        mappingApi.stubGetCourtScheduleMapping(nomisEventId = 567L, status = NOT_FOUND)
+        // So there must be a court sentencing mapping
+        sentencingMappingApi.stubGetCourtAppearanceByNomisId(567L, "$dpsSentencingCourtAppearanceId")
+        dpsApi.stubSyncCourtMovement("A1234BC", referenceId(dpsCourtMovementId))
+        mappingApi.stubCreateCourtMovementMapping()
+
+        sendMessage(courtMovementEvent(direction = "IN", inserted = true))
+          .also { waitForAnyProcessingToComplete() }
+      }
+
+      @Test
+      fun `should NOT try to get court schedule mapping`() {
+        mappingApi.verify(
+          count = 0,
+          pattern = getRequestedFor(urlPathEqualTo("/mapping/court-scheduler/schedule/nomis-id/567")),
+        )
+      }
+
+      @Test
+      fun `should try to get court sentencing mapping`() {
+        sentencingMappingApi.verify(
+          pattern = getRequestedFor(urlPathEqualTo("/mapping/court-sentencing/court-appearances/nomis-court-appearance-id/567")),
+        )
+      }
+
+      @Test
+      fun `should create DPS court movement`() {
+        CourtSchedulerDpsApiMockServer.getRequestBody<SyncCourtEventMovement>(
+          putRequestedFor(urlPathEqualTo("/sync/court-appearance-movements/A1234BC")),
+        ).apply {
+          assertThat(movement.dpsCourtAppearanceScheduleId).isNull()
+          assertThat(movement.dpsCourtAppearanceExternalReference).isEqualTo("$EXTERNAL_REF_PREFIX$dpsSentencingCourtAppearanceId")
+        }
+      }
+
+      @Test
+      fun `should publish telemetry with DPS sentencing court appearance ID`() {
+        verify(telemetryClient).trackEvent(
+          eq("court-scheduler-sync-movement-inserted-success"),
+          check {
+            assertThat(it["nomisEventId"]).isEqualTo("567")
+            assertThat(it["nomisCourtCaseId"]).isEqualTo("1314")
+            assertThat(it["dpsSentencingCourtAppearanceId"]).isEqualTo("$dpsSentencingCourtAppearanceId")
+            assertThat(it["dpsCourtMovementId"]).isEqualTo("$dpsCourtMovementId")
+          },
+          isNull(),
+        )
+      }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class CourtCaseLinkedMovementWithMissingSchedule {
+
+      @BeforeAll
+      fun setUp() {
+        setUpTestClass()
+
+        mappingApi.stubGetCourtMovementMapping(nomisBookingId = 12345L, nomisMovementSeq = 3, status = NOT_FOUND)
+        nomisApi.stubGetCourtMovementIn(
+          offenderNo = "A1234BC",
+          bookingId = 12345L,
+          movementSeq = 3,
+          courtScheduleOutId = 567L,
+          courtCaseId = 1314L,
+        )
+        // There is no mapping for the court schedule OUT becase the schedule is linked to a court case
+        mappingApi.stubGetCourtScheduleMapping(nomisEventId = 567L, status = NOT_FOUND)
+        // And there is no court sentencing mapping either
+        sentencingMappingApi.stubGetCourtAppearanceByNomisId(status = NOT_FOUND)
+
+        sendMessage(courtMovementEvent(direction = "IN", inserted = true))
+          .also { waitForAnyProcessingToComplete("court-scheduler-sync-movement-inserted-awaiting-parent") }
+      }
+
+      @Test
+      fun `should NOT try to get court schedule mapping`() {
+        mappingApi.verify(
+          count = 0,
+          pattern = getRequestedFor(urlPathEqualTo("/mapping/court-scheduler/schedule/nomis-id/567")),
+        )
+      }
+
+      @Test
+      fun `should try to get court sentencing mapping`() {
+        sentencingMappingApi.verify(
+          pattern = getRequestedFor(urlPathEqualTo("/mapping/court-sentencing/court-appearances/nomis-court-appearance-id/567")),
+        )
+      }
+
+      @Test
+      fun `should NOT create DPS court movement`() {
+        dpsApi.verify(
+          0,
+          putRequestedFor(urlPathEqualTo("/sync/court-appearance-movements/A1234BC")),
+        )
+      }
+
+      @Test
+      fun `should publish success telemetry with court appearance ID`() {
+        verify(telemetryClient).trackEvent(
+          eq("court-scheduler-sync-movement-inserted-awaiting-parent"),
+          check {
+            assertThat(it["nomisEventId"]).isEqualTo("567")
+            assertThat(it["nomisCourtCaseId"]).isEqualTo("1314")
+          },
+          isNull(),
+        )
+      }
+    }
   }
 
   @Nested
@@ -1107,6 +1435,76 @@ class CourtSchedulerSyncMovementIntTest(
             assertThat(it["nomisEventId"]).isEqualTo("567")
             assertThat(it["dpsCourtMovementId"]).isEqualTo("$dpsCourtMovementId")
             assertThat(it["dpsCourtAppearanceId"]).isEqualTo("$dpsCourtAppearanceId")
+          },
+          isNull(),
+        )
+      }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class HappyPathWithCourtCaseLinkedSchedule {
+      private val dpsCourtMovementId = UUID.randomUUID()
+      private val dpsSentencingCourtAppearanceId = UUID.randomUUID()
+
+      @BeforeAll
+      fun setUp() {
+        setUpTestClass()
+
+        mappingApi.stubGetCourtMovementMapping(nomisBookingId = 12345L, nomisMovementSeq = 3, dpsCourtMovementId = dpsCourtMovementId)
+        nomisApi.stubGetCourtMovementIn(
+          offenderNo = "A1234BC",
+          bookingId = 12345L,
+          movementSeq = 3,
+          courtScheduleOutId = 567L,
+          courtCaseId = 1314L,
+        )
+        // There is no mapping for the court schedule OUT because the schedule is linked to a court case
+        mappingApi.stubGetCourtScheduleMapping(nomisEventId = 567L, status = NOT_FOUND)
+        // So there must be a court sentencing mapping
+        sentencingMappingApi.stubGetCourtAppearanceByNomisId(567L, "$dpsSentencingCourtAppearanceId")
+        dpsApi.stubSyncCourtMovement("A1234BC", referenceId(dpsCourtMovementId))
+
+        sendMessage(courtMovementEvent(direction = "IN", inserted = false))
+          .also { waitForAnyProcessingToComplete() }
+      }
+
+      @Test
+      fun `should NOT try to get court schedule mapping`() {
+        mappingApi.verify(
+          count = 0,
+          pattern = getRequestedFor(urlPathEqualTo("/mapping/court-scheduler/schedule/nomis-id/567")),
+        )
+      }
+
+      @Test
+      fun `should try to get court sentencing mapping`() {
+        sentencingMappingApi.verify(
+          pattern = getRequestedFor(urlPathEqualTo("/mapping/court-sentencing/court-appearances/nomis-court-appearance-id/567")),
+        )
+      }
+
+      @Test
+      fun `should update DPS court appearance movement`() {
+        CourtSchedulerDpsApiMockServer.getRequestBody<SyncCourtEventMovement>(
+          putRequestedFor(urlPathEqualTo("/sync/court-appearance-movements/A1234BC")),
+        ).apply {
+          assertThat(movement.dpsId).isEqualTo(dpsCourtMovementId)
+          assertThat(movement.dpsCourtAppearanceScheduleId).isNull()
+          assertThat(movement.dpsCourtAppearanceExternalReference).isEqualTo("$EXTERNAL_REF_PREFIX$dpsSentencingCourtAppearanceId")
+          assertThat(movement.directionCode).isEqualTo("IN")
+        }
+      }
+
+      @Test
+      fun `should publish success telemetry`() {
+        verify(telemetryClient).trackEvent(
+          eq("court-scheduler-sync-movement-updated-success"),
+          check {
+            assertThat(it["nomisEventId"]).isEqualTo("567")
+            assertThat(it["nomisCourtCaseId"]).isEqualTo("1314")
+            assertThat(it["dpsSentencingCourtAppearanceId"]).isEqualTo("$dpsSentencingCourtAppearanceId")
+            assertThat(it["dpsCourtMovementId"]).isEqualTo("$dpsCourtMovementId")
           },
           isNull(),
         )


### PR DESCRIPTION
Once court scheduler and remand and sentencing sync between themselves we won't have any mappings for RaS court appearances in the CAS mapping database. Therefore whenever we sync a court movement to CAS we need to send them either the existing CAS ID if there's no court case, or the existing RaS ID if there is, or neither if the court movement is unscheduled.