### PR TITLE
SDIT-4033 In court scheduler resync, send RaS ID if court case linked else CAS ID

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationService.kt
@@ -205,7 +205,11 @@ fun OffenderCourtMovementsResponse.toDpsRequest(
     booking.courtSchedules.map { schedule ->
       ResyncCourtEvent(
         courtEvent = CourtEvent(
-          dpsId = oldMappingIds.schedules.find { it.nomisEventId == schedule.eventId }?.dpsCourtAppearanceId,
+          dpsId = if (schedule.courtCaseId == null) {
+            oldMappingIds.schedules.find { it.nomisEventId == schedule.eventId }?.dpsCourtAppearanceId
+          } else {
+            null
+          },
           agyLocId = schedule.court,
           start = schedule.startTime,
           courtEventType = schedule.eventType,
@@ -225,26 +229,28 @@ fun OffenderCourtMovementsResponse.toDpsRequest(
         created = AtAndBy(schedule.audit.createDatetime, schedule.audit.createUsername.toDpsUser()),
         modified = schedule.audit.modifyDatetime?.let { AtAndBy(it, schedule.audit.modifyUserId!!.toDpsUser()) },
         movements = listOfNotNull(
-          schedule.courtMovementOut?.toDpsRequest(oldMappingIds, booking.bookingId, schedule.eventId),
-          schedule.courtMovementIn?.toDpsRequest(oldMappingIds, booking.bookingId, schedule.eventId),
+          schedule.courtMovementOut?.toDpsRequest(oldMappingIds, sentencingMappings, booking.bookingId, schedule.eventId, schedule.courtCaseId != null),
+          schedule.courtMovementIn?.toDpsRequest(oldMappingIds, sentencingMappings, booking.bookingId, schedule.eventId, schedule.courtCaseId != null),
         ),
       )
     }
   },
   unscheduledMovements = bookings.flatMap { booking ->
     booking.unscheduledCourtMovementOuts.map { movementOut ->
-      movementOut.toDpsRequest(oldMappingIds, booking.bookingId, null)
+      movementOut.toDpsRequest(oldMappingIds, sentencingMappings, booking.bookingId, null)
     } +
       booking.unscheduledCourtMovementIns.map { movementIn ->
-        movementIn.toDpsRequest(oldMappingIds, booking.bookingId, null)
+        movementIn.toDpsRequest(oldMappingIds, sentencingMappings, booking.bookingId, null)
       }
   },
 )
 
 private fun BookingCourtMovementOut.toDpsRequest(
   oldMappingIds: CourtSchedulerPrisonerMappingIdsDto,
+  sentencingMappings: List<CourtAppearanceMappingDto>,
   bookingId: Long,
   eventId: Long?,
+  hasCourtCase: Boolean = false,
 ): ResyncCourtEventMovement = ResyncCourtEventMovement(
   movement = CourtEventMovement(
     dpsId = oldMappingIds.movements.find { it.nomisBookingId == bookingId && it.nomisMovementSeq == sequence }?.dpsCourtMovementId,
@@ -253,7 +259,16 @@ private fun BookingCourtMovementOut.toDpsRequest(
     directionCode = "OUT",
     fromAgencyId = fromPrison,
     toAgencyId = toCourt ?: MISSING_COURT,
-    dpsCourtAppearanceScheduleId = oldMappingIds.schedules.find { it.nomisEventId == eventId }?.dpsCourtAppearanceId,
+    dpsCourtAppearanceScheduleId = if (!hasCourtCase) {
+      oldMappingIds.schedules.find { it.nomisEventId == eventId }?.dpsCourtAppearanceId
+    } else {
+      null
+    },
+    dpsCourtAppearanceExternalReference = if (hasCourtCase) {
+      sentencingMappings.find { it.nomisCourtAppearanceId == eventId }?.dpsCourtAppearanceId?.let { "$EXTERNAL_REF_PREFIX$it" }
+    } else {
+      null
+    },
     offenderBookId = bookingId,
     movementSeq = sequence,
     commentText = commentText,
@@ -264,8 +279,10 @@ private fun BookingCourtMovementOut.toDpsRequest(
 
 private fun BookingCourtMovementIn.toDpsRequest(
   oldMappingIds: CourtSchedulerPrisonerMappingIdsDto,
+  sentencingMappings: List<CourtAppearanceMappingDto>,
   bookingId: Long,
   eventId: Long?,
+  hasCourtCase: Boolean = false,
 ): ResyncCourtEventMovement = ResyncCourtEventMovement(
   movement = CourtEventMovement(
     dpsId = oldMappingIds.movements.find { it.nomisBookingId == bookingId && it.nomisMovementSeq == sequence }?.dpsCourtMovementId,
@@ -274,7 +291,16 @@ private fun BookingCourtMovementIn.toDpsRequest(
     directionCode = "IN",
     fromAgencyId = fromCourt ?: MISSING_COURT,
     toAgencyId = toPrison,
-    dpsCourtAppearanceScheduleId = oldMappingIds.schedules.find { it.nomisEventId == eventId }?.dpsCourtAppearanceId,
+    dpsCourtAppearanceScheduleId = if (!hasCourtCase) {
+      oldMappingIds.schedules.find { it.nomisEventId == eventId }?.dpsCourtAppearanceId
+    } else {
+      null
+    },
+    dpsCourtAppearanceExternalReference = if (hasCourtCase) {
+      sentencingMappings.find { it.nomisCourtAppearanceId == eventId }?.dpsCourtAppearanceId?.let { "$EXTERNAL_REF_PREFIX$it" }
+    } else {
+      null
+    },
     offenderBookId = bookingId,
     movementSeq = sequence,
     commentText = commentText,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMappingApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMappingApiMockServer.kt
@@ -307,7 +307,7 @@ class CourtSchedulerMappingApiMockServer(private val jsonMapper: JsonMapper) {
     prisonerNumber: String = "A1234BC",
     bookingId: Long = 12345,
     nomisEventId: Long = 1,
-    dpsCourtAppearanceId: UUID = UUID.randomUUID(),
+    dpsCourtAppearanceId: UUID? = UUID.randomUUID(),
     nomisMovementOutSeq: Int = 3,
     dpsMovementOutId: UUID = UUID.randomUUID(),
     nomisMovementInSeq: Int = 4,
@@ -490,7 +490,7 @@ fun courtSchedulerPrisonerMappings(prisonerNumber: String = "A1234BC") = CourtSc
 fun courtSchedulerPrisonerIdMappings(
   bookingId: Long = 12345,
   nomisEventId: Long = 1,
-  dpsCourtAppearanceId: UUID = UUID.randomUUID(),
+  dpsCourtAppearanceId: UUID? = UUID.randomUUID(),
   nomisMovementOutSeq: Int = 3,
   dpsMovementOutId: UUID = UUID.randomUUID(),
   nomisMovementInSeq: Int = 4,
@@ -501,7 +501,7 @@ fun courtSchedulerPrisonerIdMappings(
   dpsUnscheduledMovementInId: UUID = UUID.randomUUID(),
 ) = CourtSchedulerPrisonerMappingIdsDto(
   prisonerNumber = "A1234BC",
-  schedules = listOf(CourtScheduleMappingIdsDto(nomisEventId, dpsCourtAppearanceId)),
+  schedules = listOfNotNull(dpsCourtAppearanceId?.let { CourtScheduleMappingIdsDto(nomisEventId, dpsCourtAppearanceId) }),
   movements = listOf(
     CourtMovementMappingIdsDto(bookingId, nomisMovementOutSeq, dpsMovementOutId),
     CourtMovementMappingIdsDto(bookingId, nomisMovementInSeq, dpsMovementInId),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerMigrationIntTest.kt
@@ -80,14 +80,14 @@ class CourtSchedulerMigrationIntTest(
   @AfterAll
   fun tearDownTelemetryClient() = reset(telemetryClient)
 
-  private fun stubMigrationDependencies(entities: Int = 2) {
+  private fun stubMigrationDependencies(entities: Int = 2, courtCaseId: Long? = null) {
     NomisApiExtension.nomisApi.stubGetPrisonerIds(totalElements = entities.toLong(), pageSize = 10, firstOffenderNo = "A0001KT")
     mappingApi.stubCreateCourtSchedulerPrisonerMappings()
     (1..entities)
       .map { index -> "A%04dKT".format(index) }
       .forEach { prisonerNumber ->
-        mappingApi.stubGetCourtSchedulerPrisonerMappingIds(prisonerNumber, 12345L, 1, dpsCourtScheduleId, 3, dpsScheduledMovementOutId, 4, dpsScheduledMovementInId, 1, dpsUnscheduledMovementOutId, 2, dpsUnscheduledMovementInId)
-        nomisApi.stubGetOffenderCourtMovements(prisonerNumber)
+        mappingApi.stubGetCourtSchedulerPrisonerMappingIds(prisonerNumber, 12345L, 1, dpsCourtScheduleId.takeIf { courtCaseId == null }, 3, dpsScheduledMovementOutId, 4, dpsScheduledMovementInId, 1, dpsUnscheduledMovementOutId, 2, dpsUnscheduledMovementInId)
+        nomisApi.stubGetOffenderCourtMovements(prisonerNumber, courtCaseId = courtCaseId)
         sentencingMappingApi.stubGetAllCourtAppearanceByNomisIds(
           mappings = listOf(CourtAppearanceMappingDto(1, dpsSentencingCourtAppearanceId.toString(), "any", CourtAppearanceMappingDto.MappingType.MIGRATED)),
         )
@@ -144,7 +144,7 @@ class CourtSchedulerMigrationIntTest(
           assertThat(eventStatus).isEqualTo("COMP")
           assertThat(commentText).isEqualTo("Some schedule comment")
           assertThat(currentTerm).isTrue
-          assertThat(externalReferenceUrn).isEqualTo("$EXTERNAL_REF_PREFIX$dpsSentencingCourtAppearanceId")
+          assertThat(externalReferenceUrn).isNull()
         }
         with(courtEvents[0].created) {
           assertThat(by).isEqualTo("SYS")
@@ -155,7 +155,7 @@ class CourtSchedulerMigrationIntTest(
     }
 
     @Test
-    fun `should populate DPS court movement`() {
+    fun `should populate DPS court movement OUT`() {
       CourtSchedulerDpsApiMockServer.getRequestBody<ResyncCourtEvents>(
         putRequestedFor(urlPathEqualTo("/resync/court-appearances/A0001KT")),
       ).apply {
@@ -168,12 +168,164 @@ class CourtSchedulerMigrationIntTest(
           assertThat(fromAgencyId).isEqualTo("BXI")
           assertThat(toAgencyId).isEqualTo("LEEDMC")
           assertThat(commentText).isEqualTo("Some movement out comment")
+          assertThat(dpsCourtScheduleId).isEqualTo(dpsCourtScheduleId)
+          assertThat(dpsCourtAppearanceExternalReference).isNull()
         }
         with(courtEvents[0].movements[0].created) {
           assertThat(by).isEqualTo("SYS")
           assertThat(at).isCloseTo(LocalDateTime.now().minusDays(1), within(5, ChronoUnit.MINUTES))
         }
         assertThat(courtEvents[0].movements[0].modified).isNull()
+      }
+    }
+
+    @Test
+    fun `should populate DPS court movement IN`() {
+      CourtSchedulerDpsApiMockServer.getRequestBody<ResyncCourtEvents>(
+        putRequestedFor(urlPathEqualTo("/resync/court-appearances/A0001KT")),
+      ).apply {
+        with(courtEvents[0].movements[1].movement) {
+          assertThat(dpsId).isEqualTo(dpsScheduledMovementInId)
+          assertThat(offenderBookId).isEqualTo(12345)
+          assertThat(movementSeq).isEqualTo(4)
+          assertThat(dpsCourtScheduleId).isEqualTo(dpsCourtScheduleId)
+          assertThat(dpsCourtAppearanceExternalReference).isNull()
+        }
+      }
+    }
+
+    @Test
+    fun `should populate unscheduled DPS court movement`() {
+      CourtSchedulerDpsApiMockServer.getRequestBody<ResyncCourtEvents>(
+        putRequestedFor(urlPathEqualTo("/resync/court-appearances/A0001KT")),
+      ).apply {
+        with(unscheduledMovements[0].movement) {
+          assertThat(dpsId).isEqualTo(dpsUnscheduledMovementOutId)
+          assertThat(offenderBookId).isEqualTo(12345)
+          assertThat(movementSeq).isEqualTo(1)
+          assertThat(dpsCourtAppearanceScheduleId).isNull()
+          assertThat(dpsCourtAppearanceExternalReference).isNull()
+        }
+      }
+    }
+
+    @Test
+    fun `should send all movements`() {
+      CourtSchedulerDpsApiMockServer.getRequestBody<ResyncCourtEvents>(
+        putRequestedFor(urlPathEqualTo("/resync/court-appearances/A0001KT")),
+      ).apply {
+        assertThat(courtEvents[0].movements.size).isEqualTo(2)
+        assertThat(courtEvents[0].movements[0].movement.movementSeq).isEqualTo(3)
+        assertThat(courtEvents[0].movements[1].movement.movementSeq).isEqualTo(4)
+        assertThat(unscheduledMovements.size).isEqualTo(2)
+        assertThat(unscheduledMovements[0].movement.movementSeq).isEqualTo(1)
+        assertThat(unscheduledMovements[1].movement.movementSeq).isEqualTo(2)
+      }
+    }
+
+    @Test
+    fun `should update mappings`() {
+      CourtSchedulerMappingApiMockServer.getRequestBody<CourtSchedulerPrisonerMappingsDto>(
+        putRequestedFor(urlPathEqualTo("/mapping/court-scheduler/migrate")),
+      ).apply {
+        assertThat(offenderNo).isEqualTo("A0001KT")
+        with(bookings[0]) {
+          assertThat(bookingId).isEqualTo(12345)
+          with(courtSchedules[0]) {
+            assertThat(nomisEventId).isEqualTo(1)
+            assertThat(dpsCourtAppearanceId).isEqualTo(dpsCourtScheduleId)
+            assertThat(movements[0].nomisMovementSeq).isEqualTo(3)
+            assertThat(movements[0].dpsCourtMovementId).isEqualTo(dpsScheduledMovementOutId)
+            assertThat(movements[1].nomisMovementSeq).isEqualTo(4)
+            assertThat(movements[1].dpsCourtMovementId).isEqualTo(dpsScheduledMovementInId)
+          }
+          assertThat(unscheduledMovements[0].nomisMovementSeq).isEqualTo(1)
+          assertThat(unscheduledMovements[0].dpsCourtMovementId).isEqualTo(dpsUnscheduledMovementOutId)
+          assertThat(unscheduledMovements[1].nomisMovementSeq).isEqualTo(2)
+          assertThat(unscheduledMovements[1].dpsCourtMovementId).isEqualTo(dpsUnscheduledMovementInId)
+        }
+      }
+    }
+
+    @Test
+    fun `will publish telemetry`() {
+      verify(telemetryClient).trackEvent(
+        eq("court-scheduler-migration-entity-migrated"),
+        check {
+          assertThat(it["offenderNo"]).isEqualTo("A0001KT")
+          assertThat(it["migrationId"]).isEqualTo(migrationId)
+        },
+        isNull(),
+      )
+    }
+  }
+
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  inner class MigrateEntityLinkedToCourtCase {
+    @BeforeAll
+    fun setUp() = runTest {
+      setupMigrationTest()
+
+      stubMigrationDependencies(entities = 1, courtCaseId = 1314L)
+      migrationId = performMigration()
+    }
+
+    @Test
+    fun `should populate DPS court appearance with court sentencing external reference`() {
+      CourtSchedulerDpsApiMockServer.getRequestBody<ResyncCourtEvents>(
+        putRequestedFor(urlPathEqualTo("/resync/court-appearances/A0001KT")),
+      ).apply {
+        with(courtEvents[0].courtEvent) {
+          assertThat(dpsId).isNull()
+          assertThat(eventId).isEqualTo(1)
+          assertThat(externalReferenceUrn).isEqualTo("$EXTERNAL_REF_PREFIX$dpsSentencingCourtAppearanceId")
+        }
+      }
+    }
+
+    @Test
+    fun `should populate DPS court movement with court sentencing external reference`() {
+      CourtSchedulerDpsApiMockServer.getRequestBody<ResyncCourtEvents>(
+        putRequestedFor(urlPathEqualTo("/resync/court-appearances/A0001KT")),
+      ).apply {
+        with(courtEvents[0].movements[0].movement) {
+          assertThat(dpsId).isEqualTo(dpsScheduledMovementOutId)
+          assertThat(offenderBookId).isEqualTo(12345)
+          assertThat(movementSeq).isEqualTo(3)
+          assertThat(dpsCourtAppearanceScheduleId).isNull()
+          assertThat(dpsCourtAppearanceExternalReference).isEqualTo("$EXTERNAL_REF_PREFIX$dpsSentencingCourtAppearanceId")
+        }
+      }
+    }
+
+    @Test
+    fun `should populate DPS court movement IN`() {
+      CourtSchedulerDpsApiMockServer.getRequestBody<ResyncCourtEvents>(
+        putRequestedFor(urlPathEqualTo("/resync/court-appearances/A0001KT")),
+      ).apply {
+        with(courtEvents[0].movements[1].movement) {
+          assertThat(dpsId).isEqualTo(dpsScheduledMovementInId)
+          assertThat(offenderBookId).isEqualTo(12345)
+          assertThat(movementSeq).isEqualTo(4)
+          assertThat(dpsCourtAppearanceScheduleId).isNull()
+          assertThat(dpsCourtAppearanceExternalReference).isEqualTo("$EXTERNAL_REF_PREFIX$dpsSentencingCourtAppearanceId")
+        }
+      }
+    }
+
+    @Test
+    fun `should populate unscheduled DPS court movement with court sentencing external reference`() {
+      CourtSchedulerDpsApiMockServer.getRequestBody<ResyncCourtEvents>(
+        putRequestedFor(urlPathEqualTo("/resync/court-appearances/A0001KT")),
+      ).apply {
+        with(unscheduledMovements[0].movement) {
+          assertThat(dpsId).isEqualTo(dpsUnscheduledMovementOutId)
+          assertThat(offenderBookId).isEqualTo(12345)
+          assertThat(movementSeq).isEqualTo(1)
+          assertThat(dpsCourtAppearanceScheduleId).isNull()
+          assertThat(dpsCourtAppearanceExternalReference).isNull()
+        }
       }
     }
 
@@ -583,7 +735,7 @@ class CourtSchedulerMigrationIntTest(
       @BeforeEach
       fun setUp() = runTest {
         mappingApi.stubGetCourtSchedulerPrisonerMappingIds(prisonerNumber, 12345L, 1, dpsCourtScheduleId, 3, dpsScheduledMovementOutId, 4, dpsScheduledMovementInId, 1, dpsUnscheduledMovementOutId, 2, dpsUnscheduledMovementInId)
-        nomisApi.stubGetOffenderCourtMovements(prisonerNumber)
+        nomisApi.stubGetOffenderCourtMovements(prisonerNumber, courtCaseId = 1314L)
         // The NOMIS response has a court case but there is no court sentencing mapping
         sentencingMappingApi.stubGetAllCourtAppearanceByNomisIds(mappings = listOf())
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerNomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfromnomismigration/movements/court/CourtSchedulerNomisApiMockServer.kt
@@ -130,7 +130,8 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
 
   fun stubGetOffenderCourtMovements(
     offenderNo: String = "A1234BC",
-    response: OffenderCourtMovementsResponse = offenderCourtMovementsResponse(),
+    courtCaseId: Long? = null,
+    response: OffenderCourtMovementsResponse = offenderCourtMovementsResponse(courtCaseId = courtCaseId),
   ) {
     nomisApi.stubFor(
       get(urlPathEqualTo("/movements/$offenderNo/court")).willReturn(
@@ -268,7 +269,8 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
       bookingId: Long = 12345L,
       activeBooking: Boolean = true,
       latestBooking: Boolean = true,
-      courtSchedules: List<BookingCourtScheduleOut> = listOf(bookingCourtSchedule()),
+      courtCaseId: Long? = null,
+      courtSchedules: List<BookingCourtScheduleOut> = listOf(bookingCourtSchedule(courtCaseId = courtCaseId)),
       unscheduledCourtMovementOuts: List<BookingCourtMovementOut> = listOf(bookingCourtMovementOut(seq = 1)),
       unscheduledCourtMovementIns: List<BookingCourtMovementIn> = listOf(bookingCourtMovementIn(seq = 2)),
     ): OffenderCourtMovementsResponse = OffenderCourtMovementsResponse(
@@ -288,6 +290,7 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
       eventId: Long = 1,
       movementOutSeq: Int? = 3,
       movementInSeq: Int? = 4,
+      courtCaseId: Long? = null,
     ) = BookingCourtScheduleOut(
       eventId = eventId,
       eventDate = yesterday.toLocalDate(),
@@ -302,7 +305,7 @@ class CourtSchedulerNomisApiMockServer(private val jsonMapper: JsonMapper) {
       courtMovementOut = movementOutSeq?.let { bookingCourtMovementOut(seq = movementOutSeq) },
       courtMovementIn = movementInSeq?.let { bookingCourtMovementIn(seq = movementInSeq) },
       comment = "Some schedule comment",
-      courtCaseId = 87878L,
+      courtCaseId = courtCaseId,
     )
 
     fun bookingCourtMovementOut(seq: Int) = BookingCourtMovementOut(


### PR DESCRIPTION
We will no longer sync or hold mappings for court appearances owned by remand and sentencing. However, we still need to send them on the resync endpoint because there may be movements linked to the RaS court appearances. Therefore whenever we send a court case linked court appearance or a court movement linked to a court case appearance, we send the RaS ID and not the CAS ID.